### PR TITLE
DCS-93 Adding polling of a reminder queue

### DIFF
--- a/job/reminders/reminderPoller.js
+++ b/job/reminders/reminderPoller.js
@@ -1,0 +1,28 @@
+/* eslint-disable no-await-in-loop */
+const logger = require('../../log')
+
+module.exports = (db, incidentClient, sendReminder) => {
+  const processReminder = async () => {
+    const reminder = await incidentClient.getNextNotificationReminder()
+    if (reminder) {
+      sendReminder(reminder)
+    }
+    return reminder
+  }
+
+  return async () => {
+    logger.info(`Starting to send reminders`)
+
+    let result = true
+    let count = 0
+
+    while (result && count < 100) {
+      result = await db.inTransaction(processReminder)
+      count += result ? 1 : 0
+    }
+
+    logger.info(`Sent ${count} reminders`)
+
+    return count
+  }
+}

--- a/job/reminders/reminderPoller.test.js
+++ b/job/reminders/reminderPoller.test.js
@@ -1,0 +1,38 @@
+const reminderPoller = require('./reminderPoller')
+
+const sendReminder = jest.fn()
+
+const db = {
+  inTransaction: async callback => {
+    const result = await callback()
+    return result
+  },
+}
+
+const incidentClient = {
+  getNextNotificationReminder: jest.fn(),
+}
+
+const poll = reminderPoller(db, incidentClient, sendReminder)
+
+describe('poll for reminders', () => {
+  test('no reminders', async () => {
+    const count = await poll()
+
+    expect(count).toEqual(0)
+  })
+  test('successfully poll one reminder', async () => {
+    incidentClient.getNextNotificationReminder.mockResolvedValueOnce({ reminder: 1 })
+
+    const count = await poll()
+
+    expect(count).toEqual(1)
+  })
+  test('infinite reminders - only process 100 reminders in one go', async () => {
+    incidentClient.getNextNotificationReminder.mockResolvedValue({ reminder: 1 })
+
+    const count = await poll()
+
+    expect(count).toEqual(100)
+  })
+})

--- a/job/reminders/reminderSender.js
+++ b/job/reminders/reminderSender.js
@@ -1,0 +1,6 @@
+const logger = require('../../log')
+
+// TODO['DCS-93'] complete processor
+module.exports = () => reminder => {
+  logger.info('processing reminder', reminder)
+}

--- a/job/sendReminders.js
+++ b/job/sendReminders.js
@@ -1,6 +1,10 @@
-const moment = require('moment')
-const logger = require('../log')
+const incidentClient = require('../server/data/incidentClient')
+const db = require('../server/data/dataAccess/db')
 
-logger.info(`send reminders job fired at: ${moment()}`)
+const reminderPoller = require('./reminders/reminderPoller')
+const reminderSender = require('./reminders/reminderSender')
 
-new Promise(done => setTimeout(done, 60 * 1000)).then(() => logger.info(`send reminders job ended at: ${moment()}`))
+const sendReminder = reminderSender()
+const poll = reminderPoller(db, incidentClient, sendReminder)
+
+poll()

--- a/migrations/20190903000000_form_db.js
+++ b/migrations/20190903000000_form_db.js
@@ -1,0 +1,9 @@
+exports.up = knex =>
+  knex.schema.table('statement', table => {
+    table.timestamp('next_reminder_date')
+  })
+
+exports.down = knex =>
+  knex.schema.table('statement', table => {
+    table.dropColumn('next_reminder_date')
+  })

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
       "server/**/*.{js,jsx,mjs}"
     ],
     "testMatch": [
-      "<rootDir>/(server)/**/?(*.)(spec|test).{js,jsx,mjs}"
+      "<rootDir>/(server|job)/**/?(*.)(spec|test).{js,jsx,mjs}"
     ],
     "testEnvironment": "node",
     "reporters": [

--- a/server/data/dataAccess/db.js
+++ b/server/data/dataAccess/db.js
@@ -45,8 +45,9 @@ module.exports = {
     ns.set('transactionalClient', client)
     try {
       await client.query('BEGIN')
-      await callback()
+      const result = await callback()
       await client.query('COMMIT')
+      return result
     } catch (error) {
       await client.query('ROLLBACK')
       throw error

--- a/server/data/incidentClient.test.js
+++ b/server/data/incidentClient.test.js
@@ -217,3 +217,22 @@ test('submitStatement', () => {
     values: [StatementStatus.SUBMITTED.value, 'user1', 'incident1', StatementStatus.PENDING.value],
   })
 })
+
+test('getNextNotificationReminder', () => {
+  incidentClient.getNextNotificationReminder()
+
+  expect(db.query).toBeCalledWith({
+    text: `select s.id
+          ,       s.name
+          ,       r.booking_id             "bookingId"
+          ,       r.reporter_name          "reporterName"
+          ,       r.incident_date          "incidentDate"
+          from report r
+          left join statement s on r.id = s.report_id
+          where next_reminder_date < now() and s.statement_status = $1
+          order by id
+          for update of statement skip locked
+          LIMIT 1`,
+    values: [StatementStatus.PENDING.value],
+  })
+})


### PR DESCRIPTION
Using [this](https://www.2ndquadrant.com/en/blog/what-is-select-skip-locked-for-in-postgresql-9-5/) mechanism for creating a work queue of outstanding reminders over the statement table.

Still need to do the code to actually process the reminder.

This will currently log the first reminder 100 times on each job poll (every 5 minutes) as still need to mark each reminder so it won't be picked up again.