### PR TITLE
DCS-100 Adding a report status checker

### DIFF
--- a/server/config/incidentDetailsValidation.test.js
+++ b/server/config/incidentDetailsValidation.test.js
@@ -48,10 +48,6 @@ describe('Incident details page - overall', () => {
         href: '#plannedUseOfForce',
         text: 'Select yes if the use of force was planned',
       },
-      {
-        href: '#involvedStaff[0][username]',
-        text: 'Enter the name of the staff member involved in the use of force incident',
-      },
     ])
 
     expect(formResponse).toEqual({})
@@ -101,19 +97,42 @@ describe('Planned use of force', () => {
 
 describe('Involved staff', () => {
   it('None present', () => {
-    const input = { ...validInput, involvedStaff: [{ username: '' }] }
+    const input = { ...validInput, involvedStaff: [] }
     const { errors, formResponse } = check(input)
 
-    expect(errors).toEqual([
-      {
-        href: '#involvedStaff[0][username]',
-        text: 'Enter the name of the staff member involved in the use of force incident',
-      },
-    ])
+    expect(errors).toEqual([])
 
     expect(formResponse).toEqual({
       locationId: -1,
       plannedUseOfForce: true,
+      witnesses: [{ name: 'User bob' }],
+    })
+  })
+
+  it('Invalid keys are stripped out', () => {
+    const input = { ...validInput, involvedStaff: [{ username: 'bob', age: 21 }] }
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([])
+
+    expect(formResponse).toEqual({
+      locationId: -1,
+      plannedUseOfForce: true,
+      involvedStaff: [{ username: 'bob' }],
+      witnesses: [{ name: 'User bob' }],
+    })
+  })
+
+  it('Usernames are trimmed', () => {
+    const input = { ...validInput, involvedStaff: [{ username: '  bob    ' }] }
+    const { errors, formResponse } = check(input)
+
+    expect(errors).toEqual([])
+
+    expect(formResponse).toEqual({
+      locationId: -1,
+      plannedUseOfForce: true,
+      involvedStaff: [{ username: 'bob' }],
       witnesses: [{ name: 'User bob' }],
     })
   })

--- a/server/services/reportStatusChecker.js
+++ b/server/services/reportStatusChecker.js
@@ -1,0 +1,24 @@
+const config = require('../config/incident')
+
+const SectionStatus = Object.freeze({
+  NOT_STARTED: 'not_started',
+  INCOMPLETE: 'incomplete',
+  COMPLETE: 'complete',
+})
+
+const getStatus = (fieldConfig, sectionValues) => {
+  if (!sectionValues) {
+    return SectionStatus.NOT_STARTED
+  }
+
+  return fieldConfig.isComplete(sectionValues) ? SectionStatus.COMPLETE : SectionStatus.INCOMPLETE
+}
+
+module.exports = {
+  SectionStatus,
+  check: report => {
+    return Object.keys(config).reduce((previous, key) => {
+      return { ...previous, [key]: getStatus(config[key], report[key]) }
+    }, {})
+  },
+}

--- a/server/services/reportStatusChecker.test.js
+++ b/server/services/reportStatusChecker.test.js
@@ -1,0 +1,126 @@
+const { SectionStatus, check } = require('./reportStatusChecker')
+
+describe('statusCheck', () => {
+  const validReport = {
+    details: {
+      pavaDrawn: false,
+      restraint: false,
+      batonDrawn: false,
+      guidingHold: false,
+      handcuffsApplied: false,
+      positiveCommunication: false,
+      personalProtectionTechniques: true,
+    },
+    evidence: {
+      cctvRecording: 'NO',
+      baggedEvidence: true,
+      bodyWornCamera: 'YES',
+      photographsTaken: false,
+      bodyWornCameraNumbers: [{ cameraNum: '1111' }, { cameraNum: '2222' }],
+      evidenceTagAndDescription: [
+        { description: 'aaaaa', evidenceTagReference: '1111' },
+        { description: 'bbbb', evidenceTagReference: '2222' },
+      ],
+    },
+    incidentDetails: {
+      witnesses: [{ name: 'BOB BARRY' }, { name: 'JAMES JOHN' }],
+      locationId: -25,
+      involvedStaff: [
+        { name: 'Itag User', email: 'itag_user@digital.justice.gov.uk', staffId: 1, username: 'ITAG_USER' },
+        { name: 'Licence Case Admin', email: 'ca_user@digital.justice.gov.uk', staffId: 3, username: 'CA_USER' },
+      ],
+      plannedUseOfForce: true,
+    },
+    relocationAndInjuries: {
+      f213CompletedBy: 'Dr Bob ',
+      prisonerInjuries: false,
+      healthcareInvolved: true,
+      prisonerRelocation: 'OWN_CELL',
+      relocationCompliancy: false,
+      staffMedicalAttention: true,
+      prisonerHospitalisation: true,
+      healthcarePractionerName: 'Dr Jenny',
+      staffNeedingMedicalAttention: [{ name: 'Frank James', hospitalisation: false }],
+    },
+  }
+
+  test('empty report', async () => {
+    const output = check({})
+
+    expect(output).toEqual({
+      incidentDetails: SectionStatus.NOT_STARTED,
+      details: SectionStatus.NOT_STARTED,
+      relocationAndInjuries: SectionStatus.NOT_STARTED,
+      evidence: SectionStatus.NOT_STARTED,
+    })
+  })
+
+  test('report with unvisited sections', async () => {
+    const { evidence, relocationAndInjuries, ...partiallyCompleteReport } = validReport
+
+    const output = check(partiallyCompleteReport)
+
+    expect(output).toEqual({
+      incidentDetails: SectionStatus.COMPLETE,
+      details: SectionStatus.COMPLETE,
+      relocationAndInjuries: SectionStatus.NOT_STARTED,
+      evidence: SectionStatus.NOT_STARTED,
+    })
+  })
+
+  test('valid report', async () => {
+    const output = check(validReport)
+
+    expect(output).toEqual({
+      incidentDetails: SectionStatus.COMPLETE,
+      details: SectionStatus.COMPLETE,
+      relocationAndInjuries: SectionStatus.COMPLETE,
+      evidence: SectionStatus.COMPLETE,
+    })
+  })
+
+  test('invalid report', async () => {
+    const invalidReport = {
+      ...validReport,
+      details: {
+        pavaDrawn: false,
+        restraint: false,
+        batonDrawn: null,
+        guidingHold: false,
+        handcuffsApplied: null,
+        positiveCommunication: false,
+        personalProtectionTechniques: undefined,
+      },
+    }
+
+    const output = check(invalidReport)
+
+    expect(output).toEqual({
+      incidentDetails: SectionStatus.COMPLETE,
+      details: SectionStatus.INCOMPLETE,
+      relocationAndInjuries: SectionStatus.COMPLETE,
+      evidence: SectionStatus.COMPLETE,
+    })
+  })
+
+  test('invalid incident details', async () => {
+    const invalidReport = {
+      ...validReport,
+      incidentDetails: {
+        witnesses: [{ name: 'BOB BARRY' }, { name: 'JAMES JOHN' }],
+        locationId: -25,
+        involvedStaff: [{ username: 'ITAG_USER' }, { username: 'CA_USER' }],
+        plannedUseOfForce: true,
+      },
+    }
+
+    const output = check(invalidReport)
+
+    expect(output).toEqual({
+      incidentDetails: SectionStatus.INCOMPLETE,
+      details: SectionStatus.COMPLETE,
+      relocationAndInjuries: SectionStatus.COMPLETE,
+      evidence: SectionStatus.COMPLETE,
+    })
+  })
+})

--- a/server/utils/fieldValidation.js
+++ b/server/utils/fieldValidation.js
@@ -139,17 +139,32 @@ const fieldOptions = {
         .required(),
     }),
 
-  requiredInvolvedStaff: joi
-    .array()
-    .min(1)
-    .items(
-      joi.object().keys({
-        username: joi
-          .string()
-          .trim()
-          .required(),
-      })
-    ),
+  optionalInvolvedStaff: joi.array().items(
+    joi.object().keys({
+      username: joi
+        .string()
+        .trim()
+        .required(),
+    })
+  ),
+
+  optionalInvolvedStaffWhenPersisted: joi.array().items(
+    joi.object().keys({
+      username: joi
+        .string()
+        .trim()
+        .required(),
+      name: joi
+        .string()
+        .trim()
+        .required(),
+      email: joi
+        .string()
+        .trim()
+        .required(),
+      staffId: joi.number().required(),
+    })
+  ),
 
   requiredStaffNeedingMedicalAttention: () =>
     joi.when('staffMedicalAttention', {
@@ -212,6 +227,12 @@ module.exports = {
     })
 
     return errors
+  },
+
+  isValid(schemaName, fieldValue) {
+    const joiFieldItem = fieldOptions[schemaName]
+    const joiErrors = joi.validate(fieldValue, joiFieldItem, { stripUnknown: false, abortEarly: false })
+    return isNilOrEmpty(joiErrors.error)
   },
 }
 

--- a/server/utils/fieldValidation.test.js
+++ b/server/utils/fieldValidation.test.js
@@ -1,0 +1,15 @@
+const { isValid } = require('./fieldValidation')
+
+describe('isValid', () => {
+  test('Check valid ', () => {
+    expect(isValid('optionalInvolvedStaff', [{ username: 'Bob' }])).toEqual(true)
+    expect(isValid('optionalInvolvedStaff', [])).toEqual(true)
+  })
+
+  test('invalid', () => {
+    expect(isValid('optionalInvolvedStaff', [{ username: 'Bob', age: 29 }])).toEqual(false)
+    expect(isValid('optionalInvolvedStaff', true)).toEqual(false)
+    expect(isValid('optionalInvolvedStaff', [{ username: '' }])).toEqual(false)
+    expect(isValid('optionalInvolvedStaff', [{ bob: 'Bob' }])).toEqual(false)
+  })
+})

--- a/server/views/formPages/incident/incidentDetails.html
+++ b/server/views/formPages/incident/incidentDetails.html
@@ -76,7 +76,7 @@
   <hr />
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <h3>Staff involved in use of force</h3>
+      <h3>Other staff involved in use of force</h3>
       <div class="add-another-staff-member">
         {% for staffMember in data.involvedStaff %} {% call govukFieldset({ classes: 'add-another__item' }) %}
         {{


### PR DESCRIPTION
This checks that each section of a report is complete and reports back either:
COMPLETE, INCOMPLETE or NOT_STARTED

This will then be used to determine whether to show the 'check your answers' page
and also to ensure that we can do a checkState when submiting a report.

Also making involved staff optional as this now refers to staff other than the
reporting officer. (If the use of force only involved the reporter than no other staff
would be entered)

Also adding a bit of an extra check to ensure that users cannot add involved staff
details through nefarious means.