### PR TITLE
DCS-75 Adding validation to statement page

### DIFF
--- a/integration-tests/pages/incidentsPage.js
+++ b/integration-tests/pages/incidentsPage.js
@@ -24,6 +24,7 @@ const incidentsPage = () =>
       date: () => completeCol(i, 0),
       prisoner: () => completeCol(i, 1),
       reporter: () => completeCol(i, 2),
+      viewButton: () => completeCol(i, 3).find('a'),
       incidentId: () =>
         completeCol(i, 3)
           .find('a')

--- a/integration-tests/pages/viewStatementPage.js
+++ b/integration-tests/pages/viewStatementPage.js
@@ -1,20 +1,15 @@
 const page = require('./page')
-const StatementSubmittedPage = require('./statementSubmittedPage')
 
-const confirmStatementPage = () =>
+const viewStatementPage = () =>
   page('Use of force statement - review', {
     offenderName: () => cy.get('[data-qa=offender-name]'),
     statement: () => cy.get('[data-qa=statement]'),
     lastTraining: () => cy.get('[data-qa=last-training]'),
     jobStartYear: () => cy.get('[data-qa=job-start-year]'),
-    confirm: () => cy.get('#confirm'),
 
-    submit: () => {
-      cy.get('[data-qa=submit]').click()
-      return StatementSubmittedPage.verifyOnPage()
-    },
+    cancel: () => cy.get('[data-qa=cancel]'),
   })
 
 export default {
-  verifyOnPage: confirmStatementPage,
+  verifyOnPage: viewStatementPage,
 }

--- a/server/config/statement.js
+++ b/server/config/statement.js
@@ -1,39 +1,56 @@
 const { EXTRACTED } = require('./fieldType')
 
+const toInteger = val => {
+  const number = parseInt(val, 10)
+  return Number.isNaN(number) ? null : number
+}
+
 module.exports = {
   fields: [
     {
-      confirm: {
-        responseType: 'requiredNumber',
+      submit: {
+        responseType: 'requiredOneOf_save-and-continue_save-and-return',
       },
     },
     {
       lastTrainingMonth: {
-        responseType: 'requiredMonth',
-        sanitiser: val => parseInt(val, 10),
+        responseType: 'requiredMonthIndex',
+        sanitiser: toInteger,
+        validationMessage: 'Select the month you last attended refresher training',
         fieldType: EXTRACTED,
       },
     },
     {
       lastTrainingYear: {
-        responseType: 'requiredYear',
-        sanitiser: val => parseInt(val, 10),
+        responseType: 'requiredYearNotInFuture',
+        sanitiser: toInteger,
         fieldType: EXTRACTED,
+        validationMessage: {
+          'number.base': 'Enter the year you last attended refresher training',
+          'number.min': 'Enter the year you last attended refresher training which is not in the future',
+          'number.max': 'Enter the year you last attended refresher training which is not in the future',
+        },
       },
     },
     {
       jobStartYear: {
-        responseType: 'requiredYear',
-        sanitiser: val => parseInt(val, 10),
+        responseType: 'requiredYearNotInFuture',
+        sanitiser: toInteger,
         fieldType: EXTRACTED,
+        validationMessage: {
+          'number.base': 'Enter the year you joined the prison service',
+          'number.min': 'Enter the year you joined the prison service which is not in the future',
+          'number.max': 'Enter the year you joined the prison service which is not in the future',
+        },
       },
     },
     {
       statement: {
         responseType: 'requiredString',
+        validationMessage: 'Enter your statement',
         fieldType: EXTRACTED,
       },
     },
   ],
-  validate: false,
+  validate: true,
 }

--- a/server/config/statementValidation.test.js
+++ b/server/config/statementValidation.test.js
@@ -1,0 +1,197 @@
+const moment = require('moment')
+const config = require('./statement.js')
+
+const formProcessing = require('../services/formProcessing')
+
+const validatorChecker = formConfig => input => {
+  const { extractedFields: formResponse, errors } = formProcessing.processInput(formConfig, input)
+  return { formResponse, errors }
+}
+
+const check = validatorChecker(config)
+
+const validInput = {
+  submit: 'save-and-continue',
+  lastTrainingMonth: '11',
+  lastTrainingYear: '1999',
+  jobStartYear: '1995',
+  statement: 'A statement about the incident',
+}
+
+it('successful input', () => {
+  const input = validInput
+  const { errors, formResponse } = check(input)
+
+  expect(errors).toEqual([])
+
+  expect(formResponse).toEqual({
+    lastTrainingMonth: 11,
+    lastTrainingYear: 1999,
+    jobStartYear: 1995,
+    statement: 'A statement about the incident',
+  })
+})
+
+it('no values supplied', () => {
+  const input = { submit: 'save-and-continue' }
+  const { errors, formResponse } = check(input)
+
+  expect(errors).toEqual([
+    {
+      href: '#lastTrainingMonth',
+      text: 'Select the month you last attended refresher training',
+    },
+    {
+      href: '#lastTrainingYear',
+      text: 'Enter the year you last attended refresher training',
+    },
+    {
+      href: '#jobStartYear',
+      text: 'Enter the year you joined the prison service',
+    },
+    {
+      href: '#statement',
+      text: 'Enter your statement',
+    },
+  ])
+
+  expect(formResponse).toEqual({})
+})
+
+describe('lastTrainingMonth', () => {
+  it('wrong type', () => {
+    const input = { ...validInput, lastTrainingMonth: 'asasas' }
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([
+      {
+        href: '#lastTrainingMonth',
+        text: 'Select the month you last attended refresher training',
+      },
+    ])
+
+    expect(formResponse).toEqual({
+      lastTrainingYear: 1999,
+      jobStartYear: 1995,
+      statement: 'A statement about the incident',
+    })
+  })
+
+  it('not a valid month', () => {
+    const input = { ...validInput, lastTrainingMonth: '12' }
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([
+      {
+        href: '#lastTrainingMonth',
+        text: 'Select the month you last attended refresher training',
+      },
+    ])
+
+    expect(formResponse).toEqual({
+      lastTrainingYear: 1999,
+      lastTrainingMonth: 12,
+      jobStartYear: 1995,
+      statement: 'A statement about the incident',
+    })
+  })
+})
+
+describe('lastTrainingYear', () => {
+  it('wrong type', () => {
+    const input = { ...validInput, lastTrainingYear: 'asasas' }
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([
+      {
+        href: '#lastTrainingYear',
+        text: 'Enter the year you last attended refresher training',
+      },
+    ])
+
+    expect(formResponse).toEqual({
+      jobStartYear: 1995,
+      lastTrainingMonth: 11,
+      statement: 'A statement about the incident',
+    })
+  })
+
+  it('not a valid year', () => {
+    const input = { ...validInput, lastTrainingYear: `${moment().year() + 1}` }
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([
+      {
+        href: '#lastTrainingYear',
+        text: 'Enter the year you last attended refresher training which is not in the future',
+      },
+    ])
+
+    expect(formResponse).toEqual({
+      lastTrainingYear: 2020,
+      lastTrainingMonth: 11,
+      jobStartYear: 1995,
+      statement: 'A statement about the incident',
+    })
+  })
+})
+
+describe('jobStartYear', () => {
+  it('wrong type', () => {
+    const input = { ...validInput, jobStartYear: 'asasas' }
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([
+      {
+        href: '#jobStartYear',
+        text: 'Enter the year you joined the prison service',
+      },
+    ])
+
+    expect(formResponse).toEqual({
+      lastTrainingYear: 1999,
+      lastTrainingMonth: 11,
+      statement: 'A statement about the incident',
+    })
+  })
+
+  it('not a valid year', () => {
+    const input = { ...validInput, jobStartYear: `${moment().year() + 1}` }
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([
+      {
+        href: '#jobStartYear',
+        text: 'Enter the year you joined the prison service which is not in the future',
+      },
+    ])
+
+    expect(formResponse).toEqual({
+      lastTrainingYear: 1999,
+      lastTrainingMonth: 11,
+      jobStartYear: 2020,
+      statement: 'A statement about the incident',
+    })
+  })
+})
+
+describe('statement', () => {
+  it('not empty space', () => {
+    const input = { ...validInput, statement: '   \n   \t   ' }
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([
+      {
+        href: '#statement',
+        text: 'Enter your statement',
+      },
+    ])
+
+    expect(formResponse).toEqual({
+      lastTrainingYear: 1999,
+      lastTrainingMonth: 11,
+      jobStartYear: 1995,
+      statement: '   \n   \t   ',
+    })
+  })
+})

--- a/server/routes/incidents.test.js
+++ b/server/routes/incidents.test.js
@@ -61,10 +61,17 @@ describe('POST /incidents/:incidentId/statement', () => {
       .expect(302)
       .expect('Location', '/incidents/'))
 
-  it('save and continue should forward to confirm page', () =>
+  it('save and continue with invalid data will redirect to same page', () =>
     request(app)
       .post('/incidents/-1/statement')
       .send('submit=save-and-continue')
+      .expect(302)
+      .expect('Location', '/incidents/-1/statement'))
+
+  it('save and continue with valid data should forward to confirm page', () =>
+    request(app)
+      .post('/incidents/-1/statement')
+      .send('submit=save-and-continue&statement=bob&jobStartYear=1999&lastTrainingMonth=1&lastTrainingYear=1999')
       .expect(302)
       .expect('Location', '/incidents/-1/statement/confirm'))
 })

--- a/server/views/pages/statement/confirm.html
+++ b/server/views/pages/statement/confirm.html
@@ -40,7 +40,7 @@ govukInput %} {% from "govuk/components/select/macro.njk" import govukSelect %} 
       <div class="govuk-grid-column-one-half govuk-!-margin-top-5">
         {% call govukFieldset({ legend: { text: "When did you last attend control and restraint basic refresher
         training?", classes: "govuk-fieldset__legend--s govuk-!-width-two-thirds"} }) %}
-        <p class="govuk-!-margin-bottom-1 govuk-label--xs" data-qa="last-training-month">
+        <p class="govuk-!-margin-bottom-1 govuk-label--xs" data-qa="last-training">
           {{ data.lastTrainingMonth }} {{ data.lastTrainingYear }}
         </p>
         {% endcall %}
@@ -57,9 +57,7 @@ govukInput %} {% from "govuk/components/select/macro.njk" import govukSelect %} 
     <div class="govuk-grid-row govuk-!-margin-top-4">
       <div class="govuk-grid-column-full ">
         <p class="govuk-!-margin-bottom-1 govuk-label--s">Your statement</p>
-        <p class="govuk-!-margin-bottom-1 govuk-label--xs statement" data-qa="statement">
-          {{ data.statement }}
-        </p>
+        <p class="govuk-!-margin-bottom-1 govuk-label--xs statement" data-qa="statement">{{ data.statement }}</p>
       </div>
     </div>
     <hr />

--- a/server/views/pages/statement/provide.html
+++ b/server/views/pages/statement/provide.html
@@ -4,10 +4,20 @@
 {% from "govuk/components/input/macro.njk" import govukInput %} 
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %} 
-{% from "govuk/components/checkboxes/macro.njk"import govukCheckboxes %} 
+{% from "govuk/components/checkboxes/macro.njk"import govukCheckboxes %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %} 
 
 {% block content %}
 <div class="govuk-body">
+  {% if errors.length > 0 %}
+  {{
+    govukErrorSummary({
+      titleText: 'There is a problem',
+      errorList: errors,
+      attributes: { 'data-qa-errors': true }
+    })
+  }}
+  {% endif %}
   <h1 class="govuk-heading-xl mainHeading">Use of force statement</h1>
 
   <form method="POST">
@@ -37,11 +47,12 @@
           <div class="govuk-grid-column-one-half">
             {{
               govukSelect({
-                id: 'month',
+                id: 'lastTrainingMonth',
                 name: 'lastTrainingMonth',
                 label: {
                   text: 'Month'
                 },
+                errorMessage: errors | findError('lastTrainingMonth'),
                 items: data.months | toSelect('value', 'label', data.lastTrainingMonth)
               })
             }}
@@ -49,13 +60,14 @@
           <div class="govuk-grid-column-one-half">
           {{
             govukInput({
-              id: 'year',
+              id: 'lastTrainingYear',
               name: 'lastTrainingYear',
               value: data.lastTrainingYear,
               classes: 'govuk-!-width-one-quarter',
               label: {
                 text: 'Year'
-              }
+              },
+              errorMessage: errors | findError('lastTrainingYear')
             })
           }}
         </div>
@@ -71,13 +83,14 @@
         %}
         {{
           govukInput({
-            id: 'job-start-year',
+            id: 'jobStartYear',
             name: 'jobStartYear',
             value: data.jobStartYear,
             classes: 'govuk-!-width-one-quarter',
             label: {
               text: 'Year'
-            }
+            },
+            errorMessage: errors | findError('jobStartYear')
           })
         }}
         {% endcall %}
@@ -95,7 +108,8 @@
             label: {
               text: 'Your statement',
               classes: 'govuk-label--s govuk-!-margin-top-4'
-            }
+            },
+            errorMessage: errors | findError('statement')
           })
         }}
       </div>

--- a/server/views/pages/statement/review.html
+++ b/server/views/pages/statement/review.html
@@ -1,8 +1,13 @@
-{% extends "../../partials/layout.html" %} {% from "govuk/components/button/macro.njk" import govukButton %} {% from
-"govuk/components/textarea/macro.njk" import govukTextarea %} {% from "govuk/components/input/macro.njk" import
-govukInput %} {% from "govuk/components/select/macro.njk" import govukSelect %} {% from
-"govuk/components/fieldset/macro.njk" import govukFieldset %} {% from "govuk/components/checkboxes/macro.njk" import
-govukCheckboxes %} {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %} {% block content %}
+{% extends "../../partials/layout.html" %} 
+{% from "govuk/components/button/macro.njk" import govukButton %} 
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %} 
+{% from "govuk/components/input/macro.njk" import govukInput %} 
+{% from "govuk/components/select/macro.njk" import govukSelect %} 
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %} 
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %} 
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %} 
+
+{% block content %}
 <div class="govuk-body">
   {% if errors.length > 0 %}
   {{
@@ -36,7 +41,7 @@ govukCheckboxes %} {% from "govuk/components/error-summary/macro.njk" import gov
     <div class="govuk-grid-column-one-half govuk-!-margin-top-5">
       {% call govukFieldset({ legend: { text: "When did you last attend control and restraint basic refresher
       training?", classes: "govuk-fieldset__legend--s govuk-!-width-two-thirds"} }) %}
-      <p class="govuk-!-margin-bottom-1 govuk-label--xs" data-qa="last-training-month">
+      <p class="govuk-!-margin-bottom-1 govuk-label--xs" data-qa="last-training">
         {{ data.lastTrainingMonth }} {{ data.lastTrainingYear }}
       </p>
       {% endcall %}


### PR DESCRIPTION
Always persistng statement on submit - even if valdiation fails.
This means that a user can comeback to their work later and we can avoid issues with trying to store large amounts of content in cookie sessions.

Not carrying out validation when the user click save and return to incident list.