### PR TITLE
DCS-60 Fixing redirect loop & adding token refreshing

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -170,13 +170,26 @@ module.exports = function createApp({ signInService, formService, offenderServic
     app.use(csurf())
   }
 
-  // token refresh
+  // JWT token refresh
   app.use(async (req, res, next) => {
-    if (req.user) {
+    if (req.user && req.originalUrl !== '/logout') {
       const timeToRefresh = new Date() > req.user.refreshTime
       if (timeToRefresh) {
-        req.session.returnTo = req.originalUrl
-        return res.redirect('/login')
+        try {
+          const newToken = await signInService.getRefreshedToken(req.user)
+          req.user.token = newToken.token
+          req.user.refreshToken = newToken.refreshToken
+          logger.info(`existing refreshTime in the past by ${new Date() - req.user.refreshTime}`)
+          logger.info(
+            `updating time by ${newToken.refreshTime - req.user.refreshTime} from ${req.user.refreshTime} to ${
+              newToken.refreshTime
+            }`
+          )
+          req.user.refreshTime = newToken.refreshTime
+        } catch (error) {
+          logger.error(`Token refresh error: ${req.user.username}`, error.stack)
+          return res.redirect('/logout')
+        }
       }
     }
     return next()

--- a/server/authentication/auth.js
+++ b/server/authentication/auth.js
@@ -4,7 +4,6 @@ const config = require('../config')
 const { generateOauthClientToken } = require('./clientCredentials')
 
 function authenticationMiddleware() {
-  // eslint-disable-next-line
   return (req, res, next) => {
     if (req.isAuthenticated()) {
       return next()

--- a/server/authentication/clientCredentials.js
+++ b/server/authentication/clientCredentials.js
@@ -1,61 +1,13 @@
-const querystring = require('querystring')
-const { getNamespace } = require('cls-hooked')
-const superagent = require('superagent')
-const Agent = require('agentkeepalive')
-const { HttpsAgent } = require('agentkeepalive')
-const logger = require('../../log')
 const config = require('../config')
 
 module.exports = {
   generateOauthClientToken,
-  getApiClientToken,
-  generate,
 }
-
-const oauthUrl = `${config.apis.oauth2.url}/oauth/token`
-const timeoutSpec = {
-  response: config.apis.oauth2.timeout.response,
-  deadline: config.apis.oauth2.timeout.deadline,
-}
-
-const agentOptions = {
-  maxSockets: config.apis.oauth2.agent.maxSockets,
-  maxFreeSockets: config.apis.oauth2.agent.maxFreeSockets,
-  freeSocketTimeout: config.apis.oauth2.agent.freeSocketTimeout,
-}
-const keepaliveAgent = oauthUrl.startsWith('https') ? new HttpsAgent(agentOptions) : new Agent(agentOptions)
 
 function generateOauthClientToken(
   clientId = config.apis.oauth2.apiClientId,
   clientSecret = config.apis.oauth2.apiClientSecret
 ) {
-  return generate(clientId, clientSecret)
-}
-
-function generate(clientId, clientSecret) {
   const token = Buffer.from(`${clientId}:${clientSecret}`).toString('base64')
   return `Basic ${token}`
-}
-
-async function getApiClientToken() {
-  const clientToken = generateOauthClientToken()
-  const handle = getNamespace('request.scope')
-  const username = handle.get('user')
-  const oauthRequest = querystring.stringify({ grant_type: 'client_credentials', username })
-
-  logger.info(
-    `Oauth request '${oauthRequest}' for client id '${config.apis.oauth2.apiClientId}' and user '${username}'`
-  )
-
-  return superagent
-    .post(oauthUrl)
-    .agent(keepaliveAgent)
-    .retry(2, (err, res) => {
-      if (err) logger.info(`Retry handler found API error with ${err.code} ${err.message}`)
-      return undefined // retry handler only for logging retries, not to influence retry logic
-    })
-    .auth(clientToken, { type: 'basic' })
-    .set('content-type', 'application/x-www-form-urlencoded')
-    .send(oauthRequest)
-    .timeout(timeoutSpec)
 }

--- a/server/authentication/clientCredentials.test.js
+++ b/server/authentication/clientCredentials.test.js
@@ -1,11 +1,11 @@
-const { generate } = require('./clientCredentials')
+const { generateOauthClientToken } = require('./clientCredentials')
 
-describe('generate', () => {
+describe('generateOauthClientToken', () => {
   it('Token can be generated', () => {
-    expect(generate('bob', 'password1')).toBe('Basic Ym9iOnBhc3N3b3JkMQ==')
+    expect(generateOauthClientToken('bob', 'password1')).toBe('Basic Ym9iOnBhc3N3b3JkMQ==')
   })
   it('Token can be generated with special characters', () => {
-    const value = generate('bob', "p@'s&sw/o$+ rd1")
+    const value = generateOauthClientToken('bob', "p@'s&sw/o$+ rd1")
 
     const decoded = Buffer.from(value.substring(6), 'base64').toString('utf-8')
 

--- a/server/authentication/signInService.js
+++ b/server/authentication/signInService.js
@@ -1,4 +1,52 @@
+const querystring = require('querystring')
+const superagent = require('superagent')
+const Agent = require('agentkeepalive')
+const { HttpsAgent } = require('agentkeepalive')
 const log = require('../../log')
+const config = require('../config')
+const fiveMinutesBefore = require('../utils/fiveMinutesBefore')
+
+const oauthUrl = `${config.apis.oauth2.url}/oauth/token`
+const timeoutSpec = {
+  response: config.apis.oauth2.timeout.response,
+  deadline: config.apis.oauth2.timeout.deadline,
+}
+
+const agentOptions = {
+  maxSockets: config.apis.oauth2.agent.maxSockets,
+  maxFreeSockets: config.apis.oauth2.agent.maxFreeSockets,
+  freeSocketTimeout: config.apis.oauth2.agent.freeSocketTimeout,
+}
+const keepaliveAgent = oauthUrl.startsWith('https') ? new HttpsAgent(agentOptions) : new Agent(agentOptions)
+
+async function oauthTokenRequest(oauthRequest) {
+  const oauthResult = await getOauthToken(oauthRequest)
+  log.info(`Oauth request for grant type '${oauthRequest.grant_type}', result status: ${oauthResult.status}`)
+
+  const token = oauthResult.body.access_token
+  const refreshToken = oauthResult.body.refresh_token
+  const expiresIn = oauthResult.body.expires_in
+
+  return { token, refreshToken, expiresIn }
+}
+
+function getOauthToken(requestSpec) {
+  const oauthRequest = querystring.stringify(requestSpec)
+  const clientId = config.apis.oauth2.apiClientId
+  const clientSecret = config.apis.oauth2.apiClientSecret
+
+  return superagent
+    .post(`${config.apis.oauth2.url}/oauth/token`)
+    .auth(clientId, clientSecret)
+    .set('content-type', 'application/x-www-form-urlencoded')
+    .agent(keepaliveAgent)
+    .retry(2, (err, res) => {
+      if (err) log.info(`Retry handler found API error with ${err.code} ${err.message}`)
+      return undefined // retry handler only for logging retries, not to influence retry logic
+    })
+    .send(oauthRequest)
+    .timeout(timeoutSpec)
+}
 
 function signInService() {
   return {
@@ -8,17 +56,20 @@ function signInService() {
       return {
         token,
         refreshToken,
-        refreshTime: getRefreshTime(expiresIn),
+        refreshTime: fiveMinutesBefore(expiresIn),
         username,
       }
     },
-  }
 
-  function getRefreshTime(expiresIn) {
-    // arbitrary five minute before expiry time
-    const now = new Date()
-    const secondsUntilExpiry = now.getSeconds() + (expiresIn - 300)
-    return now.setSeconds(secondsUntilExpiry)
+    async getRefreshedToken(user) {
+      log.info(`Refreshing token for : ${user.username}`)
+
+      const oauthRequest = { grant_type: 'refresh_token', refresh_token: user.refreshToken }
+
+      const { token, refreshToken, expiresIn } = await oauthTokenRequest(oauthRequest)
+      const refreshTime = fiveMinutesBefore(expiresIn)
+      return { token, refreshToken, refreshTime }
+    },
   }
 }
 

--- a/server/authentication/signInService.test.js
+++ b/server/authentication/signInService.test.js
@@ -45,14 +45,14 @@ describe('signInService', () => {
 
     test('successfully get token', async () => {
       const expectedBody = 'grant_type=refresh_token&refresh_token=REFRESH_TOKEN-1'
-
+      const in15Mins = new Date('May 31, 2018 12:15:00').getTime()
       fakeOauthApi
         .post('/oauth/token', expectedBody)
         .reply(200, { access_token: 'NEW_ACCESS_TOKEN-1', refresh_token: 'REFRESH_TOKEN-2', expires_in: 300 })
 
       const output = await service.getRefreshedToken({ username: 'Bob', refreshToken: 'REFRESH_TOKEN-1' })
       expect(output).toEqual({
-        refreshTime: 1527765300000,
+        refreshTime: in15Mins,
         refreshToken: 'REFRESH_TOKEN-2',
         token: 'NEW_ACCESS_TOKEN-1',
       })

--- a/server/utils/fiveMinutesBefore.js
+++ b/server/utils/fiveMinutesBefore.js
@@ -1,0 +1,6 @@
+/* (now + $seconds) - 5 minutes, in millis */
+module.exports = seconds => {
+  const now = new Date()
+  const secondsUntilExpiry = now.getSeconds() + (seconds - 300)
+  return now.setSeconds(secondsUntilExpiry)
+}

--- a/server/utils/fiveMinutesBefore.test.js
+++ b/server/utils/fiveMinutesBefore.test.js
@@ -1,0 +1,21 @@
+const fiveMinutesBefore = require('./fiveMinutesBefore')
+
+let realDateNow
+
+beforeEach(() => {
+  realDateNow = Date.now.bind(global.Date)
+  const time = new Date('May 31, 2018 12:00:00')
+  global.Date = jest.fn(() => time)
+})
+
+afterEach(() => {
+  global.Date.now = realDateNow
+})
+
+describe('fiveMinutesBefore', () => {
+  it('check', () => {
+    const twentyMinutesInSeconds = 20 * 60
+    const fifteenMinutesFromNow = new Date('May 31, 2018 12:15:00')
+    expect(fiveMinutesBefore(twentyMinutesInSeconds)).toEqual(fifteenMinutesFromNow.getTime())
+  })
+})


### PR DESCRIPTION
Token refresh was not implemented - but there was some code which attempted to redirect to login 5 minutes before the token expired (Not quite sure why).

The redirect would always be intercepted by the same code, so an infinite redirect loop would occur.

I've fixed this by back porting token refreshing functionality from categorisation tool.
