### PR TITLE
DCS 84: Details page displays error messages following field validation

### DIFF
--- a/integration-tests/integration/createIncident/form-submit.spec.js
+++ b/integration-tests/integration/createIncident/form-submit.spec.js
@@ -22,6 +22,7 @@ context('Submit the incident report', () => {
 
     const newIncidentPage = tasklistPage.startNewForm()
     const detailsPage = newIncidentPage.save()
+    detailsPage.fillForm()
     const relocationAndInjuriesPage = detailsPage.save()
     const evidencePage = relocationAndInjuriesPage.save()
     evidencePage.fillForm()
@@ -46,6 +47,7 @@ context('Submit the incident report', () => {
 
     const newIncidentPage = tasklistPage.startNewForm()
     const detailsPage = newIncidentPage.save()
+    detailsPage.fillForm()
     const relocationAndInjuriesPage = detailsPage.save()
     const evidencePage = relocationAndInjuriesPage.save()
     evidencePage.fillForm()
@@ -69,6 +71,7 @@ context('Submit the incident report', () => {
       .type('Test User')
 
     const detailsPage = newIncidentPage.save()
+    detailsPage.fillForm()
     const relocationAndInjuriesPage = detailsPage.save()
     const evidencePage = relocationAndInjuriesPage.save()
     evidencePage.fillForm()

--- a/integration-tests/integration/createIncident/submit-statement.spec.js
+++ b/integration-tests/integration/createIncident/submit-statement.spec.js
@@ -30,6 +30,7 @@ context('Submit statement', () => {
       .type('Test User')
 
     const detailsPage = newIncidentPage.save()
+    detailsPage.fillForm()
     const relocationAndInjuriesPage = detailsPage.save()
     const evidencePage = relocationAndInjuriesPage.save()
     evidencePage.fillForm()
@@ -82,6 +83,7 @@ context('Submit statement', () => {
       .type('Test User')
 
     const detailsPage = newIncidentPage.save()
+    detailsPage.fillForm()
     const relocationAndInjuriesPage = detailsPage.save()
     const evidencePage = relocationAndInjuriesPage.save()
     evidencePage.fillForm()
@@ -138,6 +140,7 @@ context('Submit statement', () => {
       .type('Test User')
 
     const detailsPage = newIncidentPage.save()
+    detailsPage.fillForm()
     const relocationAndInjuriesPage = detailsPage.save()
     const evidencePage = relocationAndInjuriesPage.save()
     evidencePage.fillForm()

--- a/server/config/detailsValidation.test.js
+++ b/server/config/detailsValidation.test.js
@@ -1,0 +1,336 @@
+const config = require('./incident.js')
+const formProcessing = require('../services/formProcessing')
+
+const validatorChecker = formConfig => input => {
+  const { payloadFields: formResponse, errors } = formProcessing.processInput(formConfig, input)
+  return { formResponse, errors }
+}
+
+let validInput = {}
+const check = validatorChecker(config.details)
+beforeEach(() => {
+  validInput = {
+    positiveCommunication: 'true',
+    personalProtectionTechniques: 'true',
+    batonDrawn: 'true',
+    batonUsed: 'true',
+    pavaDrawn: 'true',
+    pavaUsed: 'true',
+    guidingHold: 'true',
+    guidingHoldOfficersInvolved: '2',
+    restraint: 'true',
+    restraintPositions: ['STANDING', 'FACE_DOWN'],
+    handcuffsApplied: 'true',
+    handcuffsType: 'RATCHET',
+  }
+})
+
+describe('Details page - overall', () => {
+  it('Should return no validation error messages if every input field completed correctly', () => {
+    const input = validInput
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([])
+
+    expect(formResponse).toEqual({
+      positiveCommunication: true,
+      personalProtectionTechniques: true,
+      batonDrawn: true,
+      batonUsed: true,
+      pavaDrawn: true,
+      pavaUsed: true,
+      guidingHold: true,
+      guidingHoldOfficersInvolved: 2,
+      restraint: true,
+      restraintPositions: ['STANDING', 'FACE_DOWN'],
+      handcuffsApplied: true,
+      handcuffsType: 'RATCHET',
+    })
+  })
+
+  it('Should return 7 error massages if no input field is completed', () => {
+    const input = {}
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([
+      {
+        href: '#positiveCommunication',
+        text: 'Select yes if positive communication was used',
+      },
+      {
+        href: '#personalProtectionTechniques',
+        text: 'Select yes if any personal protection techniques were used',
+      },
+      {
+        href: '#batonDrawn',
+        text: 'Select yes if a baton was drawn',
+      },
+      {
+        href: '#pavaDrawn',
+        text: 'Select yes if PAVA was drawn',
+      },
+      {
+        href: '#guidingHold',
+        text: 'Select yes if a guiding hold was used',
+      },
+      {
+        href: '#restraint',
+        text: 'Select yes if control and restraint was used',
+      },
+      {
+        href: '#handcuffsApplied',
+        text: 'Select yes if handcuffs were applied',
+      },
+    ])
+
+    expect(errors.length).toEqual(7)
+
+    expect(formResponse).toEqual({})
+  })
+})
+
+describe('Details page inputs', () => {
+  it("Not selecting an option for 'positive communication' returns a validation error message", () => {
+    const input = {
+      ...validInput,
+      positiveCommunication: undefined,
+    }
+    const { errors } = check(input)
+    expect(errors).toEqual([
+      {
+        href: '#positiveCommunication',
+        text: 'Select yes if positive communication was used',
+      },
+    ])
+  })
+
+  it("Not selecting an option for 'personal protection techniques' returns a validation error message", () => {
+    const input = {
+      ...validInput,
+      personalProtectionTechniques: undefined,
+    }
+    const { errors } = check(input)
+    expect(errors).toEqual([
+      {
+        href: '#personalProtectionTechniques',
+        text: 'Select yes if any personal protection techniques were used',
+      },
+    ])
+  })
+
+  it("Not selecting an option for 'baton drawn' returns validation error message plus Baton Used is undefined", () => {
+    const input = {
+      ...validInput,
+      batonDrawn: undefined,
+    }
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([
+      {
+        href: '#batonDrawn',
+        text: 'Select yes if a baton was drawn',
+      },
+    ])
+    expect(formResponse.batonDrawn).toBe(undefined)
+    expect(formResponse.batonUsed).toBe(undefined)
+  })
+
+  it("Selecting Yes to 'baton drawn' but nothing for 'baton used' returns a  validation error messaged", () => {
+    const input = {
+      ...validInput,
+      batonUsed: undefined,
+    }
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([
+      {
+        href: '#batonUsed',
+        text: 'Select yes if a baton was used',
+      },
+    ])
+    expect(formResponse.batonDrawn).toEqual(true)
+    expect(formResponse.batonUsed).toBe(undefined)
+  })
+
+  it("Not selecting an option for 'pava drawn' returns validation error message plus 'pava used' is undefined", () => {
+    const input = {
+      ...validInput,
+      pavaDrawn: undefined,
+    }
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([
+      {
+        href: '#pavaDrawn',
+        text: 'Select yes if PAVA was drawn',
+      },
+    ])
+    expect(formResponse.pavaDrawn).toEqual(undefined)
+    expect(formResponse.pavaUsed).toBe(undefined)
+  })
+
+  it("Selecting Yes to 'pava drawn' but nothing for 'pava used' returns a validation error message", () => {
+    const input = {
+      ...validInput,
+      pavaUsed: undefined,
+    }
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([
+      {
+        href: '#pavaUsed',
+        text: 'Select yes if PAVA was used',
+      },
+    ])
+    expect(formResponse.pavaDrawn).toEqual(true)
+    expect(formResponse.pavaUsed).toBe(undefined)
+  })
+
+  it("Not selecting an option for 'guiding hold' returns validation error message plus 'how many officers involved' is undefined", () => {
+    const input = {
+      ...validInput,
+      guidingHold: undefined,
+    }
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([
+      {
+        href: '#guidingHold',
+        text: 'Select yes if a guiding hold was used',
+      },
+    ])
+    expect(formResponse.guidingHold).toEqual(undefined)
+    expect(formResponse.guidingHoldOfficersInvolved).toBe(undefined)
+  })
+
+  it("Selecting Yes to 'guiding hold' but nothing for 'how many officers were involved' returns a validation error message", () => {
+    const input = {
+      ...validInput,
+      guidingHoldOfficersInvolved: undefined,
+    }
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([
+      {
+        href: '#guidingHoldOfficersInvolved',
+        text: 'Select how many officers were involved in the guiding hold',
+      },
+    ])
+    expect(formResponse.guidingHold).toEqual(true)
+    expect(formResponse.guidingHoldOfficersInvolved).toBe(undefined)
+  })
+
+  it("Selecting 2 for 'how many officers were involved' return no errors", () => {
+    const input = {
+      ...validInput,
+      guidingHoldOfficersInvolved: '2',
+    }
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([])
+    expect(formResponse.guidingHold).toEqual(true)
+    expect(formResponse.guidingHoldOfficersInvolved).toEqual(2)
+  })
+
+  it("Not selecting an option for 'restraint'returns a validation error message plus 'restraint positions' is undefined", () => {
+    const input = {
+      ...validInput,
+      restraint: undefined,
+    }
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([
+      {
+        href: '#restraint',
+        text: 'Select yes if control and restraint was used',
+      },
+    ])
+    expect(formResponse.restraint).toBe(undefined)
+    expect(formResponse.restraintPositions).toBe(undefined)
+  })
+
+  it("Selecting Yes to 'restraint' but nothing for 'restraint positions' returns a validation error message", () => {
+    const input = {
+      ...validInput,
+      restraintPositions: undefined,
+    }
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([
+      {
+        href: '#restraintPositions',
+        text: 'Select the control and restraint positions used',
+      },
+    ])
+    expect(formResponse.restraint).toEqual(true)
+    expect(formResponse.restraintPositions).toBe(undefined)
+  })
+
+  it("Selecting just 1 option for 'restraint positions' returns no errors", () => {
+    const input = {
+      ...validInput,
+      restraintPositions: 'KNEELING',
+    }
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([])
+    expect(formResponse.restraint).toBe(true)
+    expect(formResponse.restraintPositions).toEqual('KNEELING')
+  })
+
+  it("Selecting 'Standing' and 'Face Down' for 'restraint positions' returns no errors", () => {
+    const input = {
+      ...validInput,
+    }
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([])
+    expect(formResponse.restraint).toEqual(true)
+    expect(formResponse.restraintPositions).toEqual(['STANDING', 'FACE_DOWN'])
+  })
+
+  it("Not selecting an option for 'handcuffs applied' returns a validation error message plus 'handcuffs type' is undefined", () => {
+    const input = {
+      ...validInput,
+      handcuffsApplied: undefined,
+    }
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([
+      {
+        href: '#handcuffsApplied',
+        text: 'Select yes if handcuffs were applied',
+      },
+    ])
+    expect(formResponse.handcuffsAplied).toBe(undefined)
+    expect(formResponse.handcuffsType).toBe(undefined)
+  })
+
+  it("Selecting Yes to 'handcuffs applied' but nothing for 'handcuffs type' returns a validation error message", () => {
+    const input = {
+      ...validInput,
+      handcuffsType: undefined,
+    }
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([
+      {
+        href: '#handcuffsType',
+        text: 'Select the type of handcuffs used',
+      },
+    ])
+    expect(formResponse.handcuffsApplied).toEqual(true)
+    expect(formResponse.handcuffsType).toBe(undefined)
+  })
+
+  it("Selecting 'Ratchet' for 'handcuffs type' returns no errors", () => {
+    const input = {
+      ...validInput,
+    }
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([])
+    expect(formResponse.handcuffsApplied).toEqual(true)
+    expect(formResponse.handcuffsType).toEqual('RATCHET')
+  })
+})

--- a/server/config/evidenceValidation.test.js
+++ b/server/config/evidenceValidation.test.js
@@ -110,11 +110,11 @@ describe('Evidence', () => {
     expect(errors).toEqual([
       {
         href: '#evidenceTagAndDescription[1][evidenceTagReference]',
-        text: 'Please input the tag name for the evidence',
+        text: 'Enter the evidence tag number',
       },
       {
         href: '#evidenceTagAndDescription[2][description]',
-        text: 'Please input a description of the evidence',
+        text: 'Enter a description of the evidence',
       },
     ])
 
@@ -169,7 +169,7 @@ describe('Evidence', () => {
     expect(errors).toEqual([
       {
         href: '#evidenceTagAndDescription[0][description]',
-        text: 'Please input a description of the evidence',
+        text: 'Enter a description of the evidence',
       },
     ])
 

--- a/server/config/incident.js
+++ b/server/config/incident.js
@@ -62,28 +62,28 @@ module.exports = {
       {
         positiveCommunication: {
           responseType: 'requiredBoolean',
-          validationMessage: 'Was Positive Communication used?',
+          validationMessage: 'Select yes if positive communication was used',
           sanitiser: toBoolean,
         },
       },
       {
         personalProtectionTechniques: {
           responseType: 'requiredBoolean',
-          validationMessage: 'Were Personal Protection techniques used?',
+          validationMessage: 'Select yes if any personal protection techniques were used',
           sanitiser: toBoolean,
         },
       },
       {
         batonDrawn: {
           responseType: 'requiredBoolean',
-          validationMessage: 'Was a baton drawn?',
+          validationMessage: 'Select yes if a baton was drawn',
           sanitiser: toBoolean,
         },
       },
       {
         batonUsed: {
-          responseType: 'requiredBoolean',
-          validationMessage: 'Was a baton used?',
+          responseType: 'requiredBatonUsed',
+          validationMessage: 'Select yes if a baton was used',
           sanitiser: toBoolean,
           dependentOn: 'batonDrawn',
           predicate: 'true',
@@ -92,14 +92,14 @@ module.exports = {
       {
         pavaDrawn: {
           responseType: 'requiredBoolean',
-          validationMessage: 'Was a pava drawn?',
+          validationMessage: 'Select yes if PAVA was drawn',
           sanitiser: toBoolean,
         },
       },
       {
         pavaUsed: {
-          responseType: 'requiredBoolean',
-          validationMessage: 'Was a pava used?',
+          responseType: 'requiredPavaUsed',
+          validationMessage: 'Select yes if PAVA was used',
           sanitiser: toBoolean,
           dependentOn: 'pavaDrawn',
           predicate: 'true',
@@ -108,14 +108,14 @@ module.exports = {
       {
         guidingHold: {
           responseType: 'requiredBoolean',
-          validationMessage: 'Was a guiding hold used?',
+          validationMessage: 'Select yes if a guiding hold was used',
           sanitiser: toBoolean,
         },
       },
       {
         guidingHoldOfficersInvolved: {
-          responseType: 'requiredNumber',
-          validationMessage: 'How many officers were involved?',
+          responseType: 'requiredOfficersInvolved',
+          validationMessage: 'Select how many officers were involved in the guiding hold',
           sanitiser: toInteger,
           dependentOn: 'guidingHold',
           predicate: 'true',
@@ -124,14 +124,14 @@ module.exports = {
       {
         restraint: {
           responseType: 'requiredBoolean',
-          validationMessage: 'Was control and restraint used?',
+          validationMessage: 'Select yes if control and restraint was used',
           sanitiser: toBoolean,
         },
       },
       {
         restraintPositions: {
-          responseType: 'requiredString',
-          validationMessage: 'What positions were used?',
+          responseType: 'requiredRestraintPositions',
+          validationMessage: 'Select the control and restraint positions used',
           dependentOn: 'restraint',
           predicate: 'true',
         },
@@ -139,20 +139,20 @@ module.exports = {
       {
         handcuffsApplied: {
           responseType: 'requiredBoolean',
-          validationMessage: 'Were handcuffs applied?',
+          validationMessage: 'Select yes if handcuffs were applied',
           sanitiser: toBoolean,
         },
       },
       {
         handcuffsType: {
-          responseType: 'requiredString',
-          validationMessage: 'What type of handcuffs were used?',
+          responseType: 'requiredHandcuffsType',
+          validationMessage: 'Select the type of handcuffs used',
           dependentOn: 'handcuffsApplied',
           predicate: 'true',
         },
       },
     ],
-    validate: false,
+    validate: true,
     nextPath: {
       path: bookingId => `/form/incident/relocationAndInjuries/${bookingId}`,
     },

--- a/server/utils/fieldValidation.js
+++ b/server/utils/fieldValidation.js
@@ -8,11 +8,6 @@ const { getFieldName, getFieldDetail, mergeWithRight, getIn, isNilOrEmpty } = re
 const joi = baseJoi.extend(dateExtend).extend(postcodeExtend)
 
 const fieldOptions = {
-  requiredString: joi
-    .string()
-    .trim()
-    .required(),
-  requiredNumber: joi.number().required(),
   requiredMonthIndex: joi
     .number()
     .min(0)
@@ -25,6 +20,11 @@ const fieldOptions = {
       .min(1900)
       .max(moment().year())
       .required(),
+  requiredString: joi
+    .string()
+    .trim()
+    .required(),
+  requiredNumber: joi.number().required(),
   requiredBoolean: joi
     .boolean()
     .required()
@@ -69,7 +69,7 @@ const fieldOptions = {
             cameraNum: joi
               .string()
               .required()
-              .error(() => 'Please input the camera number(s)'),
+              .error(() => 'Enter the body-worn camera number'),
           })
         )
         .required(),
@@ -86,15 +86,55 @@ const fieldOptions = {
               .string()
               .trim()
               .required()
-              .error(() => 'Please input the tag name for the evidence'),
+              .error(() => 'Enter the evidence tag number'),
             description: joi
               .string()
               .trim()
               .required()
-              .error(() => 'Please input a description of the evidence'),
+              .error(() => 'Enter a description of the evidence'),
           })
         )
         .required(),
+    }),
+
+  requiredBatonUsed: () =>
+    joi.when('batonDrawn', {
+      is: true,
+      then: joi.valid([true, false]).required(),
+      otherwise: joi.any().optional(),
+    }),
+
+  requiredPavaUsed: () =>
+    joi.when('pavaDrawn', {
+      is: true,
+      then: joi.valid([true, false]).required(),
+      otherwise: joi.any().optional(),
+    }),
+
+  requiredOfficersInvolved: () =>
+    joi.when('guidingHold', {
+      is: true,
+      then: joi.valid([1, 2]).required(),
+      otherwise: joi.any().optional(),
+    }),
+
+  requiredRestraintPositions: () =>
+    joi.when('restraint', {
+      is: true,
+      then: joi
+        .alternatives()
+        .try(
+          joi.array().items(joi.string().valid('STANDING', 'FACE_DOWN', 'ON_BACK', 'KNEELING')),
+          joi.string().valid('STANDING', 'FACE_DOWN', 'ON_BACK', 'KNEELING')
+        )
+        .required(),
+    }),
+
+  requiredHandcuffsType: () =>
+    joi.when('handcuffsApplied', {
+      is: true,
+      then: joi.valid(['RATCHET', 'FIXED_BAR']).required(),
+      otherwise: joi.any().optional(),
     }),
 }
 

--- a/server/views/formPages/incident/details.html
+++ b/server/views/formPages/incident/details.html
@@ -25,7 +25,8 @@
       text: "Was positive communication used to de-escalate the situation?",
       name: "positiveCommunication",
       value: data.positiveCommunication,
-      options: yesNoOptions
+      options: yesNoOptions,
+      errorMessage: errors | findError('positiveCommunication')
     })}}
 
     <!-- Q2 -->
@@ -33,7 +34,8 @@
       text: "Were any personal protection techniques used?",
       name: "personalProtectionTechniques",
       value: data.personalProtectionTechniques,
-      options: yesNoOptions
+      options: yesNoOptions,
+      errorMessage: errors | findError('personalProtectionTechniques')
     })}}
 
     <!-- Q3 -->
@@ -42,13 +44,15 @@
         text: "Was a baton drawn?",
         name: "batonDrawn",
         value: data.batonDrawn,
-        options: yesNoOptions
+        options: yesNoOptions,
+        errorMessage: errors | findError('batonDrawn')
       },
       followUpQuestion: {
         text: "Was it used?",
         value: data.batonUsed,
         name: "batonUsed",
-        options: yesNoOptions
+        options: yesNoOptions,
+        errorMessage: errors | findError('batonUsed')
       }
     })}}
 
@@ -58,13 +62,17 @@
         text: "Was PAVA drawn?",
         name: "pavaDrawn",
         value: data.pavaDrawn,
-        options: yesNoOptions
+        options: yesNoOptions,
+        errorMessage: errors | findError('pavaDrawn')
+
       },
       followUpQuestion: {
         text: "Was it used?",
         name: "pavaUsed",
         value: data.pavaUsed,
-        options: yesNoOptions
+        options: yesNoOptions,
+        errorMessage: errors | findError('pavaUsed')
+
       }
     }
     )}}
@@ -75,12 +83,15 @@
         text: "Was a guiding hold used?",
         name: "guidingHold",
         value: data.guidingHold,
-        options: yesNoOptions
+        options: yesNoOptions,
+        errorMessage: errors | findError('guidingHold')
+
       },
       followUpQuestion: {
         text: "How many officers were involved?",
         name: "guidingHoldOfficersInvolved",
         value: data.guidingHoldOfficersInvolved,
+        errorMessage: errors | findError('guidingHoldOfficersInvolved'),
         options: [{
           value: 1,
           label: "1"
@@ -93,21 +104,25 @@
     })}}
 
     <!-- Q6 -->
+
     {{ incidentMacro.radiosWithNestedCheckboxes({
-          primaryQuestion: {
-            text: "Was control and restraint used?",
-            name: "restraint",
-            value: data.restraint,
-            options: yesNoOptions
-          },
-          followUpQuestion: {
-            text: "What positions were used?",
-            name: "restraintPositions",
-            value: data.restraintPositions or [],
-            options: data.types.ControlAndRestraintPosition | list | extractAttr('value') | toOptions('value', 'label')
-          }
-        }) 
-      }}
+      primaryQuestion: {
+        text: "Was control and restraint used?",
+        name: "restraint",
+        value: data.restraint,
+        options: yesNoOptions,
+        errorMessage: errors | findError('restraint')
+      },
+      followUpQuestion: {
+        text: "What positions were used?",
+        name: "restraintPositions",
+        value: data.restraintPositions or [],
+        errorMessage: errors | findError('restraintPositions'),
+        options: data.types.ControlAndRestraintPosition | list | extractAttr('value') | toOptions('value', 'label')
+      }
+    }) 
+  }}
+
 
     <!-- Q7 -->
     {{ incidentMacro.radiosWithNestedRadios({
@@ -115,12 +130,14 @@
         text: "Were handcuffs applied?",
         name: "handcuffsApplied",
         value: data.handcuffsApplied,
-        options: yesNoOptions
+        options: yesNoOptions,
+        errorMessage: errors | findError('handcuffsApplied')
       },
       followUpQuestion: {
         text: "Select which type of handcuffs were used",
         name: "handcuffsType",
         value: data.handcuffsType,
+        errorMessage: errors | findError('handcuffsType'),
         options: [{
           value: "RATCHET",
           label: "Ratchet"

--- a/server/views/formPages/incidentMacros.njk
+++ b/server/views/formPages/incidentMacros.njk
@@ -1,181 +1,239 @@
 {% macro radio(question) %}
+{% if question.errorMessage.text %}
+{% set govukFormGroupError =  'govuk-form-group--error' %}
+{% set errorMessageText = question.errorMessage.text %}
+{% endif %}
 
-  <div class="govuk-form-group">
-    <fieldset class="govuk-fieldset">
-      {# primary #}
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend">
-          {{question.text}}
-      </legend>
-      <div class="govuk-!-margin-bottom-6">
-        <div class="{% if question.options | length < 3 %} govuk-radios--inline{% endif %}" data-module="govuk-radios">
-          {% set name1 = question.name %}
-          {% for option in question.options %}
-            <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="id-{{name1}}-{{loop.index}}" name="{{name1}}" type="radio" value="{{option.value}}" 
-              {% if option.value === question.value %} checked {% endif %}>
-              <label class="govuk-label govuk-radios__label" for='id-{{name1}}-{{loop.index}}'>
-                {{option.label}}
-              </label>
-            </div>
-          {% endfor %}
+<div class="govuk-form-group  {{govukFormGroupError}} ">
+  <fieldset class="govuk-fieldset">
+    <!-- primary  -->
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend">
+      {{question.text}}
+    </legend>
+
+    <span class="govuk-error-message">
+      <span class="govuk-visually-hidden">Error:</span>
+      {{ errorMessageText}}
+    </span>
+
+    <div class="govuk-!-margin-bottom-6">
+      <div class="{% if question.options | length < 3 %} govuk-radios--inline{% endif %}" data-module="govuk-radios">
+        {% set name1 = question.name %}
+        {% for option in question.options %}
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" {% if loop.index === 1 %} id={{name1}} {% else %}
+            id="id-{{name1}}-{{loop.index}}" {% endif %} name="{{name1}}" type="radio" value="{{option.value}}"
+            {% if option.value === question.value %} checked {% endif %}>
+          <label class="govuk-label govuk-radios__label" {% if loop.index === 1 %} for={{name1}} {% else %}
+            for="id-{{name1}}-{{loop.index}}" {% endif %}>
+            {{option.label}}
+          </label>
         </div>
+        {% endfor %}
       </div>
-    </fieldset>
-  </div>
+    </div>
+  </fieldset>
+</div>
 {% endmacro %}
 
 {% macro radiosWithNestedRadios(question) %}
+{% if question.primaryQuestion.errorMessage %}
+{% set govukFormGroupErrorOuter  =  'govuk-form-group--error' %}
+{% set primaryErrorMessageText = question.primaryQuestion.errorMessage.text %}
+{% endif %}
 
-  <div class="govuk-form-group">
-    <fieldset class="govuk-fieldset">
-      {# primary #}
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend">
-          {{question.primaryQuestion.text}}
-      </legend>
-      <div class="govuk-!-margin-bottom-6">
-        <div class="{% if question.primaryQuestion.options | length < 3 %} govuk-radios--inline{% endif %}" data-module="govuk-radios">
-          {% set name1 = question.primaryQuestion.name %}
-          {% for option in question.primaryQuestion.options %}
-            <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="id-{{name1}}-{{loop.index}}" name="{{name1}}" type="radio" value="{{option.value}}" 
-              {% if option.value === question.primaryQuestion.value %} checked {% endif %}
-              {% if option.value === true %} data-aria-controls="conditional-{{name1}}" {% endif %}>
-              <label class="govuk-label govuk-radios__label" for='id-{{name1}}-{{loop.index}}'>
-                {{option.label}}
-              </label>
-            </div>
-          {% endfor %}
+{% if not question.primaryQuestion.errorMessage and question.followUpQuestion.errorMessage.text %}
+{% set govukFormGroupErrorInner  =  'govuk-form-group--error' %}
+{% set followUpErrorMessageText = question.followUpQuestion.errorMessage.text %}
+{% endif %}
 
-          {# followup #}
-          {% if question.followUpQuestion %}
-            <div class="govuk-radios__conditional govuk-radios__conditional--hidden clear-both" id="conditional-{{name1}}">
-              <fieldset class="govuk-fieldset">
+
+<div class="govuk-form-group {{govukFormGroupErrorOuter}}">
+  <fieldset class="govuk-fieldset">
+    <!-- primary  -->
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend">
+      {{question.primaryQuestion.text}}
+    </legend>
+    <span class="govuk-error-message">
+      <span class="govuk-visually-hidden">Error:</span>
+      {{ primaryErrorMessageText}}
+    </span>
+    <div class="govuk-!-margin-bottom-6">
+      <div class="{% if question.primaryquestion.options | length < 3 %} govuk-radios--inline{% endif %}"
+        data-module="govuk-radios">
+        {% set name1 = question.primaryQuestion.name %}
+        {% for option in question.primaryQuestion.options %}
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" {% if loop.index === 1 %} id={{name1}} {% else %}
+            id="id-{{name1}}-{{loop.index}}" {% endif %} name="{{name1}}" type="radio" value="{{option.value}}"
+            {% if option.value === question.primaryQuestion.value %} checked {% endif %} {% if option.value === true %}
+            data-aria-controls="conditional-{{name1}}" {% endif %}>
+          <label class="govuk-label govuk-radios__label" {% if loop.index === 1 %} for={{name1}} {% else %}
+            for="id-{{name1}}-{{loop.index}}" {% endif %}>
+            {{option.label}}
+          </label>
+        </div>
+        {% endfor %}
+
+        <!-- followup-->
+        {% if question.followUpQuestion %}
+        <div class="govuk-radios__conditional govuk-radios__conditional--hidden clear-both" id="conditional-{{name1}}">
+          <div class="{{govukFormGroupErrorInner}}">
+            <fieldset class="govuk-fieldset ">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend govuk-!-font-weight-bold">
                     {{question.followUpQuestion.text}}
-                </legend>
+                  </legend>
+    
+                <span class="govuk-error-message">
+                  <span class="govuk-visually-hidden">Error:</span>
+                  {{ followUpErrorMessageText}}
+                </span>
                 {% set name2 = question.followUpQuestion.name %}
                 <div class="{% if question.followUpQuestion.options | length < 3 %} govuk-radios--inline {% endif %}">
                   {% for option in question.followUpQuestion.options %}
-                    <div class="govuk-radios__item">
-                      <input class="govuk-radios__input" id="id-{{name2}}-{{loop.index}}" name="{{name2}}" type="radio" value="{{option.value}}"                       
+                  <div class="govuk-radios__item">
+                    <input class="govuk-radios__input" {% if loop.index === 1 %} id={{name2}} {% else %}
+                      id="id-{{name2}}-{{loop.index}}" {% endif %} name="{{name2}}" type="radio" value="{{option.value}}"
                       {% if option.value === question.followUpQuestion.value %} checked {% endif %}>
-                      <label class="govuk-label govuk-radios__label" for="id-{{name2}}-{{loop.index}}">
-                        {{option.label}}
-                      </label>
-                    </div>
+                    <label class="govuk-label govuk-radios__label" {% if loop.index === 1 %} for={{name2}} {% else %}
+                      for="id-{{name2}}-{{loop.index}}" {% endif %}>
+                      {{option.label}}
+                    </label>
+                  </div>
                   {% endfor %}
                 </div>
-              </fieldset>
-            </div>
-          {% endif %}
-          {# end of followup #}
+            </fieldset>
+          </div>
         </div>
+        {% endif %}
+        <!-- end of followup -->
       </div>
-    </fieldset>
-  </div>
+    </div>
+  </fieldset>
+</div>
 
 {% endmacro %}
 
 {% macro radiosWithNestedCheckboxes(question) %}
+{% if question.primaryQuestion.errorMessage %}
+{% set govukFormGroupErrorOuter  =  'govuk-form-group--error' %}
+{% set primaryErrorMessageText = question.primaryQuestion.errorMessage.text %}
+{% endif %}
 
-  <div class="govuk-form-group">
-    <fieldset class="govuk-fieldset">
-      {# primary #}
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend">
-          {{question.primaryQuestion.text}}
-      </legend>
-      <div class="govuk-!-margin-bottom-6">
-        <div class="govuk-radios--inline" data-module="govuk-radios">
-          {% set name = question.primaryQuestion.name %}
-          {% for option in question.primaryQuestion.options %}
-            <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="id-{{name}}-{{loop.index}}" name="{{name}}" type="radio" value="{{option.value}}" 
-              {% if option.value === true %} data-aria-controls="conditional-{{name}}" {% endif %}
-              {% if option.value === question.primaryQuestion.value %} checked  {% endif %}>
-              <label class="govuk-label govuk-radios__label" for='id-{{name}}-{{loop.index}}'>
-                {{option.label}}
-              </label>
-            </div>
-          {% endfor %}
+{% if not question.primaryQuestion.errorMessage and question.followUpQuestion.errorMessage.text %}
+{% set govukFormGroupErrorInner  =  'govuk-form-group--error' %}
+{% set followUpErrorMessageText = question.followUpQuestion.errorMessage.text %}
+{% endif %}
 
-          {# followup #}
-          <div class="govuk-radios__conditional clear-both" data-module="govuk-checkboxes" id="conditional-{{name}}">
+<div class="govuk-form-group  {{govukFormGroupErrorOuter}}">
+  <fieldset class="govuk-fieldset">
+    <!-- primary -->
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend">
+      {{question.primaryQuestion.text}}
+    </legend>
+    <span class="govuk-error-message">
+      <span class="govuk-visually-hidden">Error:</span>
+      {{ primaryErrorMessageText}}
+    </span>
+    <div class="govuk-!-margin-bottom-6">
+      <div class="govuk-radios--inline" data-module="govuk-radios">
+        {% set name = question.primaryQuestion.name %}
+        {% for option in question.primaryQuestion.options %}
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" {% if loop.index === 1 %} id={{name}} {% else %}
+            id="id-{{name}}-{{loop.index}}" {% endif %} name="{{name}}" type="radio" value="{{option.value}}"
+            {% if option.value === true %} data-aria-controls="conditional-{{name}}" {% endif %}
+            {% if option.value === question.primaryQuestion.value %} checked {% endif %}>
+          <label class="govuk-label govuk-radios__label" {% if loop.index === 1 %} for={{name}} {% else %}
+            for="id-{{name}}-{{loop.index}}" {% endif %}>
+            {{option.label}}
+          </label>
+        </div>
+        {% endfor %}
+
+        <!-- followup -->
+        <div class="govuk-radios__conditional clear-both" data-module="govuk-checkboxes" id="conditional-{{name}}">
+          <div class="{{govukFormGroupErrorInner}}">
             <fieldset class="govuk-fieldset">
               <legend class="govuk-fieldset__legend govuk-fieldset__legend govuk-!-font-weight-bold">
-                  {{question.followUpQuestion.text}}
+                {{question.followUpQuestion.text}}
               </legend>
+                <span class="govuk-error-message">
+                  <span class="govuk-visually-hidden">Error:</span>
+                  {{ followUpErrorMessageText}}
+                </span>
+                {% set name = question.followUpQuestion.name %}
+                {% for option in question.followUpQuestion.options %}
 
-              {% set name = question.followUpQuestion.name %}
-              {% for option in question.followUpQuestion.options %}
-
-                <div class="govuk-checkboxes__item">
-                  <input class="govuk-checkboxes__input "  id="id-{{name}}-{{loop.index}}" name="{{name}}" type="checkbox"  value="{{option.value}}"
-                  {% if option.value in question.followUpQuestion.value %} checked  {% endif %}>
-                  <label class="govuk-label govuk-checkboxes__label" for="id-{{name}}-{{loop.index}}">
+                <div class="govuk-checkboxes__item ">
+                  <input class="govuk-checkboxes__input" {% if loop.index === 1 %} id={{name}} {% else %} id="id-{{name}}-{{loop.index}}" {% endif %} name="{{name}}" type="checkbox" value="{{option.value}}"
+                    {% if option.value in question.followUpQuestion.value %} checked {% endif %}>
+                  <label class="govuk-label govuk-checkboxes__label" {% if loop.index === 1 %} for={{name}} {% else %}
+                    for="id-{{name}}-{{loop.index}}" {% endif %}>
                     {{option.label}}
                   </label>
                 </div>
-              {% endfor %}
+                {% endfor %}
             </fieldset>
           </div>
         </div>
       </div>
-    </fieldset>
-  </div>
+    </div>
+  </fieldset>
+</div>
 
 {% endmacro %}
 
 {% macro radiosWithNestedTextbox(question) %}
 
-  <div class="govuk-form-group">
-    <fieldset class="govuk-fieldset">
-      {# primary #}
-      <legend class="govuk-fieldset__legend govuk-fieldset__legend">
-          {{question.primaryQuestion.text}}
-      </legend>
-        <div class="govuk-radios--inline" data-module="govuk-radios">
-          {% set name = question.primaryQuestion.name %}
-          {% for option in question.primaryQuestion.options %}
-            <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="id-{{name}}-{{loop.index}}" name="{{name}}" type="radio"  value="{{option.value}}" 
-                {% if option.value === true %} data-aria-controls="conditional-{{name}}" {% endif %}
-                {% if option.value === question.primaryQuestion.value %} checked="checked"  {% endif %}
-              >
-              <label class="govuk-label govuk-radios__label" for='id-{{name}}-{{loop.index}}'>
-                {{option.label}}
-              </label>
-            </div>
-          {% endfor %}
-
-          {# followup #}
-          <div class="govuk-radios govuk-radios__conditional clear-both" id="conditional-{{name}}">
-            <fieldset class="govuk-fieldset">
-              <legend class="govuk-fieldset__legend govuk-fieldset__legend {% if question.followUpQuestion.legend==='blank' %} govuk-visually-hidden {% endif %}" >
-                  {{question.followUpQuestion.legend}}
-              </legend>
-
-              {% set followUpQuestion = question.followUpQuestion %}
-                <div class="govuk-textboxes__item">
-                  <label class="govuk-label" for="id-{{followUpQuestion.name}}">
-                    {{followUpQuestion.label}}
-                  </label>
-                  <input class="govuk-input govuk-!-width-one-third" id="id-{{followUpQuestion.name}}" name="{{followUpQuestion.name}}" type="text" value="{{followUpQuestion.value}}" >
-                </div>
-                {% if followUpQuestion.alertMsg %}
-                <div class="govuk-warning-text">
-                  <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                  <p class="govuk-warning-text__text">
-                    <span class="govuk-warning-text__assistive">Warning</span>
-                      {{followUpQuestion.alertMsg}}
-                  </p>
-                </div>
-                {% endif %}
-            </fieldset>
-          </div>
+<div class="govuk-form-group">
+  <fieldset class="govuk-fieldset">
+    <!-- primary -->
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend">
+      {{question.primaryQuestion.text}}
+    </legend>
+    <div class="govuk-radios--inline" data-module="govuk-radios">
+      {% set name = question.primaryQuestion.name %}
+      {% for option in question.primaryQuestion.options %}
+      <div class="govuk-radios__item">
+        <input class="govuk-radios__input" id="id-{{name}}-{{loop.index}}" name="{{name}}" type="radio"
+          value="{{option.value}}" {% if option.value === true %} data-aria-controls="conditional-{{name}}" {% endif %}
+          {% if option.value === question.PrimaryQuestion.value %} checked="checked" {% endif %}>
+        <label class="govuk-label govuk-radios__label" for='id-{{name}}-{{loop.index}}'>
+          {{option.label}}
+        </label>
       </div>
-    </fieldset>
-  </div>
+      {% endfor %}
+
+      <!-- followup -->
+      <div class="govuk-radios govuk-radios__conditional clear-both" id="conditional-{{name}}">
+        <fieldset class="govuk-fieldset">
+          <legend
+            class="govuk-fieldset__legend govuk-fieldset__legend {% if question.followUpQuestion.legend==='blank' %} govuk-visually-hidden {% endif %}">
+            {{question.followUpQuestion.legend}}
+          </legend>
+
+          {% set followUpQuestion = question.followUpQuestion %}
+          <div class="govuk-textboxes__item">
+            <label class="govuk-label" for="id-{{followUpQuestion.name}}">
+              {{followUpQuestion.label}}
+            </label>
+            <input class="govuk-input govuk-!-width-one-third" id="id-{{followUpQuestion.name}}"
+              name="{{followUpQuestion.name}}" type="text" value="{{followUpQuestion.value}}">
+          </div>
+          {% if followUpQuestion.alertMsg %}
+          <div class="govuk-warning-text">
+            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+            <p class="govuk-warning-text__text">
+              <span class="govuk-warning-text__assistive">Warning</span>
+              {{followUpQuestion.alertMsg}}
+            </p>
+          </div>
+          {% endif %}
+        </fieldset>
+      </div>
+    </div>
+  </fieldset>
+</div>
 
 {% endmacro %}
-
-


### PR DESCRIPTION
http://localhost:3000/form/incident/details/-1

The Details page didn't previously validate user inputs. Have now ensured validation massages are presented should a user fail to either make a selection of radio/checkbox or fail to input details in text boxes.
User is unable to proceed to another page if validation rules are not met.
New unit tests created and have also made minor changes to the validation messages in the Evidence page.
Minor changes to HTML in incidentMacros.njk to make W3C compliant