### PR TITLE
DCS 52: Users selections repopulated when moving between pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
       "test/*"
     ],
     "delay": "2500",
-    "ext": "js,json,html"
+    "ext": "js,json,html,njk"
   },
   "husky": {
     "hooks": {

--- a/server/views/formPages/incident/details.html
+++ b/server/views/formPages/incident/details.html
@@ -14,6 +14,7 @@ govukRadios %} {% from "select/macro.njk" import govukSelect %}{% from "checkbox
             "primaryQuestion": {
               "text": "Was Positive Communication used to de-escalate the situation?",
               "name": "positiveCommunication",
+              "value": data.positiveCommunication,
               "options": [{
                 "value": "yes",
                 "label": "Yes"
@@ -32,6 +33,7 @@ govukRadios %} {% from "select/macro.njk" import govukSelect %}{% from "checkbox
             "primaryQuestion": {
               "text": "Were any Personal Protection techniques used?",
               "name": "personalProtectionTechniques",
+              "value": data.personalProtectionTechniques,
               "options": [{
                 "value": "yes",
                 "label": "Yes"
@@ -50,6 +52,7 @@ govukRadios %} {% from "select/macro.njk" import govukSelect %}{% from "checkbox
             "primaryQuestion": {
               "text": "Was a baton drawn?",
               "name": "batonDrawn",
+              "value": data.batonDrawn,
               "options": [{
                 "value": "yes",
                 "label": "Yes"
@@ -62,6 +65,7 @@ govukRadios %} {% from "select/macro.njk" import govukSelect %}{% from "checkbox
             },
             "followUpQuestion": {
               "text": "Was it used?",
+              "value": data.batonUsed,
               "name": "batonUsed",
               "options": [{
                 "value": "yes",
@@ -83,6 +87,7 @@ govukRadios %} {% from "select/macro.njk" import govukSelect %}{% from "checkbox
             "primaryQuestion": {
               "text": "Was pava drawn?",
               "name": "pavaDrawn",
+              "value": data.pavaDrawn,
               "options": [{
                 "value": "yes",
                 "label": "Yes"
@@ -94,6 +99,7 @@ govukRadios %} {% from "select/macro.njk" import govukSelect %}{% from "checkbox
             "followUpQuestion": {
               "text": "Was it used?",
               "name": "pavaUsed",
+              "value": data.pavaUsed,
               "options": [{
                 "value": "yes",
                 "label": "Yes"
@@ -112,6 +118,7 @@ govukRadios %} {% from "select/macro.njk" import govukSelect %}{% from "checkbox
             "primaryQuestion": {
               "text": "Was a guiding hold used?",
               "name": "guidingHold",
+              "value": data.guidingHold,
               "options": [{
                 "value": "yes",
                 "label": "Yes"
@@ -125,6 +132,7 @@ govukRadios %} {% from "select/macro.njk" import govukSelect %}{% from "checkbox
             "followUpQuestion": {
               "text": "How many officers were involved?",
               "name": "guidingHoldOfficersInvolved",
+              "value": data.guidingHoldOfficersInvolved,
               "options": [{
                 "value": 'one',
                 "label": "One"
@@ -143,6 +151,7 @@ govukRadios %} {% from "select/macro.njk" import govukSelect %}{% from "checkbox
           "primaryQuestion": {
             "text": "Was control and restraint used?",
             "name": "restraint",
+            "value": data.restraint,
             "options": [{
               "value": "yes",
               "label": "Yes"
@@ -154,6 +163,7 @@ govukRadios %} {% from "select/macro.njk" import govukSelect %}{% from "checkbox
           "followUpQuestion": {
             "text": "What positions were used?",
             "name": "restraintPositions",
+            "value": data.restraintPositions,
             "options": [{
               "value": "standing",
               "label": "standing"
@@ -177,6 +187,7 @@ govukRadios %} {% from "select/macro.njk" import govukSelect %}{% from "checkbox
           "primaryQuestion": {
             "text": "Were handcuffs applied?",
             "name": "handcuffsApplied",
+            "value": data.handcuffsApplied,
             "options": [{
               "value": "yes",
               "label": "Yes"
@@ -188,6 +199,7 @@ govukRadios %} {% from "select/macro.njk" import govukSelect %}{% from "checkbox
           "followUpQuestion": {
             "text": "Select which type of handcuffs were used",
             "name": "handcuffsType",
+            "value": data.handcuffsType,
             "options": [{
               "value": "ratchet",
               "label": "Ratchet"

--- a/server/views/formPages/incident/details.html
+++ b/server/views/formPages/incident/details.html
@@ -145,7 +145,6 @@ govukRadios %} {% from "select/macro.njk" import govukSelect %}{% from "checkbox
           }
           )
         }}
-
     <!-- Q6 -->
     {{ incidentMacro.radiosWithNestedCheckboxes({
           "primaryQuestion": {
@@ -163,7 +162,7 @@ govukRadios %} {% from "select/macro.njk" import govukSelect %}{% from "checkbox
           "followUpQuestion": {
             "text": "What positions were used?",
             "name": "restraintPositions",
-            "value": data.restraintPositions,
+            "value": data.restraintPositions or [],
             "options": [{
               "value": "standing",
               "label": "standing"

--- a/server/views/formPages/incidentMacros.njk
+++ b/server/views/formPages/incidentMacros.njk
@@ -11,7 +11,9 @@
           {% set name1 = question.primaryQuestion.name %}
           {% for option in question.primaryQuestion.options %}
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="id-{{name1}}-{{loop.index}}" name="{{name1}}" type="radio" value="{{option.value}}" {% if option.value === 'yes' %} data-aria-controls="conditional-{{name1}}" {% endif %}>
+              <input class="govuk-radios__input" id="id-{{name1}}-{{loop.index}}" name="{{name1}}" type="radio" value="{{option.value}}" 
+              {% if option.value === question.primaryQuestion.value %} checked {% endif %}
+              {% if option.value === 'yes' %} data-aria-controls="conditional-{{name1}}" {% endif %}>
               <label class="govuk-label govuk-radios__label" for='id-{{name1}}-{{loop.index}}'>
                 {{option.label}}
               </label>
@@ -29,7 +31,8 @@
                 <div class="{% if question.followUpQuestion.options | length < 3 %} govuk-radios--inline {% endif %}">
                   {% for option in question.followUpQuestion.options %}
                     <div class="govuk-radios__item">
-                      <input class="govuk-radios__input" id="id-{{name2}}-{{loop.index}}" name="{{name2}}" type="radio" value="{{option.value}}">
+                      <input class="govuk-radios__input" id="id-{{name2}}-{{loop.index}}" name="{{name2}}" type="radio" value="{{option.value}}"                       
+                      {% if option.value === question.followUpQuestion.value %} checked {% endif %}>
                       <label class="govuk-label govuk-radios__label" for="id-{{name2}}-{{loop.index}}">
                         {{option.label}}
                       </label>
@@ -60,7 +63,8 @@
           {% set name = question.primaryQuestion.name %}
           {% for option in question.primaryQuestion.options %}
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="id-{{name}}-{{loop.index}}" name="{{name}}" type="radio" value="{{option.value}}" {% if option.value === 'yes' %} data-aria-controls="conditional-{{name}}" {% endif %}>
+              <input class="govuk-radios__input" id="id-{{name}}-{{loop.index}}" name="{{name}}" type="radio" value="{{option.value}}" {% if option.value === 'yes' %} data-aria-controls="conditional-{{name}}" {% endif %}
+              {% if option.value === question.primaryQuestion.value %} checked  {% endif %}>
               <label class="govuk-label govuk-radios__label" for='id-{{name}}-{{loop.index}}'>
                 {{option.label}}
               </label>
@@ -78,7 +82,8 @@
               {% for option in question.followUpQuestion.options %}
 
                 <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input" id="id-{{name}}-{{loop.index}}" name="{{name}}" type="checkbox" value="{{option.value}}">
+                  <input class="govuk-checkboxes__input" id="id-{{name}}-{{loop.index}}" name="{{name}}" type="checkbox"  value="{{option.value}}"
+                  {% if option.value in question.followUpQuestion.value %} checked  {% endif %}>
                   <label class="govuk-label govuk-checkboxes__label" for="id-{{name}}-{{loop.index}}">
                     {{option.label}}
                   </label>


### PR DESCRIPTION
http://localhost:3000/form/incident/details/-35

The Details page was saving user selections to DB but if user navigated back to the same page,
their previous selections were not being presented.
There is a global object called data that holds all the selection info so have used that inside incidentMacro.njk and
tested it against the value property in details.html to display the previous selections.