### PR TITLE
DCS-86 adding ability to link errors to individual array items

### DIFF
--- a/server/config/evidenceValidation.test.js
+++ b/server/config/evidenceValidation.test.js
@@ -1,0 +1,264 @@
+const config = require('./incident.js')
+const validator = require('../utils/fieldValidation')
+
+const validatorChecker = ({ fields }) => input => validator.validate(input, fields)
+const check = validatorChecker(config.evidence)
+
+const validInput = {
+  baggedEvidence: 'true',
+  evidenceTagAndDescription: [
+    {
+      evidenceTagReference: '12345',
+      description: 'A Description',
+    },
+    {
+      evidenceTagReference: '',
+      description: '',
+    },
+  ],
+  photographsTaken: 'true',
+  cctvRecording: 'YES',
+  bodyWornCamera: 'YES',
+  bodyWornCameraNumbers: [{ cameraNum: 'ABC123' }, { cameraNum: '' }],
+}
+
+describe('check evidence validation', () => {
+  it('successful input', () => {
+    const input = validInput
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([])
+
+    expect(formResponse).toEqual({
+      baggedEvidence: true,
+      bodyWornCamera: 'YES',
+      bodyWornCameraNumbers: [{ cameraNum: 'ABC123' }],
+      cctvRecording: 'YES',
+      evidenceTagAndDescription: [{ description: 'A Description', evidenceTagReference: '12345' }],
+      photographsTaken: true,
+    })
+  })
+
+  it('no values supplied', () => {
+    const input = {}
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([
+      {
+        href: '#baggedEvidence',
+        text: 'Select yes if any evidence was bagged and tagged',
+      },
+      {
+        href: '#photographsTaken',
+        text: 'Select yes if any photographs were taken',
+      },
+      {
+        href: '#cctvRecording',
+        text: 'Select yes if any part of the incident captured on CCTV',
+      },
+      {
+        href: '#bodyWornCamera',
+        text: 'Select yes if any part of the incident was captured on a body-worn camera',
+      },
+    ])
+
+    expect(formResponse).toEqual({
+      baggedEvidence: null,
+      bodyWornCamera: undefined,
+      cctvRecording: undefined,
+      photographsTaken: null,
+    })
+  })
+})
+
+describe('Evidence', () => {
+  it('Conditional field not selected  - errors and filters out evidence list', () => {
+    const input = {
+      ...validInput,
+      baggedEvidence: undefined,
+      evidenceTagAndDescription: [{ description: 'A Description', evidenceTagReference: '12345' }],
+    }
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([
+      {
+        href: '#baggedEvidence',
+        text: 'Select yes if any evidence was bagged and tagged',
+      },
+    ])
+
+    expect(formResponse).toEqual({
+      baggedEvidence: null,
+      bodyWornCamera: 'YES',
+      bodyWornCameraNumbers: [{ cameraNum: 'ABC123' }],
+      cctvRecording: 'YES',
+      photographsTaken: true,
+    })
+  })
+
+  it('with invalid bagged and tag evidence input', () => {
+    const input = {
+      ...validInput,
+      baggedEvidence: 'true',
+      evidenceTagAndDescription: [
+        { description: 'A Description', evidenceTagReference: '12345' },
+        { description: 'A Description', evidenceTagReference: '' },
+        { description: '', evidenceTagReference: '12345' },
+      ],
+    }
+
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([
+      {
+        href: '#evidenceTagAndDescription[1][evidenceTagReference]',
+        text: 'Please input the tag name for the evidence',
+      },
+      {
+        href: '#evidenceTagAndDescription[2][description]',
+        text: 'Please input a description of the evidence',
+      },
+    ])
+
+    expect(formResponse).toEqual({
+      baggedEvidence: true,
+      bodyWornCamera: 'YES',
+      bodyWornCameraNumbers: [{ cameraNum: 'ABC123' }],
+      cctvRecording: 'YES',
+      evidenceTagAndDescription: [
+        { description: 'A Description', evidenceTagReference: '12345' },
+        { description: 'A Description', evidenceTagReference: '' },
+        { description: '', evidenceTagReference: '12345' },
+      ],
+      photographsTaken: true,
+    })
+  })
+
+  it('missing both fields when required', () => {
+    const input = {
+      ...validInput,
+      baggedEvidence: 'true',
+      evidenceTagAndDescription: [{ description: '', evidenceTagReference: '' }],
+    }
+
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([
+      {
+        href: '#evidenceTagAndDescription[0][evidenceTagReference]',
+        text: 'Please input both the evidence tag number and the description',
+      },
+    ])
+
+    expect(formResponse).toEqual({
+      baggedEvidence: true,
+      bodyWornCamera: 'YES',
+      bodyWornCameraNumbers: [{ cameraNum: 'ABC123' }],
+      cctvRecording: 'YES',
+      evidenceTagAndDescription: [],
+      photographsTaken: true,
+    })
+  })
+
+  it('Conditional field selected: No, evidence are not required', () => {
+    const input = {
+      ...validInput,
+      baggedEvidence: 'false',
+      evidenceTagAndDescription: undefined,
+    }
+
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([])
+
+    expect(formResponse).toEqual({
+      baggedEvidence: false,
+      bodyWornCamera: 'YES',
+      bodyWornCameraNumbers: [{ cameraNum: 'ABC123' }],
+      cctvRecording: 'YES',
+      photographsTaken: true,
+    })
+  })
+})
+
+describe('Body Worn Cameras', () => {
+  it('Conditional field not selected  - errors and filters out camera number list', () => {
+    const input = { ...validInput, bodyWornCamera: undefined, bodyWornCameraNumbers: [{ cameraNum: 'AAA123' }] }
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([
+      {
+        href: '#bodyWornCamera',
+        text: 'Select yes if any part of the incident was captured on a body-worn camera',
+      },
+    ])
+
+    expect(formResponse).toEqual({
+      baggedEvidence: true,
+      bodyWornCamera: undefined,
+      cctvRecording: 'YES',
+      evidenceTagAndDescription: [{ description: 'A Description', evidenceTagReference: '12345' }],
+      photographsTaken: true,
+    })
+  })
+
+  it('Conditional field selected: Yes, check at least one number is present', () => {
+    const input = { ...validInput, bodyWornCamera: 'YES', bodyWornCameraNumbers: [] }
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([
+      {
+        href: '#bodyWornCameraNumbers',
+        text: 'Please input the camera number',
+      },
+    ])
+
+    expect(formResponse).toEqual({
+      baggedEvidence: true,
+      bodyWornCamera: 'YES',
+      bodyWornCameraNumbers: [],
+      cctvRecording: 'YES',
+      evidenceTagAndDescription: [{ description: 'A Description', evidenceTagReference: '12345' }],
+      photographsTaken: true,
+    })
+  })
+
+  it('Conditional field selected: Yes, empty numbers are ignored', () => {
+    const input = {
+      ...validInput,
+      bodyWornCamera: 'YES',
+      bodyWornCameraNumbers: [{ cameraNum: 'AAA' }, { cameraNum: '' }, { cameraNum: 'AAA' }],
+    }
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([])
+
+    expect(formResponse).toEqual({
+      baggedEvidence: true,
+      bodyWornCamera: 'YES',
+      bodyWornCameraNumbers: [{ cameraNum: 'AAA' }, { cameraNum: 'AAA' }],
+      cctvRecording: 'YES',
+      evidenceTagAndDescription: [{ description: 'A Description', evidenceTagReference: '12345' }],
+      photographsTaken: true,
+    })
+  })
+
+  it('Conditional field selected: No, numbers are not required', () => {
+    const input = {
+      ...validInput,
+      bodyWornCamera: 'NO',
+      bodyWornCameraNumbers: [{ cameraNum: 'AAA' }, { cameraNum: '' }, { cameraNum: 'AAA' }],
+    }
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([])
+
+    expect(formResponse).toEqual({
+      baggedEvidence: true,
+      bodyWornCamera: 'NO',
+      cctvRecording: 'YES',
+      evidenceTagAndDescription: [{ description: 'A Description', evidenceTagReference: '12345' }],
+      photographsTaken: true,
+    })
+  })
+})

--- a/server/config/evidenceValidation.test.js
+++ b/server/config/evidenceValidation.test.js
@@ -208,7 +208,7 @@ describe('Body Worn Cameras', () => {
 
     expect(errors).toEqual([
       {
-        href: '#bodyWornCameraNumbers',
+        href: '#bodyWornCameraNumbers[0][cameraNum]',
         text: 'Please input the camera number',
       },
     ])

--- a/server/config/incident.js
+++ b/server/config/incident.js
@@ -272,6 +272,7 @@ module.exports = {
           dependentOn: 'bodyWornCamera',
           predicate: 'YES',
           validationMessage: 'Please input the camera number',
+          firstFieldName: 'bodyWornCameraNumbers[0][cameraNum]',
         },
       },
     ],

--- a/server/config/incident.js
+++ b/server/config/incident.js
@@ -242,6 +242,7 @@ module.exports = {
           sanitiser: removeEmptyValues(['description', 'evidenceTagReference']),
           validationMessage: 'Please input both the evidence tag number and the description',
           dependentOn: 'baggedEvidence',
+          firstFieldName: 'evidenceTagAndDescription[0][evidenceTagReference]',
           predicate: 'true',
         },
       },

--- a/server/utils/fieldValidation.js
+++ b/server/utils/fieldValidation.js
@@ -77,6 +77,20 @@ const fieldOptions = {
     }),
 }
 
+const getHref = (fieldConfig, error) => {
+  const [head, ...sections] = error.path
+  const { firstFieldName } = fieldConfig[head]
+
+  if (sections.length === 0 && firstFieldName) {
+    /* If this field represents an array and the error is related to its structure 
+        we want to focus on the first field within the array item 
+    */
+    return firstFieldName
+  }
+
+  return sections.reduce((path, section) => `${path}[${section}]`, head)
+}
+
 module.exports = {
   validate(response, fields) {
     const { formSpecificPayload: formResponse } = processUserInput({ fieldMap: fields, userInput: response })
@@ -95,7 +109,7 @@ module.exports = {
 
       return {
         text: errorMessage,
-        href: `#${getFieldName(fieldConfig)}`,
+        href: `#${getHref(fieldConfig, error)}`,
       }
     })
 

--- a/server/views/formPages/incident/evidence.html
+++ b/server/views/formPages/incident/evidence.html
@@ -237,7 +237,7 @@
                           html: 'Camera number'
                         },
                         classes: 'govuk-!-width-one-third',
-                        id: 'body-worn-camera-numbers[' + loop.index0 + '][cameraNum]',
+                        id: 'bodyWornCameraNumbers[' + loop.index0 + '][cameraNum]',
                         name: 'bodyWornCameraNumbers[' + loop.index0 + '][cameraNum]',
                         value: camera.cameraNum,
                         attributes: {
@@ -263,7 +263,7 @@
                           html: 'Camera number'
                         },
                         classes: 'govuk-!-width-one-third',
-                        id: 'body-worn-camera-numbers[0][cameraNum]',
+                        id: 'bodyWornCameraNumbers[0][cameraNum]',
                         name: 'bodyWornCameraNumbers[0][cameraNum]',
                         attributes: {
                           'data-name': 'bodyWornCameraNumbers[%index%][cameraNum]',

--- a/server/views/formPages/incident/evidence.html
+++ b/server/views/formPages/incident/evidence.html
@@ -58,26 +58,26 @@
                         html: 'Tag number'
                       },
                       classes: 'govuk-!-width-one-third',
-                      id: 'evidence-tag-and-description[' + loop.index0 + '][evidenceTagReference]',
+                      id: 'evidenceTagAndDescription[' + loop.index0 + '][evidenceTagReference]',
                       name: 'evidenceTagAndDescription[' + loop.index0 + '][evidenceTagReference]',
                       value: evidenceTagAndDescription.evidenceTagReference,
                       attributes: {
                         'data-name': 'evidenceTagAndDescription[%index%][evidenceTagReference]',
-                        'data-id': 'evidence-tag-and-description[%index%][evidenceTagReference]'
+                        'data-id': 'evidenceTagAndDescription[%index%][evidenceTagReference]'
                       }
                     })
                   }} 
                             
                   {{ govukTextarea({
                     name: 'evidenceTagAndDescription[' + loop.index0 + '][description]',
-                    id: 'evidence-tag-and-description[' + loop.index0 + '][description]',
+                    id: 'evidenceTagAndDescription[' + loop.index0 + '][description]',
                     classes: 'govuk-!-width-two-thirds',
                     value: evidenceTagAndDescription.description,
                     label: {
                       text: "Description of evidence"
                     },
                     attributes:{
-                      'data-id': 'evidence-tag-and-description[%index%][description]',
+                      'data-id': 'evidenceTagAndDescription[%index%][description]',
                       'data-name': 'evidenceTagAndDescription[%index%][description]'
                     }
                   }) }}
@@ -98,16 +98,16 @@
                         html: 'Tag number'
                       },
                       classes: 'govuk-!-width-one-third',
-                      id: 'evidence-tag-and-description[0][evidenceTagReference]',
+                      id: 'evidenceTagAndDescription[0][evidenceTagReference]',
                       name: 'evidenceTagAndDescription[0][evidenceTagReference]',
                       attributes: {
                         'data-name': 'evidenceTagAndDescription[%index%][evidenceTagReference]',
-                        'data-id': 'evidence-tag-and-description[%index%][evidenceTagReference]'
+                        'data-id': 'evidenceTagAndDescription[%index%][evidenceTagReference]'
                       }
                     })
                   }}
                   {{ govukTextarea({
-                    id: 'evidence-tag-and-description[0][description]',
+                    id: 'evidenceTagAndDescription[0][description]',
                     name: 'evidenceTagAndDescription[0][description]',
                     classes: "govuk-!-width-two-thirds",
                     value: data.evidenceTagAndDescription[0].description,
@@ -115,7 +115,7 @@
                       text: "Description of evidence"
                     },
                     attributes: {
-                      'data-id': 'evidence-tag-and-description[%index%][description]',
+                      'data-id': 'evidenceTagAndDescription[%index%][description]',
                       'data-name': 'evidenceTagAndDescription[%index%][description]'
                     }
                   }) }}


### PR DESCRIPTION
Adding ability to link errors to individual array items when multiple values can be input via add-another component. 

Also allowing focusing on the first field of the first item when there is something wrong with the overall structure of an array. 

Also adding validation tests

We currently display the same message for each invalid item: 
<kbd>
<img width="1260" alt="Screenshot 2019-08-09 at 15 48 46" src="https://user-images.githubusercontent.com/1517745/62787743-432b3080-babd-11e9-9a33-568435c31768.png">
</kbd>

So although the links now work and point to the correct item - we will need some content updating (and a way to get access to the index which might be a bit gnarly...)