### PR TITLE
DCS-113 Fixing submit location from evidence page

### DIFF
--- a/server/routes/checkYourAnswers.js
+++ b/server/routes/checkYourAnswers.js
@@ -162,11 +162,7 @@ module.exports = function CheckAnswerRoutes({ reportService, offenderService, in
     submit: async (req, res) => {
       const { bookingId } = req.params
 
-      const { form_response: formData = {} } = await reportService.getCurrentDraft(req.user.username, bookingId)
-
-      const { complete } = reportService.getReportStatus(formData)
-
-      if (!complete) {
+      if (!reportService.isDraftComplete(req.user.username, bookingId)) {
         throw new Error('Report is not complete')
       }
 

--- a/server/routes/checkYourAnswers.test.js
+++ b/server/routes/checkYourAnswers.test.js
@@ -5,8 +5,9 @@ const { authenticationMiddleware } = require('./testutils/mockAuthentication')
 
 const reportService = {
   getCurrentDraft: jest.fn(),
-  getReportStatus: jest.fn(),
+  isDraftComplete: jest.fn(),
   submit: jest.fn(),
+  getReportStatus: jest.fn(),
 }
 
 const offenderService = {
@@ -51,7 +52,7 @@ describe('GET /check-your-answers', () => {
 
 describe('POST /check-your-answers', () => {
   it('Allow submit if report is complete', async () => {
-    reportService.getReportStatus.mockReturnValue({ complete: true })
+    reportService.isDraftComplete.mockReturnValue(true)
     reportService.submit.mockReturnValue(2)
 
     await request(app)
@@ -62,7 +63,7 @@ describe('POST /check-your-answers', () => {
   })
 
   it('An error is throw if the report is not complete', async () => {
-    reportService.getReportStatus.mockReturnValue({ complete: false })
+    reportService.isDraftComplete.mockReturnValue(false)
 
     await request(app)
       .post('/report/-35/check-your-answers')

--- a/server/services/reportService.js
+++ b/server/services/reportService.js
@@ -41,8 +41,15 @@ module.exports = function createReportService({ incidentClient, elite2ClientBuil
     return id
   }
 
+  async function isDraftComplete(username, bookingId) {
+    const { form_response: formData = {} } = await getCurrentDraft(username, bookingId)
+    const { complete } = getReportStatus(formData)
+    return complete
+  }
+
   return {
     getCurrentDraft,
+    isDraftComplete,
     update,
     submit,
     getReportStatus,

--- a/server/utils/utils.js
+++ b/server/utils/utils.js
@@ -1,24 +1,19 @@
 const R = require('ramda')
-const moment = require('moment')
 
-const isNilOrEmpty = item => {
-  return R.isEmpty(item) || R.isNil(item)
-}
+const isNilOrEmpty = item => R.isEmpty(item) || R.isNil(item)
 
-const getFieldDetail = (fieldPath, fieldConfig) => {
-  return R.pipe(
+const getFieldDetail = (fieldPath, fieldConfig) =>
+  R.pipe(
     R.values,
     R.head,
     R.path(fieldPath)
   )(fieldConfig)
-}
 
-const getFieldName = fieldConfig => {
-  return R.pipe(
+const getFieldName = fieldConfig =>
+  R.pipe(
     R.keys,
     R.head
   )(fieldConfig)
-}
 
 const properCase = word =>
   typeof word === 'string' && word.length >= 1 ? word[0].toUpperCase() + word.toLowerCase().slice(1) : word
@@ -48,12 +43,7 @@ const properCaseFullName = name =>
         .map(properCaseName)
         .join(' ')
 
-const formatDate = val => (isBlank(val) ? '' : moment(val, 'YYYY-MM-DD').format('DD/MM/YYYY'))
-const formatTimestampToDateTime = val => moment(val).format('DD/MM/YYYY - HH:mm')
-
 module.exports = {
-  formatDate,
-  formatTimestampToDateTime,
   isNilOrEmpty,
   getFieldDetail,
   getFieldName,
@@ -63,6 +53,5 @@ module.exports = {
   equals: R.equals,
   firstItem: R.head,
   mergeWithRight: R.mergeDeepRight,
-  pickBy: R.pickBy,
   isBlank,
 }

--- a/server/utils/utils.test.js
+++ b/server/utils/utils.test.js
@@ -1,4 +1,4 @@
-const { properCaseName, properCaseFullName, formatDate } = require('./utils')
+const { properCaseName, properCaseFullName } = require('./utils')
 
 describe('properCaseName', () => {
   it('null string', () => {
@@ -44,14 +44,5 @@ describe('properCaseFullName', () => {
     expect(properCaseFullName('JAMES robert MONTGOMERY-FOSTER-SMYTH-WALLACE-BOB')).toEqual(
       'James Robert Montgomery-Foster-Smyth-Wallace-Bob'
     )
-  })
-})
-
-describe('formatDate', () => {
-  it('null string', () => {
-    expect(formatDate(null)).toEqual('')
-  })
-  it('correct date', () => {
-    expect(formatDate('2010-12-30')).toEqual('30/12/2010')
   })
 })

--- a/server/views/formPages/incident/incidentDetails.html
+++ b/server/views/formPages/incident/incidentDetails.html
@@ -77,6 +77,9 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h3>Other staff involved in use of force</h3>
+      <span class="govuk-hint">
+        You do not have to add yourself
+      </span>
       <div class="add-another-staff-member">
 
         {% macro addStaffMember(index, value, showRemove) %}


### PR DESCRIPTION
This would previously go to check-your-answers but now we are restricting the
check your answers page if the whole form is not valid.

Now, if the form is not complete, then submitting from the evidence page will
redirect the user back to the main task list page.

Also adding missing hint text for involved staff