### PR TITLE
DCS-78 - Users additional comments being persisted to db

### DIFF
--- a/integration-tests/integration/createIncident/save-additional-comment.spec.js
+++ b/integration-tests/integration/createIncident/save-additional-comment.spec.js
@@ -1,0 +1,68 @@
+const TasklistPage = require('../../pages/tasklistPage')
+const SubmittedPage = require('../../pages/submittedPage')
+const ViewStatementPage = require('../../pages/viewStatementPage')
+const IncidentsPage = require('../../pages/incidentsPage')
+
+context('Add comments to statement', () => {
+  const bookingId = 1001
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubLogin')
+    cy.task('stubOffenderDetails', bookingId)
+    cy.task('stubLocations', 'MDI')
+    cy.task('stubOffenders')
+    cy.task('stubLocation', '357591')
+    cy.task('stubUserDetailsRetrieval', 'Mr Zagato')
+    cy.task('stubUserDetailsRetrieval', 'Mrs Jones')
+    cy.task('stubUserDetailsRetrieval', 'Test User')
+  })
+
+  it('A user can select a specific statement, add to it and then return back to statements page', () => {
+    cy.login(bookingId)
+
+    const tasklistPage = TasklistPage.visit(bookingId)
+    tasklistPage.checkNoPartsComplete()
+
+    const newIncidentPage = tasklistPage.startNewForm()
+    newIncidentPage.fillForm()
+
+    const detailsPage = newIncidentPage.save()
+    detailsPage.fillForm()
+
+    const relocationAndInjuriesPage = detailsPage.save()
+    relocationAndInjuriesPage.fillForm()
+
+    const evidencePage = relocationAndInjuriesPage.save()
+    evidencePage.fillForm()
+
+    const checkAnswersPage = evidencePage.save()
+    checkAnswersPage.clickSubmit()
+
+    const submittedPage = SubmittedPage.verifyOnPage()
+
+    const submitStatementPage = submittedPage.continueToStatement()
+    submitStatementPage.lastTrainingMonth().select('March')
+    submitStatementPage.lastTrainingYear().type('2010')
+    submitStatementPage.jobStartYear().type('1999')
+    submitStatementPage.statement().type('This is my statement')
+
+    const confirmStatementPage = submitStatementPage.submit()
+    const statementSubmittedPage = confirmStatementPage.submit()
+    const incidentsPage = statementSubmittedPage.finish()
+    const { viewButton } = incidentsPage.getCompleteRow(0)
+    viewButton().click()
+
+    const pageComponent = ViewStatementPage.verifyOnPage()
+
+    pageComponent.additionalComment().type('Some new comment 1')
+    pageComponent.save().click()
+    pageComponent.viewAdditionalComment(1).should('contain', 'Some new comment 1')
+    pageComponent.additionalComment().should('be.empty')
+    pageComponent.additionalComment(2).type('Some new comment 2')
+    pageComponent.save().click()
+    pageComponent.viewAdditionalComment(2).should('contain', 'Some new comment 2')
+    pageComponent.additionalComment().should('be.empty')
+    pageComponent.cancel().click()
+    IncidentsPage.verifyOnPage()
+  })
+})

--- a/integration-tests/pages/viewStatementPage.js
+++ b/integration-tests/pages/viewStatementPage.js
@@ -6,7 +6,10 @@ const viewStatementPage = () =>
     statement: () => cy.get('[data-qa=statement]'),
     lastTraining: () => cy.get('[data-qa=last-training]'),
     jobStartYear: () => cy.get('[data-qa=job-start-year]'),
+    additionalComment: () => cy.get('[data-qa="additionalComment"]'),
+    viewAdditionalComment: index => cy.get(`[data-qa="viewAdditionalComment"][data-loop=${index}]`),
 
+    save: () => cy.get('[data-qa="save-and-continue"]'),
     cancel: () => cy.get('[data-qa=cancel]'),
   })
 

--- a/server/data/incidentClient.js
+++ b/server/data/incidentClient.js
@@ -88,6 +88,14 @@ const getAdditionalComments = async statementId => {
   return results.rows
 }
 
+const saveAdditionalComment = (statementId, additionalComment) => {
+  return db.query({
+    text: `insert into statement_amendments (statement_id, additional_comment)
+            values ($1, $2)`,
+    values: [statementId, additionalComment],
+  })
+}
+
 const saveStatement = (
   userId,
   reportId,
@@ -165,4 +173,5 @@ module.exports = {
   saveStatement,
   submitStatement,
   getAdditionalComments,
+  saveAdditionalComment,
 }

--- a/server/data/incidentClient.test.js
+++ b/server/data/incidentClient.test.js
@@ -125,6 +125,15 @@ test('getAdditionalComments', () => {
   })
 })
 
+test('saveAdditionalComment', () => {
+  incidentClient.saveAdditionalComment(50, 'Another comment made')
+  expect(db.query).toBeCalledWith({
+    text: `insert into statement_amendments (statement_id, additional_comment)
+            values ($1, $2)`,
+    values: [50, 'Another comment made'],
+  })
+})
+
 test('getInvolvedStaff', async () => {
   const expected = [
     {

--- a/server/routes/incidents.js
+++ b/server/routes/incidents.js
@@ -129,19 +129,24 @@ module.exports = function CreateReportRoutes({ statementService, offenderService
 
     viewYourStatement: async (req, res) => {
       const { reportId } = req.params
-
       const statement = await statementService.getStatement(req.user.username, reportId, StatementStatus.SUBMITTED)
-      const offenderDetail = await offenderService.getOffenderDetails(res.locals.user.token, statement.bookingId)
-      const { displayName, offenderNo } = offenderDetail
-      res.render('pages/statement/your-statement', {
-        data: {
-          reportId,
-          displayName,
-          offenderNo,
-          ...statement,
-          lastTrainingMonth: moment.months(statement.lastTrainingMonth),
-        },
-      })
+
+      if (req.body.submit && req.body.additionalContent.trim().length) {
+        await statementService.saveAdditionalComment(statement.id, req.body.additionalContent)
+        res.redirect(`/${reportId}/your-statement`)
+      } else {
+        const offenderDetail = await offenderService.getOffenderDetails(res.locals.user.token, statement.bookingId)
+        const { displayName, offenderNo } = offenderDetail
+        res.render('pages/statement/your-statement', {
+          data: {
+            reportId,
+            displayName,
+            offenderNo,
+            ...statement,
+            lastTrainingMonth: moment.months(statement.lastTrainingMonth),
+          },
+        })
+      }
     },
   }
 }

--- a/server/routes/incidents.js
+++ b/server/routes/incidents.js
@@ -131,22 +131,26 @@ module.exports = function CreateReportRoutes({ statementService, offenderService
       const { reportId } = req.params
       const statement = await statementService.getStatement(req.user.username, reportId, StatementStatus.SUBMITTED)
 
-      if (req.body.submit && req.body.additionalContent.trim().length) {
-        await statementService.saveAdditionalComment(statement.id, req.body.additionalContent)
-        res.redirect(`/${reportId}/your-statement`)
-      } else {
-        const offenderDetail = await offenderService.getOffenderDetails(res.locals.user.token, statement.bookingId)
-        const { displayName, offenderNo } = offenderDetail
-        res.render('pages/statement/your-statement', {
-          data: {
-            reportId,
-            displayName,
-            offenderNo,
-            ...statement,
-            lastTrainingMonth: moment.months(statement.lastTrainingMonth),
-          },
-        })
+      const offenderDetail = await offenderService.getOffenderDetails(res.locals.user.token, statement.bookingId)
+      const { displayName, offenderNo } = offenderDetail
+      res.render('pages/statement/your-statement', {
+        data: {
+          reportId,
+          displayName,
+          offenderNo,
+          ...statement,
+          lastTrainingMonth: moment.months(statement.lastTrainingMonth),
+        },
+      })
+    },
+
+    saveAdditionalComment: async (req, res) => {
+      const { reportId } = req.params
+      const statement = await statementService.getStatement(req.user.username, reportId, StatementStatus.SUBMITTED)
+      if (req.body.additionalComment && req.body.additionalComment.trim().length) {
+        await statementService.saveAdditionalComment(statement.id, req.body.additionalComment)
       }
+      return res.redirect(`/${reportId}/your-statement`)
     },
   }
 }

--- a/server/routes/incidents.test.js
+++ b/server/routes/incidents.test.js
@@ -9,6 +9,7 @@ const statementService = {
   submitStatement: jest.fn(),
   save: jest.fn(),
   validateSavedStatement: jest.fn(),
+  saveAdditionalComment: jest.fn(),
 }
 
 const offenderService = {
@@ -95,5 +96,28 @@ describe('GET /:reportId/statement-submitted', () => {
       .expect('Content-Type', /html/)
       .expect(res => {
         expect(res.text).toContain('Your statement has been submitted')
+      }))
+})
+
+describe('GET /:reportId/your-statement', () => {
+  it('should render page', () =>
+    request(app)
+      .get('/-1/your-statement')
+      .expect(200)
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain('Your use of force statement')
+      }))
+})
+
+describe('POST /:reportId/your-statement', () => {
+  it('should save ammendment', () =>
+    request(app)
+      .post('/-1/your-statement')
+      .send('additionalContent=statement1&submit=true')
+      .expect(302)
+      .expect('Location', '/-1/your-statement')
+      .expect(res => {
+        expect(statementService.saveAdditionalComment).toBeCalledWith(1, 'statement1')
       }))
 })

--- a/server/routes/incidents.test.js
+++ b/server/routes/incidents.test.js
@@ -114,10 +114,10 @@ describe('POST /:reportId/your-statement', () => {
   it('should save ammendment', () =>
     request(app)
       .post('/-1/your-statement')
-      .send('additionalContent=statement1&submit=true')
+      .send('additionalComment=statement1&submit=true')
       .expect(302)
       .expect('Location', '/-1/your-statement')
-      .expect(res => {
+      .expect(() => {
         expect(statementService.saveAdditionalComment).toBeCalledWith(1, 'statement1')
       }))
 })

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -67,6 +67,7 @@ module.exports = function Index({
   post('/:reportId/check-your-statement', incidents.submitCheckYourStatement)
   get('/:reportId/statement-submitted', incidents.viewStatementSubmitted)
   get('/:reportId/your-statement', incidents.viewYourStatement)
+  post('/:reportId/your-statement', incidents.viewYourStatement)
 
   return router
 }

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -67,7 +67,7 @@ module.exports = function Index({
   post('/:reportId/check-your-statement', incidents.submitCheckYourStatement)
   get('/:reportId/statement-submitted', incidents.viewStatementSubmitted)
   get('/:reportId/your-statement', incidents.viewYourStatement)
-  post('/:reportId/your-statement', incidents.viewYourStatement)
+  post('/:reportId/your-statement', incidents.saveAdditionalComment)
 
   return router
 }

--- a/server/services/statementService.js
+++ b/server/services/statementService.js
@@ -34,11 +34,17 @@ module.exports = function createReportService({ incidentClient }) {
     return incidentClient.submitStatement(userId, reportId)
   }
 
+  const saveAdditionalComment = (statementId, additionalComment) => {
+    logger.info(`Saving additional comment for statement with id: ${statementId}`)
+    return incidentClient.saveAdditionalComment(statementId, additionalComment)
+  }
+
   return {
     getStatement,
     getStatementsForUser,
     save,
     submitStatement,
     validateSavedStatement,
+    saveAdditionalComment,
   }
 }

--- a/server/services/statementService.test.js
+++ b/server/services/statementService.test.js
@@ -8,6 +8,7 @@ const incidentClient = {
   saveStatement: jest.fn(),
   submitStatement: jest.fn(),
   getAdditionalComments: jest.fn(),
+  saveAdditionalComment: jest.fn(),
 }
 
 let service
@@ -16,10 +17,18 @@ beforeEach(() => {
   service = serviceCreator({ incidentClient })
   incidentClient.getCurrentDraft.mockReturnValue({ a: 'b' })
   incidentClient.getStatementsForUser.mockReturnValue({ rows: [{ id: 1 }, { id: 2 }] })
+  incidentClient.saveAdditionalComment(50, 'Some new comment')
 })
 
 afterEach(() => {
   jest.resetAllMocks()
+})
+
+describe('saveAdditionalComment', () => {
+  test('save a new comment', async () => {
+    await service.saveAdditionalComment(50, 'Some new comment')
+    expect(incidentClient.saveAdditionalComment).toBeCalledWith(50, 'Some new comment')
+  })
 })
 
 describe('getStatementsForUser', () => {

--- a/server/views/pages/incidents.html
+++ b/server/views/pages/incidents.html
@@ -67,6 +67,7 @@
               role="button"
               draggable="false"
               class="govuk-button govuk-button--secondary"
+              data-qa="view-amend"
             >
             View and amend
             </a>

--- a/server/views/pages/statement/your-statement.html
+++ b/server/views/pages/statement/your-statement.html
@@ -71,7 +71,12 @@ govukCheckboxes %} {% from "govuk/components/error-summary/macro.njk" import gov
         </p>
       </div>
     </div>
-  {{comment.additionalComment}}<hr/>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <p class="govuk-!-margin-bottom-1 govuk-!-margin-top-0 govuk-label--xs statement" data-qa="statement">{{comment.additionalComment}}</p>
+      </div>
+    </div>
+  <hr/>
   {% endfor %}
 
   <form method="POST">
@@ -80,8 +85,8 @@ govukCheckboxes %} {% from "govuk/components/error-summary/macro.njk" import gov
       <div class="govuk-grid-column-two-thirds">
         {{
           govukTextarea({
-            id: 'additionalContent',
-            name: 'additionalContent',
+            id: 'additionalComment',
+            name: 'additionalComment',
             rows: 15,
             cols: 200,
             label: {

--- a/server/views/pages/statement/your-statement.html
+++ b/server/views/pages/statement/your-statement.html
@@ -73,7 +73,7 @@ govukCheckboxes %} {% from "govuk/components/error-summary/macro.njk" import gov
     </div>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
-        <p class="govuk-!-margin-bottom-1 govuk-!-margin-top-0 govuk-label--xs statement" data-qa="statement">{{comment.additionalComment}}</p>
+        <p class="govuk-!-margin-bottom-1 govuk-!-margin-top-0 govuk-label--xs statement" data-loop={{loop.index}} data-qa="viewAdditionalComment">{{comment.additionalComment}}</p>
       </div>
     </div>
   <hr/>
@@ -89,6 +89,7 @@ govukCheckboxes %} {% from "govuk/components/error-summary/macro.njk" import gov
             name: 'additionalComment',
             rows: 15,
             cols: 200,
+            attributes: { 'data-qa': 'additionalComment' },
             label: {
               text: 'Additional comments',
               classes: 'govuk-label--m govuk-!-margin-top-4'


### PR DESCRIPTION
New functionality to take user's inputs in UI and persist to db.

User can navigate to the incident statement by clicking the View and Amend button on http://localhost:3000/

User can then input any additional details in the text box. Clicking the Save additional comments button persists new entry to db and redirects user back to the same screen. 

The additional comments are linked to the original statement via the statement.id value

Testing not yet included