### PR TITLE
Alee/dcs 75 prevent confirming invalid statements

### DIFF
--- a/integration-tests/db/db.js
+++ b/integration-tests/db/db.js
@@ -1,5 +1,6 @@
 const format = require('pg-format')
 const db = require('../../server/data/dataAccess/db')
+const types = require('../../server/config/types')
 
 const incidentClient = require('../../server/data/incidentClient')
 

--- a/integration-tests/db/db.js
+++ b/integration-tests/db/db.js
@@ -1,7 +1,5 @@
 const format = require('pg-format')
 const db = require('../../server/data/dataAccess/db')
-const types = require('../../server/config/types')
-
 const incidentClient = require('../../server/data/incidentClient')
 
 const getCurrentDraftIncident = bookingId =>

--- a/server/config/statement.js
+++ b/server/config/statement.js
@@ -8,11 +8,6 @@ const toInteger = val => {
 module.exports = {
   fields: [
     {
-      submit: {
-        responseType: 'requiredOneOf_save-and-continue_save-and-return',
-      },
-    },
-    {
       lastTrainingMonth: {
         responseType: 'requiredMonthIndex',
         sanitiser: toInteger,

--- a/server/config/statementValidation.test.js
+++ b/server/config/statementValidation.test.js
@@ -11,7 +11,6 @@ const validatorChecker = formConfig => input => {
 const check = validatorChecker(config)
 
 const validInput = {
-  submit: 'save-and-continue',
   lastTrainingMonth: '11',
   lastTrainingYear: '1999',
   jobStartYear: '1995',

--- a/server/routes/incidents.js
+++ b/server/routes/incidents.js
@@ -35,7 +35,7 @@ module.exports = function Index({ authenticationMiddleware, incidentService, off
 
   const toStatement = namesByOffenderNumber => incident => ({
     id: incident.id,
-    date: moment(incident.incident_date).format('DD/MM/YYYY - HH:mm'),
+    incidentdate: incident.incident_date,
     staffMemberName: incident.reporter_name,
     offenderName: namesByOffenderNumber[incident.offender_no],
   })
@@ -99,7 +99,6 @@ module.exports = function Index({ authenticationMiddleware, incidentService, off
 
       if (!isValid) {
         req.flash('errors', errors)
-        req.flash('userInput', statement)
         return res.redirect(`/incidents/${incidentId}/statement`)
       }
 
@@ -136,6 +135,14 @@ module.exports = function Index({ authenticationMiddleware, incidentService, off
     asyncMiddleware(async (req, res) => {
       const { incidentId } = req.params
       const { confirmed } = req.body
+
+      const errors = await incidentService.validateSavedStatement(req.user.username, incidentId)
+
+      if (!isNilOrEmpty(errors)) {
+        req.flash('errors', errors)
+        return res.redirect(`/incidents/${incidentId}/statement`)
+      }
+
       if (!confirmed) {
         req.flash('errors', [
           {

--- a/server/routes/incidents.test.js
+++ b/server/routes/incidents.test.js
@@ -9,6 +9,7 @@ const incidentService = {
   submitStatement: jest.fn(),
   saveStatement: jest.fn(),
   processUserInput: () => ({}),
+  validateSavedStatement: jest.fn(),
 }
 
 const offenderService = {
@@ -20,6 +21,8 @@ const route = createRouter({ authenticationMiddleware, incidentService, offender
 let app
 
 beforeEach(() => {
+  incidentService.validateSavedStatement.mockReturnValue([])
+
   app = appSetup(route)
 })
 
@@ -77,7 +80,7 @@ describe('POST /incidents/:incidentId/statement', () => {
 })
 
 describe('POST /incidents/:incidentId/statement/confirm', () => {
-  it('unconfirmed submit redirects due to validation', () =>
+  it('unconfirmed submit redirects due to no confirmation', () =>
     request(app)
       .post('/incidents/-1/statement/confirm')
       .expect(302)
@@ -89,6 +92,14 @@ describe('POST /incidents/:incidentId/statement/confirm', () => {
       .send('confirmed=confirmed')
       .expect(302)
       .expect('Location', '/incidents/-1/statement/submitted'))
+
+  it('confirmed submit redirects due to form not being complete', () => {
+    incidentService.validateSavedStatement.mockReturnValue([{ href: '#field', text: 'An error' }])
+    return request(app)
+      .post('/incidents/-1/statement/confirm')
+      .expect(302)
+      .expect('Location', '/incidents/-1/statement')
+  })
 })
 
 describe('GET /incidents/:incidentId/statement', () => {

--- a/server/services/incidentService.js
+++ b/server/services/incidentService.js
@@ -1,5 +1,8 @@
 const logger = require('../../log.js')
 const { isNilOrEmpty } = require('../utils/utils')
+const { StatementStatus } = require('../config/types')
+const statementConfig = require('../config/statement')
+const { validate } = require('../utils/fieldValidation')
 
 module.exports = function createIncidentService({ incidentClient, elite2ClientBuilder }) {
   function getCurrentDraftIncident(userId, bookingId) {
@@ -78,6 +81,12 @@ module.exports = function createIncidentService({ incidentClient, elite2ClientBu
     return statement
   }
 
+  const validateSavedStatement = async (username, incidentId) => {
+    const statement = await getStatement(username, incidentId, StatementStatus.PENDING)
+    const errors = statementConfig.validate ? validate(statementConfig.fields, statement, true) : []
+    return errors
+  }
+
   const getInvolvedStaff = incidentId => {
     return incidentClient.getInvolvedStaff(incidentId)
   }
@@ -101,5 +110,6 @@ module.exports = function createIncidentService({ incidentClient, elite2ClientBu
     getInvolvedStaff,
     saveStatement,
     submitStatement,
+    validateSavedStatement,
   }
 }

--- a/server/services/incidentService.test.js
+++ b/server/services/incidentService.test.js
@@ -1,5 +1,5 @@
 const serviceCreator = require('./incidentService')
-const { StatementStatus } = require('../config/types')
+const { ReportStatus, StatementStatus } = require('../config/types')
 
 const incidentClient = {
   getCurrentDraftIncident: jest.fn(),

--- a/server/services/incidentService.test.js
+++ b/server/services/incidentService.test.js
@@ -1,5 +1,5 @@
 const serviceCreator = require('./incidentService')
-const { ReportStatus, StatementStatus } = require('../config/types')
+const { StatementStatus } = require('../config/types')
 
 const incidentClient = {
   getCurrentDraftIncident: jest.fn(),
@@ -188,5 +188,45 @@ describe('update', () => {
 
     expect(incidentClient.submitStatement).toBeCalledTimes(1)
     expect(incidentClient.submitStatement).toBeCalledWith('user1', 'incident-1')
+  })
+})
+
+describe('validateSavedStatement', () => {
+  test('valid statement', async () => {
+    incidentClient.getStatement.mockReturnValue({
+      lastTrainingMonth: 1,
+      lastTrainingYear: 2000,
+      jobStartYear: 1998,
+      statement: 'A statement',
+    })
+
+    const errors = await service.validateSavedStatement('user-1', 1)
+    expect(errors).toEqual([])
+  })
+
+  test('can cope with additional attributes', async () => {
+    incidentClient.getStatement.mockReturnValue({
+      lastTrainingMonth: 1,
+      lastTrainingYear: 2000,
+      jobStartYear: 1998,
+      statement: 'A statement',
+      id: 1223,
+      bookingId: 'bookingId',
+    })
+
+    const errors = await service.validateSavedStatement('user-1', 1)
+    expect(errors).toEqual([])
+  })
+
+  test('invalid statement', async () => {
+    incidentClient.getStatement.mockReturnValue({})
+
+    const errors = await service.validateSavedStatement('user-1', 1)
+    expect(errors.map(error => error.href)).toEqual([
+      '#lastTrainingMonth',
+      '#lastTrainingYear',
+      '#jobStartYear',
+      '#statement',
+    ])
   })
 })

--- a/server/utils/fieldValidation.js
+++ b/server/utils/fieldValidation.js
@@ -113,9 +113,9 @@ const getHref = (fieldConfig, error) => {
 }
 
 module.exports = {
-  validate(fields, formResponse) {
+  validate(fields, formResponse, stripUnknown = false) {
     const formSchema = createSchemaFromConfig(fields)
-    const joiErrors = joi.validate(formResponse, formSchema, { stripUnknown: false, abortEarly: false })
+    const joiErrors = joi.validate(formResponse, formSchema, { stripUnknown, abortEarly: false })
     const fieldsConfig = fields
 
     if (isNilOrEmpty(joiErrors.error)) {

--- a/server/views/pages/incidents.html
+++ b/server/views/pages/incidents.html
@@ -22,7 +22,7 @@
   <tbody class="govuk-table__body">
       {% for incident in awaitingStatements %}
       <tr class="govuk-table__row">
-          <td class="govuk-table__cell">{{incident.date}}</td>
+          <td class="govuk-table__cell">{{incident.incidentdate | formatDate('DD/MM/YYYY - HH:mm')}}</td>
           <td class="govuk-table__cell">{{incident.offenderName}}</td>
           <td class="govuk-table__cell">{{incident.staffMemberName}}</td>
           <td class="govuk-table__cell govuk-!-padding-top-1">
@@ -58,7 +58,7 @@
   <tbody class="govuk-table__body">
       {% for incident in completedStatements %}
       <tr class="govuk-table__row">
-          <td class="govuk-table__cell">{{incident.date}}</td>
+          <td class="govuk-table__cell">{{incident.incidentdate | formatDate('DD/MM/YYYY - HH:mm')}}</td>
           <td class="govuk-table__cell">{{incident.offenderName}}</td>
           <td class="govuk-table__cell">{{incident.staffMemberName}}</td>
           <td class="govuk-table__cell govuk-!-padding-top-1">


### PR DESCRIPTION
A user could theoretically go to the confirm page directly and confirm the statement whilst bypassing statement validation.
To prevent this, a validation check has been added to the confirm handler, which will redirect the user to the statement page with present errors if their statement is not complete. 