### PR TITLE
DCS-38 Adding ability to retrieve emails for usernames

### DIFF
--- a/server/data/authClientBuilder.js
+++ b/server/data/authClientBuilder.js
@@ -1,0 +1,56 @@
+const superagent = require('superagent')
+const Agent = require('agentkeepalive')
+const { HttpsAgent } = require('agentkeepalive')
+const logger = require('../../log')
+const config = require('../config')
+
+const timeoutSpec = {
+  response: config.apis.oauth2.timeout.response,
+  deadline: config.apis.oauth2.timeout.deadline,
+}
+const apiUrl = config.apis.oauth2.url
+
+const agentOptions = {
+  maxSockets: config.apis.oauth2.agent.maxSockets,
+  maxFreeSockets: config.apis.oauth2.agent.maxFreeSockets,
+  freeSocketTimeout: config.apis.oauth2.agent.freeSocketTimeout,
+}
+
+const keepaliveAgent = apiUrl.startsWith('https') ? new HttpsAgent(agentOptions) : new Agent(agentOptions)
+
+module.exports = token => {
+  const userGet = userGetBuilder(token)
+
+  return {
+    async getEmail(username) {
+      const path = `${apiUrl}/api/user/${username}/email`
+      const { status, body } = await userGet({ path, raw: true })
+      return { ...body, username, exists: status !== 404, verified: status === 200 }
+    },
+  }
+}
+function userGetBuilder(token) {
+  return async ({ path, query = '', headers = {}, responseType = '', raw = false } = {}) => {
+    logger.info(`Get using user credentials: calling elite2api: ${path} ${query}`)
+    try {
+      const result = await superagent
+        .get(path)
+        .ok(res => res.status < 500)
+        .agent(keepaliveAgent)
+        .retry(2, (err, res) => {
+          if (err) logger.info(`Retry handler found API error with ${err.code} ${err.message}`)
+          return undefined // retry handler only for logging retries, not to influence retry logic
+        })
+        .query(query)
+        .auth(token, { type: 'bearer' })
+        .set(headers)
+        .responseType(responseType)
+        .timeout(timeoutSpec)
+
+      return raw ? result : result.body
+    } catch (error) {
+      logger.warn(error, 'Error calling elite2api')
+      throw error
+    }
+  }
+}

--- a/server/data/elite2ClientBuilder.test.js
+++ b/server/data/elite2ClientBuilder.test.js
@@ -12,7 +12,7 @@ describe('elite2Client', () => {
   const token = 'token-1'
 
   beforeEach(() => {
-    fakeElite2Api = nock(`${config.apis.elite2.url}`)
+    fakeElite2Api = nock(config.apis.elite2.url)
     elite2Client = elite2ClientBuilder(token)
     getNamespace.mockReturnValue({ get: () => 'myuser' })
   })

--- a/server/index.js
+++ b/server/index.js
@@ -6,6 +6,7 @@ const createApp = require('./app')
 
 const incidentClient = require('./data/incidentClient')
 const elite2ClientBuilder = require('./data/elite2ClientBuilder')
+const authClientBuilder = require('./data/authClientBuilder')
 
 const createIncidentService = require('./services/incidentService')
 const createSignInService = require('./authentication/signInService')
@@ -15,7 +16,7 @@ const createUserService = require('./services/userService')
 // pass in dependencies of service
 const incidentService = createIncidentService({ elite2ClientBuilder, incidentClient })
 const offenderService = createOffenderService(elite2ClientBuilder)
-const userService = createUserService(elite2ClientBuilder)
+const userService = createUserService(elite2ClientBuilder, authClientBuilder)
 
 const app = createApp({
   incidentService,

--- a/server/routes/incidents.js
+++ b/server/routes/incidents.js
@@ -63,6 +63,7 @@ module.exports = function Index({ authenticationMiddleware, incidentService, off
     asyncMiddleware(async (req, res) => {
       const { incidentId } = req.params
 
+      // TODO retrieve statement/errors from flash to re-render on validation error
       const statement = await incidentService.getStatement(req.user.username, incidentId)
       const offenderDetail = await offenderService.getOffenderDetails(res.locals.user.token, statement.bookingId)
       const { displayName, offenderNo } = offenderDetail

--- a/server/services/userService.js
+++ b/server/services/userService.js
@@ -1,7 +1,7 @@
 const logger = require('../../log.js')
 const { properCaseName } = require('../utils/utils.js')
 
-module.exports = function createUserService(elite2ClientBuilder) {
+module.exports = function createUserService(elite2ClientBuilder, authClientBuilder) {
   async function getUser(token) {
     try {
       const elite2Client = elite2ClientBuilder(token)
@@ -21,5 +21,27 @@ module.exports = function createUserService(elite2ClientBuilder) {
     }
   }
 
-  return { getUser }
+  async function getEmails(token, usernames) {
+    try {
+      const client = authClientBuilder(token)
+      const requests = usernames.map(username => client.getEmail(username))
+      const responses = await Promise.all(requests)
+
+      const missing = responses.filter(email => !email.exists)
+      const notVerified = responses.filter(email => !email.verified)
+      const exist = responses.filter(email => email.email)
+
+      return {
+        exist,
+        missing,
+        notVerified,
+        success: missing.length === 0 && notVerified.length === 0,
+      }
+    } catch (error) {
+      logger.error('Error during getEmails: ', error.stack)
+      throw error
+    }
+  }
+
+  return { getUser, getEmails }
 }

--- a/server/services/userService.test.js
+++ b/server/services/userService.test.js
@@ -7,18 +7,24 @@ const elite2Client = {
   getUserCaseLoads: jest.fn(),
 }
 
+const authClient = {
+  getEmail: jest.fn(),
+}
+
 const elite2ClientBuilder = jest.fn()
+const authClientBuilder = jest.fn()
 
 let service
 
 beforeEach(() => {
   elite2ClientBuilder.mockReturnValue(elite2Client)
-  service = serviceCreator(elite2ClientBuilder)
+  authClientBuilder.mockReturnValue(authClient)
+
+  service = serviceCreator(elite2ClientBuilder, authClientBuilder)
 })
 
 afterEach(() => {
-  elite2Client.getUser.mockReset()
-  elite2Client.getUserCaseLoads.mockReset()
+  jest.resetAllMocks()
 })
 
 describe('getUser', () => {
@@ -40,5 +46,91 @@ describe('getUser', () => {
     await service.getUser(token, -5)
 
     expect(elite2ClientBuilder).toBeCalledWith(token)
+  })
+})
+
+describe('getEmails', () => {
+  it('All successfull', async () => {
+    const user1 = { username: 'Bob', email: 'an@email.com', exists: true, verified: true }
+    const user2 = { username: 'June', email: 'an@email.com', exists: true, verified: true }
+
+    authClient.getEmail.mockResolvedValueOnce(user1).mockResolvedValueOnce(user2)
+
+    const result = await service.getEmails(token, ['Bob', 'June'])
+
+    expect(result).toEqual({
+      exist: [
+        {
+          email: 'an@email.com',
+          exists: true,
+          username: 'Bob',
+          verified: true,
+        },
+        {
+          email: 'an@email.com',
+          exists: true,
+          username: 'June',
+          verified: true,
+        },
+      ],
+      missing: [],
+      notVerified: [],
+      success: true,
+    })
+  })
+
+  it('One non existent', async () => {
+    const user1 = { username: 'Bob', email: 'an@email.com', exists: true, verified: true }
+    const user2 = { username: 'June', exists: false, verified: true }
+
+    authClient.getEmail.mockResolvedValueOnce(user1).mockResolvedValueOnce(user2)
+
+    const result = await service.getEmails(token, ['Bob', 'June'])
+
+    expect(result).toEqual({
+      exist: [
+        {
+          email: 'an@email.com',
+          exists: true,
+          username: 'Bob',
+          verified: true,
+        },
+      ],
+      missing: [{ exists: false, username: 'June', verified: true }],
+      notVerified: [],
+      success: false,
+    })
+  })
+
+  it('One not verified', async () => {
+    const user1 = { username: 'Bob', email: 'an@email.com', exists: true, verified: true }
+    const user2 = { username: 'June', exists: true, verified: false }
+
+    authClient.getEmail.mockResolvedValueOnce(user1).mockResolvedValueOnce(user2)
+
+    const result = await service.getEmails(token, ['Bob', 'June'])
+
+    expect(result).toEqual({
+      exist: [
+        {
+          email: 'an@email.com',
+          exists: true,
+          username: 'Bob',
+          verified: true,
+        },
+      ],
+      missing: [],
+      notVerified: [{ exists: true, username: 'June', verified: false }],
+      success: false,
+    })
+  })
+
+  it('should use the user token', async () => {
+    const user1 = { username: 'Bob', email: 'an@email.com' }
+    authClient.getEmail.mockReturnValue(user1)
+
+    await service.getEmails(token, ['Bob'])
+
+    expect(authClientBuilder).toBeCalledWith(token)
   })
 })


### PR DESCRIPTION
This is not currently hooked up to anything and also does not take into account users
which exist in nomis but not new-nomis.
(For the alpha we can ensure all users will exist in new-nomis but will ticket up this limitation)

It groups usernames into those that have verified email address, those that don't and those that
don't exist. We'll use these groups and the success flag to determine whether we can persist the
data and how to display validation messages if we can't