### PR TITLE
Alee/dcs 33 link offender

### DIFF
--- a/migrations/20190624000000_form_db.js
+++ b/migrations/20190624000000_form_db.js
@@ -1,0 +1,25 @@
+exports.up = knex =>
+  knex.schema.alterTable('form', table => {
+    table
+      .integer('sequence_no')
+      .notNullable()
+      .defaultTo(1)
+    table.bigInteger('booking_id').notNullable()
+    table
+      .timestamp('start_date')
+      .notNullable()
+      .defaultTo(knex.fn.now(6))
+
+    table.string('user_id', 32).alter()
+    table.string('status', 20)
+    table.unique(['booking_id', 'sequence_no'], 'booking_sequence_index')
+  })
+
+exports.down = knex =>
+  knex.schema.table('form', table => {
+    table.dropUnique(['booking_id', 'sequence_no'], 'booking_sequence_index')
+    table.dropColumn('sequence_no')
+    table.dropColumn('booking_id')
+    table.dropColumn('status')
+    table.dropColumn('start_date')
+  })

--- a/migrations/20190626000000_form_db.js
+++ b/migrations/20190626000000_form_db.js
@@ -12,12 +12,12 @@ exports.up = knex =>
 
     table.string('user_id', 32).alter()
     table.string('status', 20)
-    table.unique(['booking_id', 'sequence_no'], 'booking_sequence_index')
+    table.unique(['user_id', 'booking_id', 'sequence_no'], 'user_booking_sequence_index')
   })
 
 exports.down = knex =>
   knex.schema.table('form', table => {
-    table.dropUnique(['booking_id', 'sequence_no'], 'booking_sequence_index')
+    table.dropUnique(['user_id', 'booking_id', 'sequence_no'], 'user_booking_sequence_index')
     table.dropColumn('sequence_no')
     table.dropColumn('booking_id')
     table.dropColumn('status')

--- a/server/data/formClient.js
+++ b/server/data/formClient.js
@@ -1,30 +1,39 @@
 const db = require('./dataAccess/db')
 
-module.exports = {
-  getFormDataForUser(userId) {
-    const query = {
-      text: 'select id, form_response from form where user_id = $1',
-      values: [userId],
-    }
-
-    return db.query(query)
-  },
-
-  update(formId, formResponse, userId) {
-    const query = {
-      text: getUpsertQuery(formId),
-
-      values: [formResponse, userId],
-    }
-
-    return db.query(query)
-  },
+const update = (formId, formResponse) => {
+  const query = {
+    text: `update form f set form_response = $1 where f.id = $2`,
+    values: [formResponse, formId],
+  }
+  return db.query(query)
 }
 
-function getUpsertQuery(formId) {
-  if (formId) {
-    return 'update form set form_response = $1 where user_id=$2'
-  }
+const create = (userId, bookingId) => {
+  const nextSequence = `(select COALESCE(MAX(sequence_no), 0) + 1 from form where booking_id = $3 and user_id = $2)`
 
-  return 'insert into form (form_response, user_id) values ($1, $2)'
+  const query = {
+    text: `insert into form (form_response, user_id, booking_id, status, sequence_no, start_date)
+            values ($1, CAST($2 AS VARCHAR), $3, $4, ${nextSequence}, CURRENT_TIMESTAMP)`,
+    values: [{}, userId, bookingId, 'IN_PROGRESS'],
+  }
+  return db.query(query)
+}
+
+module.exports = {
+  create,
+  update,
+  getFormDataForUser(userId, bookingId) {
+    const maxSequenceForBooking =
+      '(select max(f2.sequence_no) from form f2 where f2.booking_id = f.booking_id and user_id = f.user_id)'
+    const query = {
+      text: `select id, form_response from form f
+            where user_id = $1
+            and booking_id = $2
+            and status = 'IN_PROGRESS'
+            and f.sequence_no = ${maxSequenceForBooking}`,
+      values: [userId, bookingId],
+    }
+
+    return db.query(query)
+  },
 }

--- a/server/middleware/getFormData.js
+++ b/server/middleware/getFormData.js
@@ -1,9 +1,10 @@
 module.exports = formService => async (req, res, next) => {
   try {
-    const formData = await formService.getFormResponse(req.user.username)
+    const { bookingId } = req.params
+    const { form_response: response = {}, id } = await formService.getFormResponse(req.user.username, bookingId)
 
-    res.locals.formObject = formData.form_response || {}
-    res.locals.formId = formData.id
+    res.locals.formObject = response
+    res.locals.formId = id
 
     next()
   } catch (error) {

--- a/server/routes/form.js
+++ b/server/routes/form.js
@@ -27,8 +27,8 @@ const renderForm = (req, res, section, form, data = {}) => {
 module.exports = function Index({ formService, authenticationMiddleware, offenderService }) {
   const router = express.Router()
 
+  const withFormData = getFormData(formService)
   router.use(authenticationMiddleware())
-  router.use(getFormData(formService))
   router.use(flash())
 
   router.use((req, res, next) => {
@@ -40,6 +40,7 @@ module.exports = function Index({ formService, authenticationMiddleware, offende
 
   router.get(
     '/incident/newIncident/:bookingId',
+    withFormData,
     asyncMiddleware(async (req, res) => {
       const { bookingId } = req.params
       const offenderDetail = await offenderService.getOffenderDetails(res.locals.user.token, bookingId)
@@ -51,6 +52,7 @@ module.exports = function Index({ formService, authenticationMiddleware, offende
 
   router.get(
     '/:section/:form/:bookingId',
+    withFormData,
     asyncMiddleware(async (req, res) => {
       const { section, form } = req.params
       renderForm(req, res, section, form)
@@ -59,6 +61,7 @@ module.exports = function Index({ formService, authenticationMiddleware, offende
 
   router.post(
     '/:section/:form/:bookingId',
+    withFormData,
     asyncMiddleware(async (req, res) => {
       const { section, form, bookingId } = req.params
       const formPageConfig = formConfig[form]
@@ -77,6 +80,7 @@ module.exports = function Index({ formService, authenticationMiddleware, offende
       }
 
       await formService.update({
+        bookingId: parseInt(bookingId, 10),
         userId: req.user.username,
         formId: res.locals.formId,
         formObject: res.locals.formObject,

--- a/server/routes/form.test.js
+++ b/server/routes/form.test.js
@@ -59,6 +59,7 @@ describe('POST /section/form', () => {
       .expect(() => {
         expect(formService.update).toBeCalledTimes(1)
         expect(formService.update).toBeCalledWith({
+          bookingId: 1,
           userId: 'user1',
           formId: undefined,
           formObject: {},

--- a/server/routes/submitted.js
+++ b/server/routes/submitted.js
@@ -6,10 +6,11 @@ module.exports = function Index({ formService, authenticationMiddleware }) {
   const router = express.Router()
 
   router.use(authenticationMiddleware())
-  router.use(getFormData(formService))
+  const withFormData = getFormData(formService)
 
   router.get(
     '/:bookingId',
+    withFormData,
     asyncMiddleware(async (req, res) => {
       res.render('pages/submitted', { data: res.locals.formObject, bookingId: req.params.bookingId })
     })

--- a/server/services/formService.js
+++ b/server/services/formService.js
@@ -2,13 +2,12 @@ const { equals } = require('../utils/utils')
 const { validate } = require('../utils/fieldValidation')
 
 module.exports = function createSomeService(formClient) {
-  async function getFormResponse(userId) {
-    const data = await formClient.getFormDataForUser(userId)
-
+  async function getFormResponse(userId, bookingId) {
+    const data = await formClient.getFormDataForUser(userId, bookingId)
     return data.rows[0] || {}
   }
 
-  async function update({ userId, formId, formObject, config, userInput, formSection, formName }) {
+  async function update({ userId, formId, bookingId, formObject, config, userInput, formSection, formName }) {
     const updatedFormObject = getUpdatedFormObject({
       formObject,
       fieldMap: config.fields,
@@ -21,7 +20,11 @@ module.exports = function createSomeService(formClient) {
       return formObject
     }
 
-    await formClient.update(formId, updatedFormObject, userId)
+    if (formId) {
+      await formClient.update(formId, updatedFormObject)
+    } else {
+      await formClient.create(userId, bookingId)
+    }
     return updatedFormObject
   }
 

--- a/server/services/formService.test.js
+++ b/server/services/formService.test.js
@@ -3,6 +3,7 @@ const serviceCreator = require('./formService')
 const formClient = {
   getFormDataForUser: jest.fn(),
   update: jest.fn(),
+  create: jest.fn(),
 }
 let service
 
@@ -14,6 +15,7 @@ beforeEach(() => {
 afterEach(() => {
   formClient.getFormDataForUser.mockReset()
   formClient.update.mockReset()
+  formClient.create.mockReset()
 })
 
 describe('getFormResponse', () => {
@@ -62,6 +64,7 @@ describe('update', () => {
       }
 
       const output = await service.update({
+        bookingId: 1,
         userId: 'user1',
         formId: 'form1',
         formObject: baseForm,
@@ -84,7 +87,7 @@ describe('update', () => {
       })
     })
 
-    test('should call updateLicence and pass in the licence', async () => {
+    test('should call update and pass in the form', async () => {
       const userInput = {
         decision: 'Yes',
         followUp1: 'County',
@@ -92,6 +95,7 @@ describe('update', () => {
       }
 
       const output = await service.update({
+        bookingId: 1,
         userId: 'user1',
         formId: 'form1',
         formObject: baseForm,
@@ -102,7 +106,28 @@ describe('update', () => {
       })
 
       expect(formClient.update).toBeCalledTimes(1)
-      expect(formClient.update).toBeCalledWith('form1', output, 'user1')
+      expect(formClient.update).toBeCalledWith('form1', output)
+    })
+
+    test('should call create when form id not present', async () => {
+      const userInput = {
+        decision: 'Yes',
+        followUp1: 'County',
+        followUp2: 'Town',
+      }
+
+      await service.update({
+        bookingId: 1,
+        userId: 'user1',
+        formObject: baseForm,
+        config: { fields: fieldMap },
+        userInput,
+        formSection: 'section4',
+        formName: 'form3',
+      })
+
+      expect(formClient.create).toBeCalledTimes(1)
+      expect(formClient.create).toBeCalledWith('user1', 1)
     })
 
     test('should not call update if there are no changes', async () => {
@@ -110,6 +135,7 @@ describe('update', () => {
       const userInput = { answer: 'answer' }
 
       const output = await service.update({
+        bookingId: 1,
         userId: 'user1',
         formId: 'form1',
         formObject: baseForm,
@@ -131,6 +157,7 @@ describe('update', () => {
       }
 
       const output = await service.update({
+        bookingId: 1,
         userId: 'user1',
         formId: 'form1',
         formObject: baseForm,
@@ -194,6 +221,7 @@ describe('update', () => {
       const formName = 'form3'
 
       const output = await service.update({
+        bookingId: 1,
         userId: 'user1',
         formId: 'form1',
         formObject: baseForm,
@@ -227,6 +255,7 @@ describe('update', () => {
       const formName = 'form3'
 
       const output = await service.update({
+        bookingId: 1,
         userId: 'user1',
         formId: 'form1',
         formObject: baseForm,


### PR DESCRIPTION
Allowing a staff member to create multiple incident reports.

These DB changes should allow the following behaviour: 
 * Each staff member can have only one in progress report per offender.
 * Staff members will not be able to view other staff members in progress reports.
 * Once a staff member marks a report as not in progress (e.g: 'complete'), then it will allow creation of a new report for that offender (by using a higher sequence number).
 * Reports are lazily created on the fly if no 'in progress' report exists for that staff member and offender. 