### PR TITLE
DCS-56 and 61 Fixed HTML validation errors

### DIFF
--- a/integration-tests/pages/checkAnswersPage.js
+++ b/integration-tests/pages/checkAnswersPage.js
@@ -19,13 +19,13 @@ export default () =>
       cy.get('.govuk-grid-column-full > :nth-child(5) > :nth-child(6) > :nth-child(2)').contains(
         'Yes - standing, supine, prone, kneeling'
       )
-      cy.get(':nth-child(5) > :nth-child(7) > .govuk-summary-list__value').contains('Yes - ratchet')
+      cy.get(':nth-child(5) > :nth-child(7) > .govuk-summary-list__value').contains('ratchet')
       cy.get(':nth-child(7) > :nth-child(1) > .govuk-summary-list__value').contains('segregation unit')
       cy.get(':nth-child(7) > :nth-child(2) > .govuk-summary-list__value').contains('compliant')
-      cy.get(':nth-child(7) > :nth-child(3) > .govuk-summary-list__value').contains('Yes - Dr Smith')
+      cy.get(':nth-child(7) > :nth-child(3) > .govuk-summary-list__value').contains('Dr Smith')
       cy.get(':nth-child(7) > :nth-child(4) > .govuk-summary-list__value').contains('Dr Taylor')
       cy.get(':nth-child(7) > :nth-child(5) > .govuk-summary-list__value').contains('Yes')
-      cy.get(':nth-child(7) > :nth-child(6) > .govuk-summary-list__value').contains('Yes - Eddie Thomas, Jayne Eyre')
+      cy.get(':nth-child(7) > :nth-child(6) > .govuk-summary-list__value').contains('Eddie Thomas, Jayne Eyre')
       cy.get(':nth-child(7) > :nth-child(6) > .govuk-summary-list__value').contains('Eddie Thomas, Jayne Eyre')
       cy.get(':nth-child(9) > :nth-child(1) > .govuk-summary-list__value')
         .contains('Bagged evidence 1')
@@ -37,7 +37,7 @@ export default () =>
 
       cy.get(':nth-child(9) > :nth-child(2) > .govuk-summary-list__value').contains('Yes')
       cy.get(':nth-child(9) > :nth-child(3) > .govuk-summary-list__value').contains('Not Known')
-      cy.get(':nth-child(9) > :nth-child(4) > .govuk-summary-list__value').contains('Yes - 123, 789, 456')
+      cy.get(':nth-child(9) > :nth-child(4) > .govuk-summary-list__value').contains('123, 789, 456')
     },
     clickSubmit,
     confirm: () => cy.get('#confirm').click(),

--- a/integration-tests/pages/relocationAndInjuriesPage.js
+++ b/integration-tests/pages/relocationAndInjuriesPage.js
@@ -20,7 +20,7 @@ export default () =>
       cy.get('[data-qa-add-another-staff-needing-medical-attention = true]').click()
       cy.get('[name="staffNeedingMedicalAttention[2][name]"]').type('Jayne Eyre')
       cy.get('[name="staffNeedingMedicalAttention[2][hospitalisation]"]').check('Yes')
-      cy.get(':nth-child(1) > .govuk-button').click()
+      cy.get('.add-another-staff-needing-medical-attention > :nth-child(1) > .govuk-button').click()
     },
     save: () => {
       cy.get('[data-qa="save-and-continue"]').click()

--- a/server/views/formPages/incident/evidence.html
+++ b/server/views/formPages/incident/evidence.html
@@ -106,7 +106,7 @@
                       }
                     })
                   }}
-                  {{ govukInput({
+                  {{ govukTextarea({
                     id: 'evidence-tag-and-description[0][description]',
                     name: 'evidenceTagAndDescription[0][description]',
                     classes: "govuk-!-width-two-thirds",

--- a/server/views/formPages/incident/evidence.html
+++ b/server/views/formPages/incident/evidence.html
@@ -70,7 +70,7 @@
                             
                   {{ govukTextarea({
                     name: 'evidenceTagAndDescription[' + loop.index0 + '][description]',
-                    idPrefix: 'evidence-tag-and-description[' + loop.index0 + '][description]',
+                    id: 'evidence-tag-and-description[' + loop.index0 + '][description]',
                     classes: 'govuk-!-width-two-thirds',
                     value: evidenceTagAndDescription.description,
                     label: {
@@ -78,9 +78,7 @@
                     },
                     attributes:{
                       'data-id': 'evidence-tag-and-description[%index%][description]',
-                      'data-name': 'evidenceTagAndDescription[%index%][description]',
-                      'rows':10,
-                      'columns': 40
+                      'data-name': 'evidenceTagAndDescription[%index%][description]'
                     }
                   }) }}
 
@@ -109,7 +107,7 @@
                     })
                   }}
                   {{ govukInput({
-                    idPrefix: 'evidence-tag-and-description[0][description]',
+                    id: 'evidence-tag-and-description[0][description]',
                     name: 'evidenceTagAndDescription[0][description]',
                     classes: "govuk-!-width-two-thirds",
                     value: data.evidenceTagAndDescription[0].description,
@@ -118,9 +116,7 @@
                     },
                     attributes: {
                       'data-id': 'evidence-tag-and-description[%index%][description]',
-                      'data-name': 'evidenceTagAndDescription[%index%][description]',
-                      'rows':10,
-                      'columns': 40
+                      'data-name': 'evidenceTagAndDescription[%index%][description]'
                     }
                   }) }}
 
@@ -137,6 +133,7 @@
               </div> 
             </div>  <!-- add another ends here -->
           </div>  <!-- hidden panel end -->
+        </div> <!-- end of radios -->
       </fieldset>     
     </div> <!-- end of this component  -->
 
@@ -306,8 +303,9 @@
                 <label class="govuk-label govuk-radios__label" for="body-worn-camera-notKnown">
                   Not known
                 </label>
-              </div>
-          </div>
+            </div>
+            </div> 
+          </div> <!-- end of radios -->
         </fieldset>     
       </div> <!-- end of this Q4 component  -->
 

--- a/server/views/formPages/incident/relocationAndInjuries.html
+++ b/server/views/formPages/incident/relocationAndInjuries.html
@@ -184,7 +184,7 @@
     <!-- Q6 -->          
 
 <div class="govuk-!-margin-bottom-6">
-      <div class="govuk-fieldset">
+      <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend ">
           Did a member of staff need medical attention at the time?
         </legend>
@@ -192,7 +192,7 @@
         <div class="govuk-radios" data-module="radios">
           <div class=" govuk-radios--inline">
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="staff-medical-attention" name="staffMedicalAttention" type="radio"
+              <input class="govuk-radios__input" id="staff-medical-attention-1" name="staffMedicalAttention" type="radio"
                 value="Yes" data-aria-controls="staff-medical-attention--conditional"
                 {% if data.staffMedicalAttention === 'Yes' %} checked {% endif %}
               >
@@ -336,8 +336,9 @@
               </div> 
             </div>  <!-- add another ends here -->
           </div>  <!-- hidden panel end -->
-        </fieldset>     
-      </div> <!-- end of this component  -->
+        </div> <!--end of radios -->
+      </fieldset>     
+    </div> <!-- end of this component  -->
   </div> <!-- end of column two thirds -->
 </div>   <!-- end of grid row-->
 

--- a/server/views/formPages/incident/relocationAndInjuries.html
+++ b/server/views/formPages/incident/relocationAndInjuries.html
@@ -25,9 +25,9 @@
         attributes: {style:'min-width:33%'},
         items: [
           {
-            value: "select",
+            value: "",
             text: "Select",
-            selected: data.prisonerRelocation === 'select'
+            selected: data.prisonerRelocation === ''
           },
           {
             value: "own cell",
@@ -69,9 +69,9 @@
       attributes: {style:'min-width:33%'},
       items: [
         {
-          value: "select",
+          value: "",
           text: "Select",
-          selected: data.relocationCompliancy === 'select'
+          selected: data.relocationCompliancy === ''
         },
         {
           value: "compliant",

--- a/server/views/formPages/incidentMacros.njk
+++ b/server/views/formPages/incidentMacros.njk
@@ -125,9 +125,7 @@
           <div class="govuk-radios govuk-radios__conditional clear-both" id="conditional-{{name}}">
             <fieldset class="govuk-fieldset">
               <legend class="govuk-fieldset__legend govuk-fieldset__legend {% if question.followUpQuestion.legend==='blank' %} govuk-visually-hidden {% endif %}" >
-                <p class="govuk-fieldset__heading govuk-heading-l">
                   {{question.followUpQuestion.legend}}
-                </p>
               </legend>
 
               {% set followUpQuestion = question.followUpQuestion %}

--- a/server/views/pages/pagesMacros.njk
+++ b/server/views/pages/pagesMacros.njk
@@ -1,7 +1,5 @@
 
 {% macro getUserInputs(data, title, url) %}
-{# regex to prevent display of 'undefined' which may occur if value depends on answer to a preceding question. Will also prevent 'select' displaying #}
-{% set regExp = r/^(?:undefined.*|select.*)/i %}  
 
   <h2 class="govuk-heading-l govuk-!-margin-bottom-1 govuk-!-margin-top-9">
     {{title}}
@@ -16,9 +14,9 @@
       <div class="govuk-summary-list__row">
             <dt class="govuk-summary-list__key"> {{key}} </dt>
             <dd class="govuk-summary-list__value"> 
-              {% if not value or regExp.test(value) %} 
+              {% if not value or value.length  == 0 %} 
                 &ndash;  
-              {% elif key === "Evidence bagged and tagged" %} 
+              {% elif key === "Evidence bagged and tagged" and value !== "No" %}
               {% for item in value %}
                 {{item.tag }}<br>{{item.description}}<br/><br/>
               {% endfor %}


### PR DESCRIPTION
http://localhost:3000/form/incident/relocationAndInjuries/-1
http://localhost:3000/form/incident/evidence/-1

Ran the Relocation and Injuries and Evidence pages through HTMLM validator. It revealed unnecessary definition of rows and columns for textareas, missing divs and missing id attribute. Corrected erorrs and rechecked. Updated Cypress tests.