### PR TITLE
DaCS-37 Sanitising input

### DIFF
--- a/integration-tests/integration/createIncident/enter-initial-details.js
+++ b/integration-tests/integration/createIncident/enter-initial-details.js
@@ -26,11 +26,13 @@ context('Submitting details page form', () => {
     newIncidentPage.witnesses(0).type('1111')
     newIncidentPage.addAnotherWitness().click()
     newIncidentPage.witnesses(1).type('2222')
+    newIncidentPage.addAnotherWitness().click()
+    newIncidentPage.addAnotherWitness().click()
     newIncidentPage.save()
 
     cy.task('getFormData', { bookingId, formName: 'newIncident' }).then(data =>
       expect(data).to.deep.equal({
-        locationId: '357591',
+        locationId: 357591,
         involved: [{ name: 'AAAA' }, { name: 'BBBB' }],
         forceType: 'spontaneous',
         witnesses: [{ name: '1111' }, { name: '2222' }],

--- a/server/config/incident.js
+++ b/server/config/incident.js
@@ -5,6 +5,7 @@ module.exports = {
         locationId: {
           responseType: 'requiredNumber',
           validationMessage: 'Where did the incident occur?',
+          sanitiser: val => parseInt(val, 10),
         },
       },
       {
@@ -14,10 +15,14 @@ module.exports = {
         },
       },
       {
-        involved: {},
+        involved: {
+          sanitiser: vals => vals.reduce((res, val) => (val.name && val.name.trim() ? [...res, val] : res), []),
+        },
       },
       {
-        witnesses: {},
+        witnesses: {
+          sanitiser: vals => vals.reduce((res, val) => (val.name && val.name.trim() ? [...res, val] : res), []),
+        },
       },
     ],
     validate: false,

--- a/server/routes/form.js
+++ b/server/routes/form.js
@@ -71,7 +71,7 @@ module.exports = function Index({ formService, authenticationMiddleware, offende
           locations.map(location => ({
             value: location.locationId,
             text: location.userDescription,
-            selected: pageData.locationId === location.locationId.toString(),
+            selected: pageData.locationId === location.locationId,
           }))
         ),
       }

--- a/server/services/formService.js
+++ b/server/services/formService.js
@@ -48,13 +48,13 @@ module.exports = function createSomeService(formClient) {
 
   function answersFromMapReducer(userInput) {
     return (answersAccumulator, field) => {
-      const { fieldName, answerIsRequired } = getFieldInfo(field, userInput)
+      const { fieldName, answerIsRequired, sanitiser } = getFieldInfo(field, userInput)
 
       if (!answerIsRequired) {
         return answersAccumulator
       }
 
-      return { ...answersAccumulator, [fieldName]: userInput[fieldName] }
+      return { ...answersAccumulator, [fieldName]: sanitiser(userInput[fieldName]) }
     }
   }
 
@@ -63,11 +63,12 @@ module.exports = function createSomeService(formClient) {
     const fieldConfig = field[fieldName]
 
     const fieldDependentOn = userInput[fieldConfig.dependentOn]
-    const predicateResponse = fieldConfig.predicate
+    const { sanitiser = value => value, predicate: predicateResponse } = fieldConfig
     const dependentMatchesPredicate = fieldConfig.dependentOn && fieldDependentOn === predicateResponse
 
     return {
       fieldName,
+      sanitiser,
       answerIsRequired: !fieldDependentOn || dependentMatchesPredicate,
     }
   }

--- a/server/services/formService.test.js
+++ b/server/services/formService.test.js
@@ -307,4 +307,36 @@ describe('getValidationErrors', () => {
   `('should return errors $expectedContent for form return', ({ formBody, formConfig, expectedOutput }) => {
     expect(service.getValidationErrors(formBody, formConfig)).toEqual(expectedOutput)
   })
+
+  test('sanitisation', async () => {
+    const config = {
+      fields: [
+        {
+          q1: {
+            responseType: 'requiredString',
+            validationMessage: 'Please give a full name',
+            sanitiser: val => val.toUpperCase(),
+          },
+        },
+      ],
+    }
+    const output = await service.update({
+      bookingId: 1,
+      userId: 'user1',
+      formId: 'form1',
+      formObject: {},
+      config,
+      userInput: { q1: 'aaaAAAaa' },
+      formSection: 'section4',
+      formName: 'form1',
+    })
+
+    expect(output).toEqual({
+      section4: {
+        form1: {
+          q1: 'AAAAAAAA',
+        },
+      },
+    })
+  })
 })


### PR DESCRIPTION
Adding the ability to specify sanitisers as part of the field config

The specific sanitisers required were:
 * Ensure that numeric ids are stored as ids
 * Filtering out empty rows for add another staff and witnesses