### PR TITLE
DCS-64 Refactoring incident persistence

### DIFF
--- a/integration-tests/db/db.js
+++ b/integration-tests/db/db.js
@@ -1,17 +1,31 @@
+const format = require('pg-format')
 const db = require('../../server/data/dataAccess/db')
 const formClient = require('../../server/data/formClient')
 
+const getFormDataForUser = bookingId =>
+  formClient.getFormDataForUser('Test User', bookingId, db.queryWithoutTransaction)
+
 module.exports = {
   clearDb() {
-    db.queryWithoutTransaction({
-      text: 'delete from form',
-      values: [],
-    })
+    const drops = ['incidents', 'involved_staff'].map(table =>
+      db.queryWithoutTransaction({
+        text: format('delete from %I', table),
+      })
+    )
+    return Promise.all(drops)
   },
 
   getFormData({ bookingId, formName }) {
-    return formClient.getFormDataForUser('Test User', bookingId, db.queryWithoutTransaction).then(form => {
-      return form.rows[0].form_response.incident[formName]
-    })
+    return getFormDataForUser(bookingId)
+      .then(form => ({
+        id: form.rows[0].id,
+        data: { incidentDate: form.rows[0].incident_date, ...form.rows[0].form_response.incident[formName] },
+      }))
+      .then(({ id, data }) =>
+        formClient
+          .getInvolvedStaff(id, db.queryWithoutTransaction)
+          .then(staff => staff.map(s => ({ userId: s.user_id, name: s.name })))
+          .then(staff => ({ data, staff }))
+      )
   },
 }

--- a/integration-tests/integration/createIncident/enter-initial-details.spec.js
+++ b/integration-tests/integration/createIncident/enter-initial-details.spec.js
@@ -44,7 +44,7 @@ context('Submitting details page form', () => {
 
     fillFormAndSave()
 
-    cy.task('getFormData', { bookingId, formName: 'newIncident' }).then(data => {
+    cy.task('getFormData', { bookingId, formName: 'newIncident' }).then(({ data, staff }) => {
       const { incidentDate, ...payload } = data
 
       const incidentDateInMillis = moment(incidentDate).valueOf()
@@ -55,10 +55,10 @@ context('Submitting details page form', () => {
 
       expect(payload).to.deep.equal({
         locationId: 357591,
-        involved: [{ name: 'AAAA' }, { name: 'BBBB' }],
         forceType: 'spontaneous',
         witnesses: [{ name: '1111' }],
       })
+      expect(staff).to.deep.equal([{ userId: 'AAAA', name: 'AAAA' }, { userId: 'BBBB', name: 'BBBB' }])
     })
   })
 

--- a/integration-tests/integration/createIncident/form-submit.spec.js
+++ b/integration-tests/integration/createIncident/form-submit.spec.js
@@ -60,6 +60,11 @@ context('Submit the incident report', () => {
     tasklistPage.checkNoPartsComplete()
 
     const newIncidentPage = tasklistPage.startNewForm()
+    newIncidentPage
+      .staffInvolved(0)
+      .name()
+      .type('Test User')
+
     const detailsPage = newIncidentPage.save()
     const relocationAndInjuriesPage = detailsPage.save()
     const evidencePage = relocationAndInjuriesPage.save()

--- a/migrations/20190726000000_form_db.js
+++ b/migrations/20190726000000_form_db.js
@@ -30,5 +30,6 @@ exports.down = knex =>
       table.dropColumn('incident_date')
       table.renameColumn('created_date', 'start_date')
     }),
-    knex.schema.dropTable('form'),
+
+    knex.schema.dropTable('involved_staff'),
   ])

--- a/migrations/20190726000000_form_db.js
+++ b/migrations/20190726000000_form_db.js
@@ -1,0 +1,33 @@
+exports.up = knex =>
+  Promise.all([
+    knex.schema.renameTable('form', 'incidents'),
+
+    knex.schema.alterTable('incidents', table => {
+      table.timestamp('incident_date')
+      table.renameColumn('start_date', 'created_date')
+    }),
+
+    knex.schema.createTable('involved_staff', table => {
+      table.increments('id').primary('pk_form')
+      table
+        .integer('incident_id')
+        .references('id')
+        .inTable('incidents')
+        .notNull()
+        .onDelete('cascade')
+      table.string('user_id').nullable()
+      table.string('name').nullable()
+      table.timestamp('submitted_date')
+      table.string('statement_status').notNullable()
+    }),
+  ])
+exports.down = knex =>
+  Promise.all([
+    knex.schema.renameTable('incidents', 'form'),
+
+    knex.schema.table('form', table => {
+      table.dropColumn('incident_date')
+      table.renameColumn('created_date', 'start_date')
+    }),
+    knex.schema.dropTable('form'),
+  ])

--- a/migrations/20190726000000_form_db.js
+++ b/migrations/20190726000000_form_db.js
@@ -17,6 +17,7 @@ exports.up = knex =>
         .onDelete('cascade')
       table.string('user_id').nullable()
       table.string('name').nullable()
+      table.string('email').nullable()
       table.timestamp('submitted_date')
       table.string('statement_status').notNullable()
     }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -9179,6 +9179,11 @@
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.0.0.tgz",
       "integrity": "sha1-Pu/lmX4G2Ugh5NUC5CtqHHP434I="
     },
+    "pg-format": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pg-format/-/pg-format-1.0.4.tgz",
+      "integrity": "sha1-J3NCNsKtP05QZJFaWTNOIAQKgo4="
+    },
     "pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "passport-local": "^1.0.0",
     "passport-oauth2": "^1.5.0",
     "pg": "^7.11.0",
+    "pg-format": "^1.0.4",
     "querystring": "^0.2.0",
     "ramda": "^0.25.0",
     "sass-middleware": "^0.0.3",

--- a/server/app.js
+++ b/server/app.js
@@ -170,26 +170,13 @@ module.exports = function createApp({ signInService, incidentService, offenderSe
     app.use(csurf())
   }
 
-  // JWT token refresh
+  // token refresh
   app.use(async (req, res, next) => {
-    if (req.user && req.originalUrl !== '/logout') {
+    if (req.user) {
       const timeToRefresh = new Date() > req.user.refreshTime
       if (timeToRefresh) {
-        try {
-          const newToken = await signInService.getRefreshedToken(req.user)
-          req.user.token = newToken.token
-          req.user.refreshToken = newToken.refreshToken
-          logger.info(`existing refreshTime in the past by ${new Date() - req.user.refreshTime}`)
-          logger.info(
-            `updating time by ${newToken.refreshTime - req.user.refreshTime} from ${req.user.refreshTime} to ${
-              newToken.refreshTime
-            }`
-          )
-          req.user.refreshTime = newToken.refreshTime
-        } catch (error) {
-          logger.error(`Token refresh error: ${req.user.username}`, error.stack)
-          return res.redirect('/logout')
-        }
+        req.session.returnTo = req.originalUrl
+        return res.redirect('/login')
       }
     }
     return next()

--- a/server/app.js
+++ b/server/app.js
@@ -170,13 +170,26 @@ module.exports = function createApp({ signInService, incidentService, offenderSe
     app.use(csurf())
   }
 
-  // token refresh
+  // JWT token refresh
   app.use(async (req, res, next) => {
-    if (req.user) {
+    if (req.user && req.originalUrl !== '/logout') {
       const timeToRefresh = new Date() > req.user.refreshTime
       if (timeToRefresh) {
-        req.session.returnTo = req.originalUrl
-        return res.redirect('/login')
+        try {
+          const newToken = await signInService.getRefreshedToken(req.user)
+          req.user.token = newToken.token
+          req.user.refreshToken = newToken.refreshToken
+          logger.info(`existing refreshTime in the past by ${new Date() - req.user.refreshTime}`)
+          logger.info(
+            `updating time by ${newToken.refreshTime - req.user.refreshTime} from ${req.user.refreshTime} to ${
+              newToken.refreshTime
+            }`
+          )
+          req.user.refreshTime = newToken.refreshTime
+        } catch (error) {
+          logger.error(`Token refresh error: ${req.user.username}`, error.stack)
+          return res.redirect('/logout')
+        }
       }
     }
     return next()
@@ -225,7 +238,7 @@ module.exports = function createApp({ signInService, incidentService, offenderSe
   app.use(currentUserInContext)
 
   app.use('/', createIncidentsRouter({ authenticationMiddleware, incidentService, offenderService }))
-  app.use('/check-answers/', createCheckAnswersRouter({ authenticationMiddleware, incidentService, offenderService }))
+  app.use('/check-answers/', createCheckAnswersRouter({ authenticationMiddleware, incidentService }))
   app.use('/submitted/', createSubmittedRouter({ authenticationMiddleware }))
   app.use('/form/', createFormRouter({ authenticationMiddleware, incidentService, offenderService }))
   app.use('/api/', createApiRouter({ authenticationMiddleware, offenderService }))

--- a/server/app.js
+++ b/server/app.js
@@ -238,7 +238,7 @@ module.exports = function createApp({ signInService, incidentService, offenderSe
   app.use(currentUserInContext)
 
   app.use('/', createIncidentsRouter({ authenticationMiddleware, incidentService, offenderService }))
-  app.use('/check-answers/', createCheckAnswersRouter({ authenticationMiddleware, incidentService }))
+  app.use('/check-answers/', createCheckAnswersRouter({ authenticationMiddleware, incidentService, offenderService }))
   app.use('/submitted/', createSubmittedRouter({ authenticationMiddleware }))
   app.use('/form/', createFormRouter({ authenticationMiddleware, incidentService, offenderService }))
   app.use('/api/', createApiRouter({ authenticationMiddleware, offenderService }))

--- a/server/config/fieldType.js
+++ b/server/config/fieldType.js
@@ -1,0 +1,4 @@
+module.exports = {
+  PAYLOAD: 'payload',
+  EXTRACTED: 'extracted',
+}

--- a/server/config/incident.js
+++ b/server/config/incident.js
@@ -1,5 +1,6 @@
 const moment = require('moment')
 const { isBlank } = require('../utils/utils')
+const { EXTRACTED } = require('./fieldType')
 
 module.exports = {
   newIncident: {
@@ -8,6 +9,7 @@ module.exports = {
         incidentDate: {
           responseType: 'requiredString',
           sanitiser: val => moment(val, 'DD/MM/YYYY-HH:mm').toDate(),
+          fieldType: EXTRACTED,
         },
       },
       {
@@ -32,6 +34,7 @@ module.exports = {
       {
         involved: {
           sanitiser: vals => removeEmptyValues('name', vals),
+          fieldType: EXTRACTED,
         },
       },
       {

--- a/server/data/formClient.js
+++ b/server/data/formClient.js
@@ -1,50 +1,52 @@
 const db = require('./dataAccess/db')
 
-const create = ({ userId, bookingId, reporterName, offenderNo, formResponse }) => {
-  const nextSequence = `(select COALESCE(MAX(sequence_no), 0) + 1 from form where booking_id = $5 and user_id = $2)`
-  return db.query({
-    text: `insert into form (form_response, user_id, reporter_name, offender_no, booking_id, status, sequence_no, start_date)
-            values ($1, CAST($2 AS VARCHAR), $3, $4, $5, $6, ${nextSequence}, CURRENT_TIMESTAMP)`,
-    values: [formResponse, userId, reporterName, offenderNo, bookingId, 'IN_PROGRESS'],
+const create = ({ userId, bookingId, reporterName, offenderNo, incidentDate, formResponse }) => {
+  const nextSequence = `(select COALESCE(MAX(sequence_no), 0) + 1 from incidents where booking_id = $5 and user_id = $2)`
+  const result = db.query({
+    text: `insert into incidents (form_response, user_id, reporter_name, offender_no, booking_id, status, incident_date, sequence_no, created_date)
+            values ($1, CAST($2 AS VARCHAR), $3, $4, $5, $6, $7, ${nextSequence}, CURRENT_TIMESTAMP)
+            returning id`,
+    values: [formResponse, userId, reporterName, offenderNo, bookingId, 'IN_PROGRESS', incidentDate],
   })
+  return result.rows[0].id
 }
 
-const update = (formId, formResponse) => {
+const update = (incidentId, incidentDate, formResponse) => {
   return db.query({
-    text: `update form f set form_response = $1 where f.id = $2`,
-    values: [formResponse, formId],
+    text: `update incidents i set form_response = $1, incident_date = COALESCE($2, i.incident_date) where i.id = $3`,
+    values: [formResponse, incidentDate, incidentId],
   })
 }
 
 const maxSequenceForBooking =
-  '(select max(f2.sequence_no) from form f2 where f2.booking_id = f.booking_id and user_id = f.user_id)'
+  '(select max(i2.sequence_no) from incidents i2 where i2.booking_id = i.booking_id and user_id = i.user_id)'
 
 const submit = (userId, bookingId) => {
   return db.query({
-    text: `update form f set status = $1, submitted_date = CURRENT_TIMESTAMP 
+    text: `update incidents i set status = $1, submitted_date = CURRENT_TIMESTAMP 
     where user_id = $2
     and booking_id = $3
     and status = 'IN_PROGRESS'
-    and f.sequence_no = ${maxSequenceForBooking}`,
+    and i.sequence_no = ${maxSequenceForBooking}`,
     values: ['SUBMITTED', userId, bookingId],
   })
 }
 
 const getFormDataForUser = (userId, bookingId, query = db.query) => {
   return query({
-    text: `select id, form_response from form f
+    text: `select id, incident_date, form_response from incidents i
           where user_id = $1
           and booking_id = $2
           and status = 'IN_PROGRESS'
-          and f.sequence_no = ${maxSequenceForBooking}`,
+          and i.sequence_no = ${maxSequenceForBooking}`,
     values: [userId, bookingId],
   })
 }
 
 const getIncidentsForUser = (userId, status, query = db.query) => {
   return query({
-    text: `select id, booking_id, reporter_name, offender_no, form_response -> 'incident' -> 'newIncident' -> 'incidentDate' incident_date
-          from form
+    text: `select id, booking_id, reporter_name, offender_no, incident_date
+          from incidents
           where (user_id = $1 or form_response -> 'incident' -> 'newIncident' -> 'involved'  @> $2)
           and status = $3`,
     values: [userId, JSON.stringify([{ name: userId }]), status],

--- a/server/data/formClient.js
+++ b/server/data/formClient.js
@@ -1,3 +1,4 @@
+const format = require('pg-format')
 const db = require('./dataAccess/db')
 
 const create = ({ userId, bookingId, reporterName, offenderNo, incidentDate, formResponse }) => {
@@ -53,10 +54,27 @@ const getIncidentsForUser = (userId, status, query = db.query) => {
   })
 }
 
+const deleteInvolvedStaff = incidentId => {
+  return db.query({
+    text: `delete from involved_staff where incident_id = $1`,
+    values: [incidentId],
+  })
+}
+
+const insertInvolvedStaff = (incidentId, staff) => {
+  const rows = staff.map(s => [incidentId, s.name, 'PENDING'])
+  const results = db.query({
+    text: format('insert into involved_staff (incident_id, user_id, statement_status) VALUES %L returning id', rows),
+  })
+  return results.rows.map(row => row.id)
+}
+
 module.exports = {
   create,
   update,
   submit,
   getFormDataForUser,
   getIncidentsForUser,
+  deleteInvolvedStaff,
+  insertInvolvedStaff,
 }

--- a/server/data/formClient.test.js
+++ b/server/data/formClient.test.js
@@ -81,3 +81,23 @@ test('getIncidentsForUser', () => {
     values: ['user1', '[{"name":"user1"}]', 'STATUS_1'],
   })
 })
+
+test('deleteInvolvedStaff', () => {
+  formClient.deleteInvolvedStaff('incident-1')
+
+  expect(db.query).toBeCalledWith({
+    text: `delete from involved_staff where incident_id = $1`,
+    values: ['incident-1'],
+  })
+})
+
+test('inserInvolvedStaff', () => {
+  db.query.mockReturnValue({ rows: [{ id: 1 }, { id: 2 }] })
+
+  const ids = formClient.insertInvolvedStaff('incident-1', [{ name: 'aaaa' }, { name: 'bbbb' }])
+
+  expect(ids).toEqual([1, 2])
+  expect(db.query).toBeCalledWith({
+    text: `insert into involved_staff (incident_id, user_id, statement_status) VALUES ('incident-1', 'aaaa', 'PENDING'), ('incident-1', 'bbbb', 'PENDING') returning id`,
+  })
+})

--- a/server/routes/form.js
+++ b/server/routes/form.js
@@ -57,7 +57,7 @@ module.exports = function Index({ incidentService, authenticationMiddleware, off
       const section = 'incident'
       const form = 'newIncident'
 
-      const { formObject, incidentDate } = await loadForm(req)
+      const { formId, formObject, incidentDate } = await loadForm(req)
       const date = incidentDate ? moment(incidentDate) : moment()
 
       const dateAndTime = {
@@ -65,11 +65,14 @@ module.exports = function Index({ incidentService, authenticationMiddleware, off
         time: date.format('HH:mm'),
       }
 
+      const involved = formId ? await incidentService.getInvolvedStaff(formId) : []
+
       const data = {
         displayName,
         offenderNo,
         dateAndTime,
         locations,
+        involved,
       }
 
       renderForm({ req, res, formObject, data, section, form })

--- a/server/routes/form.js
+++ b/server/routes/form.js
@@ -27,11 +27,12 @@ const renderForm = ({ req, res, formObject, section, form, data = {} }) => {
 module.exports = function Index({ incidentService, authenticationMiddleware, offenderService }) {
   const loadForm = async req => {
     const { bookingId } = req.params
-    const { form_response: formObject = {}, id: formId } = await incidentService.getFormResponse(
-      req.user.username,
-      bookingId
-    )
-    return { formId, formObject }
+    const {
+      id: formId,
+      incident_date: incidentDate,
+      form_response: formObject = {},
+    } = await incidentService.getFormResponse(req.user.username, bookingId)
+    return { formId, incidentDate, formObject }
   }
 
   const router = express.Router()
@@ -56,14 +57,12 @@ module.exports = function Index({ incidentService, authenticationMiddleware, off
       const section = 'incident'
       const form = 'newIncident'
 
-      const { formObject } = await loadForm(req)
-      const pageData = firstItem(req.flash('userInput')) || getIn([section, form], formObject) || {}
-
-      const incidentDate = pageData.incidentDate ? moment(pageData.incidentDate) : moment()
+      const { formObject, incidentDate } = await loadForm(req)
+      const date = incidentDate ? moment(incidentDate) : moment()
 
       const dateAndTime = {
-        date: incidentDate.format('DD/MM/YYYY'),
-        time: incidentDate.format('HH:mm'),
+        date: date.format('DD/MM/YYYY'),
+        time: date.format('HH:mm'),
       }
 
       const data = {

--- a/server/routes/incidents.test.js
+++ b/server/routes/incidents.test.js
@@ -4,7 +4,7 @@ const createRouter = require('./incidents')
 const { authenticationMiddleware } = require('./testutils/mockAuthentication')
 
 const incidentService = {
-  getIncidentsForUser: () => [{ id: 1, booking_id: 2, start_date: '12/12/2018', user_id: 'ITAG_USER' }],
+  getIncidentsForUser: () => [{ id: 1, booking_id: 2, created_date: '12/12/2018', user_id: 'ITAG_USER' }],
 }
 
 const offenderService = {

--- a/server/services/incidentService.js
+++ b/server/services/incidentService.js
@@ -1,6 +1,6 @@
 const logger = require('../../log.js')
 const { validate } = require('../utils/fieldValidation')
-const { isNilOrEmpty, equals } = require('../utils/utils')
+const { isNilOrEmpty } = require('../utils/utils')
 
 const getUpdatedFormObject = require('./updateBuilder')
 
@@ -23,7 +23,7 @@ module.exports = function createIncidentService({ formClient, elite2ClientBuilde
   async function update({ token, userId, reporterName, formId, bookingId, updatedFormObject }) {
     const incidentId = await updateIncident({ token, userId, reporterName, formId, bookingId, updatedFormObject })
     if (updatedFormObject.involved) {
-      await updateInvolvedStaff(incidentId, updatedFormObject.involved)
+      await updateInvolvedStaff({ incidentId, userId, reporterName, involvedStaff: updatedFormObject.involved })
     }
   }
 
@@ -49,16 +49,26 @@ module.exports = function createIncidentService({ formClient, elite2ClientBuilde
     return id
   }
 
-  async function updateInvolvedStaff(incidentId, involvedStaff) {
+  async function updateInvolvedStaff({ incidentId, involvedStaff }) {
     await formClient.deleteInvolvedStaff(incidentId)
     if (involvedStaff.length) {
-      await formClient.insertInvolvedStaff(incidentId, involvedStaff)
+      // TODO The reporting staff may need to be added to the list
+      // TODO: Currently have no way of retrieving user_id from a name - so currently coding both to same value
+      const staff = involvedStaff.map(user => ({
+        userId: user.name,
+        ...user,
+      }))
+      await formClient.insertInvolvedStaff(incidentId, staff)
     }
   }
 
   const getIncidentsForUser = async (userId, status) => {
     const data = await formClient.getIncidentsForUser(userId, status)
     return data.rows
+  }
+
+  const getInvolvedStaff = incidentId => {
+    return formClient.getInvolvedStaff(incidentId)
   }
 
   return {
@@ -68,5 +78,6 @@ module.exports = function createIncidentService({ formClient, elite2ClientBuilde
     getValidationErrors: validate,
     getIncidentsForUser,
     getUpdatedFormObject,
+    getInvolvedStaff,
   }
 }

--- a/server/services/incidentService.js
+++ b/server/services/incidentService.js
@@ -1,5 +1,7 @@
 const logger = require('../../log.js')
 const { validate } = require('../utils/fieldValidation')
+const { isNilOrEmpty } = require('../utils/utils')
+
 const getUpdatedFormObject = require('./updateBuilder')
 
 module.exports = function createIncidentService({ formClient, elite2ClientBuilder }) {
@@ -20,19 +22,22 @@ module.exports = function createIncidentService({ formClient, elite2ClientBuilde
 
   async function update({ token, userId, reporterName, formId, bookingId, updatedFormObject }) {
     if (formId) {
-      await formClient.update(formId, updatedFormObject)
+      if (!isNilOrEmpty(updatedFormObject.payload)) {
+        await formClient.update(formId, updatedFormObject.incidentDate, updatedFormObject.payload)
+      }
     } else {
       const elite2Client = elite2ClientBuilder(token)
       const { offenderNo } = await elite2Client.getOffenderDetails(bookingId)
-      await formClient.create({
+      const id = await formClient.create({
         userId,
         bookingId,
         reporterName,
         offenderNo,
-        formResponse: updatedFormObject,
+        incidentDate: updatedFormObject.incidentDate,
+        formResponse: updatedFormObject.payload,
       })
+      logger.info('Newly created id:', id)
     }
-    return updatedFormObject
   }
 
   const getIncidentsForUser = async (userId, status) => {

--- a/server/services/incidentService.js
+++ b/server/services/incidentService.js
@@ -1,6 +1,6 @@
 const logger = require('../../log.js')
 const { validate } = require('../utils/fieldValidation')
-const { isNilOrEmpty } = require('../utils/utils')
+const { isNilOrEmpty, equals } = require('../utils/utils')
 
 const getUpdatedFormObject = require('./updateBuilder')
 
@@ -21,22 +21,38 @@ module.exports = function createIncidentService({ formClient, elite2ClientBuilde
   }
 
   async function update({ token, userId, reporterName, formId, bookingId, updatedFormObject }) {
+    const incidentId = await updateIncident({ token, userId, reporterName, formId, bookingId, updatedFormObject })
+    if (updatedFormObject.involved) {
+      await updateInvolvedStaff(incidentId, updatedFormObject.involved)
+    }
+  }
+
+  async function updateIncident({ token, userId, reporterName, formId, bookingId, updatedFormObject }) {
     if (formId) {
       if (!isNilOrEmpty(updatedFormObject.payload)) {
+        logger.info(`Updated incident with id: ${formId} for user: ${userId} on booking: ${bookingId}`)
         await formClient.update(formId, updatedFormObject.incidentDate, updatedFormObject.payload)
       }
-    } else {
-      const elite2Client = elite2ClientBuilder(token)
-      const { offenderNo } = await elite2Client.getOffenderDetails(bookingId)
-      const id = await formClient.create({
-        userId,
-        bookingId,
-        reporterName,
-        offenderNo,
-        incidentDate: updatedFormObject.incidentDate,
-        formResponse: updatedFormObject.payload,
-      })
-      logger.info('Newly created id:', id)
+      return formId
+    }
+    const elite2Client = elite2ClientBuilder(token)
+    const { offenderNo } = await elite2Client.getOffenderDetails(bookingId)
+    const id = await formClient.create({
+      userId,
+      bookingId,
+      reporterName,
+      offenderNo,
+      incidentDate: updatedFormObject.incidentDate,
+      formResponse: updatedFormObject.payload,
+    })
+    logger.info(`Created new incident with id: ${id} for user: ${userId} on booking: ${bookingId}`)
+    return id
+  }
+
+  async function updateInvolvedStaff(incidentId, involvedStaff) {
+    await formClient.deleteInvolvedStaff(incidentId)
+    if (involvedStaff.length) {
+      await formClient.insertInvolvedStaff(incidentId, involvedStaff)
     }
   }
 

--- a/server/services/incidentService.test.js
+++ b/server/services/incidentService.test.js
@@ -43,17 +43,114 @@ describe('getFormResponse', () => {
   })
 })
 
-describe('getIncidentsForUser', () => {
-  test('retrieve  details', async () => {
-    const output = await service.getIncidentsForUser('user1', 'STATUS-1')
-
-    expect(output).toEqual([{ id: 1 }, { id: 2 }])
-
-    expect(formClient.getIncidentsForUser).toBeCalledTimes(1)
-    expect(formClient.getIncidentsForUser).toBeCalledWith('user1', 'STATUS-1')
-  })
-})
 describe('update', () => {
+  const baseForm = {
+    section1: '',
+    section2: '',
+    section3: {},
+    section4: {
+      form1: {},
+      form2: { answer: 'answer' },
+    },
+  }
+
+  describe('When there are no dependant fields', () => {
+    const fieldMap = [{ decision: {} }, { followUp1: {} }, { followUp2: {} }]
+
+    const form = {
+      ...baseForm,
+      section4: {
+        ...baseForm.section4,
+        form3: {
+          decision: '',
+          followUp1: '',
+          followUp2: '',
+        },
+      },
+    }
+
+    test('should build updated object correctly', async () => {
+      const userInput = {
+        decision: 'Yes',
+        followUp1: 'County',
+        followUp2: 'Town',
+      }
+
+      const output = await service.getUpdatedFormObject({
+        formObject: baseForm,
+        fieldMap,
+        userInput,
+        formSection: 'section4',
+        formName: 'form3',
+      })
+
+      expect(output).toEqual({
+        ...form,
+        section4: {
+          ...form.section4,
+          form3: {
+            decision: 'Yes',
+            followUp1: 'County',
+            followUp2: 'Town',
+          },
+        },
+      })
+    })
+
+    test('should not return updated form object when there has been no change', async () => {
+      const fieldMapSimple = [{ answer: {} }]
+      const userInput = { answer: 'answer' }
+
+      const existingForm = {
+        section1: '',
+        section2: '',
+        section3: {},
+        section4: {
+          form1: {},
+          form2: { answer: 'answer' },
+        },
+      }
+
+      const output = await service.getUpdatedFormObject({
+        formObject: existingForm,
+        fieldMap: fieldMapSimple,
+        userInput,
+        formSection: 'section4',
+        formName: 'form2',
+      })
+
+      expect(output).toEqual(false)
+    })
+
+    it('should add new sections and forms to the form if they dont exist', async () => {
+      const userInput = {
+        decision: 'Yes',
+        followUp1: 'County',
+        followUp2: 'Town',
+      }
+
+      const output = await service.getUpdatedFormObject({
+        formObject: baseForm,
+        fieldMap,
+        userInput,
+        formSection: 'section5',
+        formName: 'form1',
+      })
+
+      const expectedForm = {
+        ...baseForm,
+        section5: {
+          form1: {
+            decision: 'Yes',
+            followUp1: 'County',
+            followUp2: 'Town',
+          },
+        },
+      }
+      expect(output).toEqual(expectedForm)
+    })
+  })
+
   test('should call update and pass in the form when form id is present', async () => {
     const updatedFormObject = { decision: 'Yes', followUp1: 'County', followUp2: 'Town' }
 
@@ -87,6 +184,96 @@ describe('update', () => {
       formResponse: updatedFormObject,
     })
   })
+
+  describe('When there are dependant fields', () => {
+    const form = {
+      ...baseForm,
+      section4: {
+        ...baseForm.section4,
+        form3: {
+          decision: '',
+          followUp1: '',
+          followUp2: '',
+        },
+      },
+    }
+
+    const fieldMap = [
+      { decision: {} },
+      {
+        followUp1: {
+          dependentOn: 'decision',
+          predicate: 'Yes',
+        },
+      },
+      {
+        followUp2: {
+          dependentOn: 'decision',
+          predicate: 'Yes',
+        },
+      },
+    ]
+
+    test('should store dependents if predicate matches', async () => {
+      const userInput = {
+        decision: 'Yes',
+        followUp1: 'County',
+        followUp2: 'Town',
+      }
+
+      const formSection = 'section4'
+      const formName = 'form3'
+
+      const output = await service.getUpdatedFormObject({
+        formObject: baseForm,
+        fieldMap,
+        userInput,
+        formSection,
+        formName,
+      })
+
+      expect(output).toEqual({
+        ...form,
+        section4: {
+          ...form.section4,
+          form3: {
+            decision: 'Yes',
+            followUp1: 'County',
+            followUp2: 'Town',
+          },
+        },
+      })
+    })
+
+    test('should remove dependents if predicate does not match', async () => {
+      const userInput = {
+        decision: 'No',
+        followUp1: 'County',
+        followUp2: 'Town',
+      }
+
+      const formSection = 'section4'
+      const formName = 'form3'
+
+      const output = await service.getUpdatedFormObject({
+        formObject: baseForm,
+        fieldMap,
+        userInput,
+        formSection,
+        formName,
+      })
+
+      expect(output).toEqual({
+        ...form,
+        section4: {
+          ...form.section4,
+          form3: {
+            decision: 'No',
+          },
+        },
+      })
+    })
+  })
 })
 
 describe('getValidationErrors', () => {
@@ -113,5 +300,42 @@ describe('getValidationErrors', () => {
     ${{ q1: 'No' }}  | ${dependantConfig} | ${[]}
   `('should return errors $expectedContent for form return', ({ formBody, formConfig, expectedOutput }) => {
     expect(service.getValidationErrors(formBody, formConfig)).toEqual(expectedOutput)
+  })
+
+  test('sanitisation', async () => {
+    const config = [
+      {
+        q1: {
+          responseType: 'requiredString',
+          validationMessage: 'Please give a full name',
+          sanitiser: val => val.toUpperCase(),
+        },
+      },
+    ]
+
+    const output = await service.getUpdatedFormObject({
+      formObject: {},
+      fieldMap: config,
+      userInput: { q1: 'aaaAAAaa' },
+      formSection: 'section4',
+      formName: 'form1',
+    })
+
+    expect(output).toEqual({
+      section4: {
+        form1: {
+          q1: 'AAAAAAAA',
+        },
+      },
+    })
+  })
+
+  test('getIncidentsForUser', async () => {
+    const output = await service.getIncidentsForUser('user1', 'STATUS-1')
+
+    expect(output).toEqual([{ id: 1 }, { id: 2 }])
+
+    expect(formClient.getIncidentsForUser).toBeCalledTimes(1)
+    expect(formClient.getIncidentsForUser).toBeCalledWith('user1', 'STATUS-1')
   })
 })

--- a/server/services/incidentService.test.js
+++ b/server/services/incidentService.test.js
@@ -3,6 +3,8 @@ const serviceCreator = require('./incidentService')
 const formClient = {
   getFormDataForUser: jest.fn(),
   getIncidentsForUser: jest.fn(),
+  deleteInvolvedStaff: jest.fn(),
+  insertInvolvedStaff: jest.fn(),
   update: jest.fn(),
   create: jest.fn(),
 }
@@ -28,6 +30,8 @@ afterEach(() => {
   formClient.update.mockReset()
   formClient.create.mockReset()
   formClient.getIncidentsForUser.mockReset()
+  formClient.insertInvolvedStaff.mockReset()
+  formClient.deleteInvolvedStaff.mockReset()
   elite2Client.getOffenderDetails.mockReset()
 })
 
@@ -58,6 +62,7 @@ describe('update', () => {
     const updatedFormObject = {
       incidentDate: '21/12/2010',
       payload: { decision: 'Yes', followUp1: 'County', followUp2: 'Town' },
+      involved: [{ name: 'Bob' }],
     }
 
     await service.update({
@@ -69,6 +74,50 @@ describe('update', () => {
 
     expect(formClient.update).toBeCalledTimes(1)
     expect(formClient.update).toBeCalledWith('form1', updatedFormObject.incidentDate, updatedFormObject.payload)
+    expect(formClient.deleteInvolvedStaff).toBeCalledTimes(1)
+    expect(formClient.deleteInvolvedStaff).toBeCalledWith('form1')
+    expect(formClient.insertInvolvedStaff).toBeCalledTimes(1)
+    expect(formClient.insertInvolvedStaff).toBeCalledWith('form1', [{ name: 'Bob' }])
+  })
+
+  test('updates if no-one is present', async () => {
+    const updatedFormObject = {
+      incidentDate: '21/12/2010',
+      payload: { decision: 'Yes', followUp1: 'County', followUp2: 'Town' },
+      involved: [],
+    }
+
+    await service.update({
+      bookingId: 1,
+      userId: 'user1',
+      formId: 'form1',
+      updatedFormObject,
+    })
+
+    expect(formClient.update).toBeCalledTimes(1)
+    expect(formClient.update).toBeCalledWith('form1', updatedFormObject.incidentDate, updatedFormObject.payload)
+    expect(formClient.deleteInvolvedStaff).toBeCalledTimes(1)
+    expect(formClient.deleteInvolvedStaff).toBeCalledWith('form1')
+    expect(formClient.insertInvolvedStaff).not.toBeCalled()
+  })
+
+  test('doesnt update involved staff if non-present', async () => {
+    const updatedFormObject = {
+      incidentDate: '21/12/2010',
+      payload: { decision: 'Yes', followUp1: 'County', followUp2: 'Town' },
+    }
+
+    await service.update({
+      bookingId: 1,
+      userId: 'user1',
+      formId: 'form1',
+      updatedFormObject,
+    })
+
+    expect(formClient.update).toBeCalledTimes(1)
+    expect(formClient.update).toBeCalledWith('form1', updatedFormObject.incidentDate, updatedFormObject.payload)
+    expect(formClient.deleteInvolvedStaff).not.toBeCalled()
+    expect(formClient.insertInvolvedStaff).not.toBeCalled()
   })
 
   test('should call create when form id not present', async () => {

--- a/server/services/incidentService.test.js
+++ b/server/services/incidentService.test.js
@@ -55,7 +55,10 @@ describe('getIncidentsForUser', () => {
 })
 describe('update', () => {
   test('should call update and pass in the form when form id is present', async () => {
-    const updatedFormObject = { decision: 'Yes', followUp1: 'County', followUp2: 'Town' }
+    const updatedFormObject = {
+      incidentDate: '21/12/2010',
+      payload: { decision: 'Yes', followUp1: 'County', followUp2: 'Town' },
+    }
 
     await service.update({
       bookingId: 1,
@@ -65,11 +68,11 @@ describe('update', () => {
     })
 
     expect(formClient.update).toBeCalledTimes(1)
-    expect(formClient.update).toBeCalledWith('form1', updatedFormObject)
+    expect(formClient.update).toBeCalledWith('form1', updatedFormObject.incidentDate, updatedFormObject.payload)
   })
 
   test('should call create when form id not present', async () => {
-    const updatedFormObject = { decision: 'Yes', followUp1: 'County', followUp2: 'Town' }
+    const updatedFormObject = { payload: { decision: 'Yes', followUp1: 'County', followUp2: 'Town' } }
 
     await service.update({
       bookingId: 1,
@@ -84,7 +87,7 @@ describe('update', () => {
       bookingId: 1,
       offenderNo: 'AA123ABC',
       reporterName: 'Bob Smith',
-      formResponse: updatedFormObject,
+      formResponse: updatedFormObject.payload,
     })
   })
 })

--- a/server/services/incidentService.test.js
+++ b/server/services/incidentService.test.js
@@ -3,6 +3,7 @@ const serviceCreator = require('./incidentService')
 const formClient = {
   getFormDataForUser: jest.fn(),
   getIncidentsForUser: jest.fn(),
+  getInvolvedStaff: jest.fn(),
   deleteInvolvedStaff: jest.fn(),
   insertInvolvedStaff: jest.fn(),
   update: jest.fn(),
@@ -47,6 +48,13 @@ describe('getFormResponse', () => {
   })
 })
 
+describe('getInvolvedStaff', () => {
+  test('it should call query on db', async () => {
+    await service.getInvolvedStaff('incident-1')
+    expect(formClient.getInvolvedStaff).toBeCalledTimes(1)
+  })
+})
+
 describe('getIncidentsForUser', () => {
   test('retrieve  details', async () => {
     const output = await service.getIncidentsForUser('user1', 'STATUS-1')
@@ -77,7 +85,7 @@ describe('update', () => {
     expect(formClient.deleteInvolvedStaff).toBeCalledTimes(1)
     expect(formClient.deleteInvolvedStaff).toBeCalledWith('form1')
     expect(formClient.insertInvolvedStaff).toBeCalledTimes(1)
-    expect(formClient.insertInvolvedStaff).toBeCalledWith('form1', [{ name: 'Bob' }])
+    expect(formClient.insertInvolvedStaff).toBeCalledWith('form1', [{ userId: 'Bob', name: 'Bob' }])
   })
 
   test('updates if no-one is present', async () => {

--- a/server/services/updateBuilder.test.js
+++ b/server/services/updateBuilder.test.js
@@ -1,4 +1,5 @@
 const getUpdatedFormObject = require('./updateBuilder')
+const { EXTRACTED, PAYLOAD } = require('../config/fieldType')
 
 describe('getUpdatedFormObject', () => {
   const baseForm = {
@@ -42,13 +43,15 @@ describe('getUpdatedFormObject', () => {
       })
 
       expect(output).toEqual({
-        ...form,
-        section4: {
-          ...form.section4,
-          form3: {
-            decision: 'Yes',
-            followUp1: 'County',
-            followUp2: 'Town',
+        payload: {
+          ...form,
+          section4: {
+            ...form.section4,
+            form3: {
+              decision: 'Yes',
+              followUp1: 'County',
+              followUp2: 'Town',
+            },
           },
         },
       })
@@ -76,7 +79,7 @@ describe('getUpdatedFormObject', () => {
         formName: 'form2',
       })
 
-      expect(output).toEqual(false)
+      expect(output).toEqual({})
     })
 
     it('should add new sections and forms to the form if they dont exist', async () => {
@@ -95,12 +98,14 @@ describe('getUpdatedFormObject', () => {
       })
 
       const expectedForm = {
-        ...baseForm,
-        section5: {
-          form1: {
-            decision: 'Yes',
-            followUp1: 'County',
-            followUp2: 'Town',
+        payload: {
+          ...baseForm,
+          section5: {
+            form1: {
+              decision: 'Yes',
+              followUp1: 'County',
+              followUp2: 'Town',
+            },
           },
         },
       }
@@ -156,13 +161,15 @@ describe('getUpdatedFormObject', () => {
       })
 
       expect(output).toEqual({
-        ...form,
-        section4: {
-          ...form.section4,
-          form3: {
-            decision: 'Yes',
-            followUp1: 'County',
-            followUp2: 'Town',
+        payload: {
+          ...form,
+          section4: {
+            ...form.section4,
+            form3: {
+              decision: 'Yes',
+              followUp1: 'County',
+              followUp2: 'Town',
+            },
           },
         },
       })
@@ -187,15 +194,47 @@ describe('getUpdatedFormObject', () => {
       })
 
       expect(output).toEqual({
-        ...form,
-        section4: {
-          ...form.section4,
-          form3: {
-            decision: 'No',
+        payload: {
+          ...form,
+          section4: {
+            ...form.section4,
+            form3: {
+              decision: 'No',
+            },
           },
         },
       })
     })
+  })
+})
+
+test('check extracted fields are present outside of the payload', async () => {
+  const config = [
+    { q1: {} },
+    { q2: { fieldType: EXTRACTED } },
+    { q3: { fieldType: PAYLOAD } },
+    { q4: { fieldType: EXTRACTED } },
+  ]
+
+  const output = getUpdatedFormObject({
+    formObject: {},
+    fieldMap: config,
+    userInput: { q1: 'aaa', q2: 'bbb', q3: 'ccc', q4: 'ddd' },
+    formSection: 'section4',
+    formName: 'form1',
+  })
+
+  expect(output).toEqual({
+    payload: {
+      section4: {
+        form1: {
+          q1: 'aaa',
+          q3: 'ccc',
+        },
+      },
+    },
+    q2: 'bbb',
+    q4: 'ddd',
   })
 })
 
@@ -219,9 +258,11 @@ test('sanitisation', async () => {
   })
 
   expect(output).toEqual({
-    section4: {
-      form1: {
-        q1: 'AAAAAAAA',
+    payload: {
+      section4: {
+        form1: {
+          q1: 'AAAAAAAA',
+        },
       },
     },
   })


### PR DESCRIPTION
Several changes to the data layer: 
* Renaming form service to incident service (and renaming associated tables)
* renaming incident start_date to created_date
* Storing incident date separately from json payload
* Storing staff involved in an incident in separate table
 
