### PR TITLE
DCS-37 Fixing bugs and improving tests

### DIFF
--- a/integration-tests/integration/createIncident/enter-initial-details.js
+++ b/integration-tests/integration/createIncident/enter-initial-details.js
@@ -1,4 +1,5 @@
 const TasklistPage = require('../../pages/tasklistPage')
+const newIncidentPageFactory = require('../../pages/newIncidentPage')
 
 context('Submitting details page form', () => {
   const bookingId = 1001
@@ -9,34 +10,86 @@ context('Submitting details page form', () => {
     cy.task('stubLocations', 'MDI')
   })
 
-  it('Can login and create a new incident', () => {
-    cy.login(bookingId)
-
+  const fillFormAndSave = () => {
     const tasklistPage = TasklistPage.visit(bookingId)
-
     const newIncidentPage = tasklistPage.startNewForm()
     newIncidentPage.offenderName().contains('Norman Smith (A1234AC)')
     newIncidentPage.location().select('Asso A Wing')
-    newIncidentPage.forceType().check('spontaneous')
+    newIncidentPage.forceType.check('spontaneous')
 
-    newIncidentPage.staffInvolved(0).type('AAAA')
+    newIncidentPage
+      .staffInvolved(0)
+      .name()
+      .type('AAAA')
     newIncidentPage.addAnotherStaff().click()
-    newIncidentPage.staffInvolved(1).type('BBBB')
+    newIncidentPage
+      .staffInvolved(1)
+      .name()
+      .type('BBBB')
 
-    newIncidentPage.witnesses(0).type('1111')
+    newIncidentPage
+      .witnesses(0)
+      .name()
+      .type('1111')
     newIncidentPage.addAnotherWitness().click()
-    newIncidentPage.witnesses(1).type('2222')
     newIncidentPage.addAnotherWitness().click()
     newIncidentPage.addAnotherWitness().click()
-    newIncidentPage.save()
+    const detailsPage = newIncidentPage.save()
+    return detailsPage
+  }
+
+  it('Can login and create a new incident', () => {
+    cy.login(bookingId)
+
+    fillFormAndSave()
 
     cy.task('getFormData', { bookingId, formName: 'newIncident' }).then(data =>
       expect(data).to.deep.equal({
         locationId: 357591,
         involved: [{ name: 'AAAA' }, { name: 'BBBB' }],
         forceType: 'spontaneous',
-        witnesses: [{ name: '1111' }, { name: '2222' }],
+        witnesses: [{ name: '1111' }],
       })
     )
+  })
+
+  it('Can revisit saved data', () => {
+    cy.login(bookingId)
+
+    const detailsPage = fillFormAndSave()
+    detailsPage.back().click()
+
+    const updatedIncidentPage = newIncidentPageFactory()
+    updatedIncidentPage.offenderName().contains('Norman Smith (A1234AC)')
+    updatedIncidentPage.location().contains('Asso A Wing')
+    updatedIncidentPage.forceType.spontaneous().should('be.checked')
+
+    updatedIncidentPage
+      .staffInvolved(0)
+      .name()
+      .should('have.value', 'AAAA')
+    updatedIncidentPage
+      .staffInvolved(0)
+      .remove()
+      .should('exist')
+    updatedIncidentPage
+      .staffInvolved(1)
+      .name()
+      .should('have.value', 'BBBB')
+    updatedIncidentPage
+      .staffInvolved(1)
+      .remove()
+      .should('exist')
+
+    updatedIncidentPage
+      .witnesses(0)
+      .name()
+      .should('have.value', '1111')
+
+    // Should't be able to remove sole item
+    updatedIncidentPage
+      .witnesses(0)
+      .remove()
+      .should('not.exist')
   })
 })

--- a/integration-tests/integration/createIncident/form-submit.spec.js
+++ b/integration-tests/integration/createIncident/form-submit.spec.js
@@ -25,7 +25,8 @@ context('Submit the incident report', () => {
 
     checkAnswersPage.checkStillOnPage()
     checkAnswersPage.errorSummary().contains('There is a problem')
-    checkAnswersPage.confirm()
+    checkAnswersPage.errorLink('Check that you agree before submitting').click()
+    cy.focused().check()
     checkAnswersPage.submit()
   })
 })

--- a/integration-tests/pages/checkAnswersPage.js
+++ b/integration-tests/pages/checkAnswersPage.js
@@ -12,4 +12,5 @@ export default () =>
     },
     confirm: () => cy.get('#confirm').click(),
     errorSummary: () => cy.get('#error-summary-title'),
+    errorLink: error => cy.get('[data-qa-errors]').contains(error),
   })

--- a/integration-tests/pages/newIncidentPage.js
+++ b/integration-tests/pages/newIncidentPage.js
@@ -1,15 +1,37 @@
-const detailsPage = require('./detailsPage')
 const page = require('./page')
+const detailsPage = require('./detailsPage')
 
 export default () =>
   page('New use of force incident', {
     offenderName: () => cy.get('[data-offender-name]'),
     location: () => cy.get('#location'),
-    forceType: () => cy.get('[name="forceType"]'),
-    staffInvolved: index => cy.get(`#involved\\[${index}\\]\\[name\\]`),
+
+    forceType: {
+      check: value => cy.get('[name="forceType"]').check(value),
+      planned: () => cy.get("[name='forceType'][value='planned']"),
+      spontaneous: () => cy.get("[name='forceType'][value='spontaneous']"),
+    },
+
+    staffInvolved: index => ({
+      name: () => cy.get(`#involved\\[${index}\\]\\[name\\]`),
+      remove: () =>
+        cy
+          .get(`#involved\\[${index}\\]\\[name\\]`)
+          .parents('.add-another__item')
+          .find('button.add-another__remove-button'),
+    }),
     addAnotherStaff: () => cy.get('[data-qa-add-another-staff]'),
-    witnesses: index => cy.get(`#witnesses\\[${index}\\]\\[name\\]`),
+
+    witnesses: index => ({
+      name: () => cy.get(`#witnesses\\[${index}\\]\\[name\\]`),
+      remove: () =>
+        cy
+          .get(`#witnesses\\[${index}\\]\\[name\\]`)
+          .parents('.add-another__item')
+          .find('button.add-another__remove-button'),
+    }),
     addAnotherWitness: () => cy.get('[data-qa-add-another-witness]'),
+
     save: () => {
       cy.get('[data-next]').click()
       return detailsPage()

--- a/integration-tests/pages/page.js
+++ b/integration-tests/pages/page.js
@@ -1,5 +1,5 @@
 export default (name, pageObject = {}) => {
   const checkOnPage = () => cy.get('h1').contains(name)
   checkOnPage()
-  return { ...pageObject, checkStillOnPage: checkOnPage }
+  return { ...pageObject, checkStillOnPage: checkOnPage, back: () => cy.get('.govuk-back-link') }
 }

--- a/server/routes/checkAnswers.js
+++ b/server/routes/checkAnswers.js
@@ -34,7 +34,7 @@ module.exports = function Index({ formService, authenticationMiddleware }) {
         req.flash('errors', [
           {
             text: 'Check that you agree before submitting',
-            href: `#confirmed`,
+            href: '#confirm',
           },
         ])
         return res.redirect(`/check-answers/${bookingId}`)

--- a/server/views/formPages/incident/newIncident.html
+++ b/server/views/formPages/incident/newIncident.html
@@ -83,9 +83,11 @@
             }
           })
         }}
+        {% if loop.length != 1 %}
         <button type="button" class="govuk-button govuk-button--secondary add-another__remove-button">
           Remove
         </button>
+        {% endif %}
         {% endcall %} {% else %} {% call govukFieldset({ classes: 'add-another__item' }) %}
         {{
           govukInput({
@@ -135,9 +137,11 @@
             }
           })
         }}
+        {% if loop.length != 1 %}
         <button type="button" class="govuk-button govuk-button--secondary add-another__remove-button">
           Remove
         </button>
+        {% endif  %}
         {% endcall %} {% else %} {% call govukFieldset({ classes: 'add-another__item' }) %}
         {{
           govukInput({

--- a/server/views/pages/check-answers.html
+++ b/server/views/pages/check-answers.html
@@ -14,7 +14,8 @@ href: backLink or "/"
       {{
         govukErrorSummary({
           titleText: 'There is a problem',
-          errorList: errors
+          errorList: errors,
+          attributes: { 'data-qa-errors': true }
         })
       }}
       {% endif %}


### PR DESCRIPTION
Fixed a couple of bugs:
 * When a sole witness or staff member were persisted - when we re-visited the page
   the remove button was present. If that remove button was pressed we couldn't add
   another entry
 * When no witnesses or staff members were persisted, we would get a null pointer
   when trying to persist the form again

Also test to ensure that we can render pre-saved data