### PR TITLE
DCS-118: User is now able to view the current statements before movin…

### DIFF
--- a/integration-tests/integration/createIncident/save-additional-comment.spec.js
+++ b/integration-tests/integration/createIncident/save-additional-comment.spec.js
@@ -2,6 +2,7 @@ const TasklistPage = require('../../pages/tasklistPage')
 const SubmittedPage = require('../../pages/submittedPage')
 const ViewStatementPage = require('../../pages/viewStatementPage')
 const IncidentsPage = require('../../pages/incidentsPage')
+const ViewAddCommentPage = require('../../pages/addAdditionalCommentPage')
 
 context('Add comments to statement', () => {
   const bookingId = 1001
@@ -52,17 +53,34 @@ context('Add comments to statement', () => {
     const { viewButton } = incidentsPage.getCompleteRow(0)
     viewButton().click()
 
-    const pageComponent = ViewStatementPage.verifyOnPage()
+    let pageComponent = ViewStatementPage.verifyOnPage()
+    pageComponent.addComment().click()
 
+    pageComponent = ViewAddCommentPage.verifyOnPage()
+    pageComponent.additionalComment().should('be.empty')
     pageComponent.additionalComment().type('Some new comment 1')
     pageComponent.save().click()
+
+    pageComponent = IncidentsPage.verifyOnPage()
+    pageComponent.viewStatement().click()
+
+    pageComponent = ViewStatementPage.verifyOnPage()
+    pageComponent.addComment().click()
+
+    pageComponent = ViewAddCommentPage.verifyOnPage()
     pageComponent.viewAdditionalComment(1).should('contain', 'Some new comment 1')
     pageComponent.additionalComment().should('be.empty')
     pageComponent.additionalComment(2).type('Some new comment 2')
     pageComponent.save().click()
+
+    pageComponent = IncidentsPage.verifyOnPage()
+    pageComponent.viewStatement().click()
+
+    pageComponent = ViewStatementPage.verifyOnPage()
+    pageComponent.viewAdditionalComment(1).should('contain', 'Some new comment 1')
     pageComponent.viewAdditionalComment(2).should('contain', 'Some new comment 2')
-    pageComponent.additionalComment().should('be.empty')
-    pageComponent.cancel().click()
+    pageComponent.continue().click()
+
     IncidentsPage.verifyOnPage()
   })
 })

--- a/integration-tests/pages/addAdditionalCommentPage.js
+++ b/integration-tests/pages/addAdditionalCommentPage.js
@@ -1,17 +1,18 @@
 const page = require('./page')
 
-const viewStatementPage = () =>
-  page('Your use of force statement', {
+const addCommentPage = () =>
+  page('Add a comment to your statement', {
     offenderName: () => cy.get('[data-qa=offender-name]'),
     statement: () => cy.get('[data-qa=statement]'),
     lastTraining: () => cy.get('[data-qa=last-training]'),
     jobStartYear: () => cy.get('[data-qa=job-start-year]'),
+    additionalComment: () => cy.get('[data-qa="additional-comment"]'),
     viewAdditionalComment: index => cy.get(`[data-qa="viewAdditionalComment"][data-loop=${index}]`),
 
-    addComment: () => cy.get('[data-qa="add-comment"]'),
-    continue: () => cy.get('[data-qa=continue]'),
+    save: () => cy.get('[data-qa=save]'),
+    cancel: () => cy.get('[data-qa=cancel]'),
   })
 
 export default {
-  verifyOnPage: viewStatementPage,
+  verifyOnPage: addCommentPage,
 }

--- a/integration-tests/pages/incidentsPage.js
+++ b/integration-tests/pages/incidentsPage.js
@@ -31,6 +31,7 @@ const incidentsPage = () =>
           .invoke('attr', 'href')
           .then(link => link.match(/\/(.*?)\/your-statement/)[1]),
     }),
+    viewStatement: () => cy.get('[data-qa="view-statement"]'),
   })
 
 export default {

--- a/server/routes/incidents.js
+++ b/server/routes/incidents.js
@@ -154,7 +154,7 @@ module.exports = function CreateReportRoutes({ statementService, offenderService
       return res.redirect(`/`)
     },
 
-    addCommentToStatement: async (req, res) => {
+    viewAddCommentToStatement: async (req, res) => {
       const { reportId } = req.params
       const statement = await statementService.getStatement(req.user.username, reportId, StatementStatus.SUBMITTED)
       const offenderDetail = await offenderService.getOffenderDetails(res.locals.user.token, statement.bookingId)

--- a/server/routes/incidents.js
+++ b/server/routes/incidents.js
@@ -151,7 +151,27 @@ module.exports = function CreateReportRoutes({ statementService, offenderService
       if (req.body.additionalComment && req.body.additionalComment.trim().length) {
         await statementService.saveAdditionalComment(statement.id, req.body.additionalComment)
       }
-      return res.redirect(`/${reportId}/your-statement`)
+      return res.redirect(`/`)
+    },
+
+    addCommentToStatement: async (req, res) => {
+      const { reportId } = req.params
+      const statement = await statementService.getStatement(req.user.username, reportId, StatementStatus.SUBMITTED)
+      const offenderDetail = await offenderService.getOffenderDetails(res.locals.user.token, statement.bookingId)
+      const { displayName, offenderNo } = offenderDetail
+
+      if (req.body.additionalComment && req.body.additionalComment.trim().length) {
+        await statementService.saveAdditionalComment(statement.id, req.body.additionalComment)
+      }
+      return res.render('pages/statement/add-comment-to-statement', {
+        data: {
+          reportId,
+          displayName,
+          offenderNo,
+          ...statement,
+          lastTrainingMonth: moment.months(statement.lastTrainingMonth),
+        },
+      })
     },
   }
 }

--- a/server/routes/incidents.test.js
+++ b/server/routes/incidents.test.js
@@ -5,7 +5,13 @@ const { authenticationMiddleware } = require('./testutils/mockAuthentication')
 
 const statementService = {
   getStatementsForUser: () => [{ id: 1, booking_id: 2, created_date: '12/12/2018', user_id: 'ITAG_USER' }],
-  getStatement: () => ({ id: 1, booking_id: 2, created_date: '12/12/2018', user_id: 'ITAG_USER' }),
+  getStatement: () => ({
+    id: 1,
+    booking_id: 2,
+    created_date: '12/12/2018',
+    user_id: 'ITAG_USER',
+    statement: 'Some initial statement',
+  }),
   submitStatement: jest.fn(),
   save: jest.fn(),
   validateSavedStatement: jest.fn(),
@@ -14,15 +20,15 @@ const statementService = {
 
 const offenderService = {
   getOffenderNames: () => [],
-  getOffenderDetails: () => ({}),
+  getOffenderDetails: () => ({ displayName: 'Jimmy Choo', offenderNo: '123456' }),
 }
+
 const route = createRouter({ authenticationMiddleware, statementService, offenderService })
 
 let app
 
 beforeEach(() => {
   statementService.validateSavedStatement.mockReturnValue([])
-
   app = appSetup(route)
 })
 
@@ -119,5 +125,19 @@ describe('POST /:reportId/add-comment-to-statement', () => {
       .expect('Location', '/')
       .expect(() => {
         expect(statementService.saveAdditionalComment).toBeCalledWith(1, 'statement1')
+      }))
+})
+
+describe('GET /:reportId/add-comment-to-statement', () => {
+  it('should render page', () =>
+    request(app)
+      .get('/-1/add-comment-to-statement')
+      .expect(200)
+      .expect(res => {
+        expect(res.text).toContain('Add a comment to your statement')
+        expect(res.text).toContain(1)
+        expect(res.text).toContain('Jimmy Choo')
+        expect(res.text).toContain('123456')
+        expect(res.text).toContain('Some initial statement')
       }))
 })

--- a/server/routes/incidents.test.js
+++ b/server/routes/incidents.test.js
@@ -110,13 +110,13 @@ describe('GET /:reportId/your-statement', () => {
       }))
 })
 
-describe('POST /:reportId/your-statement', () => {
-  it('should save ammendment', () =>
+describe('POST /:reportId/add-comment-to-statement', () => {
+  it('should save amendment', () =>
     request(app)
-      .post('/-1/your-statement')
+      .post('/-1/add-comment-to-statement')
       .send('additionalComment=statement1&submit=true')
       .expect(302)
-      .expect('Location', '/-1/your-statement')
+      .expect('Location', '/')
       .expect(() => {
         expect(statementService.saveAdditionalComment).toBeCalledWith(1, 'statement1')
       }))

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -67,7 +67,7 @@ module.exports = function Index({
   post('/:reportId/check-your-statement', incidents.submitCheckYourStatement)
   get('/:reportId/statement-submitted', incidents.viewStatementSubmitted)
   get('/:reportId/your-statement', incidents.viewYourStatement)
-  get('/:reportId/add-comment-to-statement', incidents.addCommentToStatement)
+  get('/:reportId/add-comment-to-statement', incidents.viewAddCommentToStatement)
   post('/:reportId/add-comment-to-statement', incidents.saveAdditionalComment)
 
   return router

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -67,7 +67,8 @@ module.exports = function Index({
   post('/:reportId/check-your-statement', incidents.submitCheckYourStatement)
   get('/:reportId/statement-submitted', incidents.viewStatementSubmitted)
   get('/:reportId/your-statement', incidents.viewYourStatement)
-  post('/:reportId/your-statement', incidents.saveAdditionalComment)
+  get('/:reportId/add-comment-to-statement', incidents.addCommentToStatement)
+  post('/:reportId/add-comment-to-statement', incidents.saveAdditionalComment)
 
   return router
 }

--- a/server/views/pages/incidents.html
+++ b/server/views/pages/incidents.html
@@ -67,9 +67,9 @@
               role="button"
               draggable="false"
               class="govuk-button govuk-button--secondary"
-              data-qa="view-amend"
+              data-qa="view-statement"
             >
-            View and amend
+            View
             </a>
           </td>
       </tr>  

--- a/server/views/pages/statement/add-comment-to-statement.html
+++ b/server/views/pages/statement/add-comment-to-statement.html
@@ -13,7 +13,7 @@ govukCheckboxes %} {% from "govuk/components/error-summary/macro.njk" import gov
     })
   }}
   {% endif %}
-  <h1 class="govuk-heading-xl mainHeading">Your use of force statement</h1>
+  <h1 class="govuk-heading-xl mainHeading">Add a comment to your statement</h1>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full ">
@@ -80,23 +80,43 @@ govukCheckboxes %} {% from "govuk/components/error-summary/macro.njk" import gov
   <hr />
   {% endfor %}
 
-  {{
+  <form method="POST">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        {{
+          govukTextarea({
+            id: 'additionalComment',
+            name: 'additionalComment',
+            rows: 15,
+            cols: 200,
+            attributes: { 'data-qa': 'additional-comment' },
+            label: {
+              text: 'Additional comments',
+              classes: 'govuk-label--m govuk-!-margin-top-4'
+            }          
+          })
+        }}
+      </div>
+    </div>
+
+    {{
       govukButton({
-        text: 'Continue',
-        name: 'continue',
-        href: '/',
+        text: 'Save additional comment',
+        name: 'submit',
+        value: 'submit',
         classes: 'govuk-button  govuk-!-margin-top-5',
-        attributes: { 'data-qa': 'continue' }
+        attributes: { 'data-qa': 'save' }
       })
     }}
-
-  {{
-        govukButton({
-          text: 'Add comment',
-          href:  '/' + data.reportId + '/add-comment-to-statement',
-          classes: 'govuk-button govuk-button--secondary govuk-!-margin-left-3 govuk-!-margin-top-5',
-          attributes: { 'data-qa': 'add-comment' }
-        })
-      }}
+    {{
+      govukButton({
+        text: 'Cancel',
+        href:  '/' + data.reportId + '/your-statement',
+        classes: 'govuk-button govuk-button--secondary govuk-!-margin-left-3 govuk-!-margin-top-5',
+        attributes: { 'data-qa': 'cancel' }
+      })
+    }}
+  </form>
 </div>
 {% endblock %}

--- a/server/views/pages/statement/add-comment-to-statement.html
+++ b/server/views/pages/statement/add-comment-to-statement.html
@@ -54,8 +54,7 @@ govukCheckboxes %} {% from "govuk/components/error-summary/macro.njk" import gov
   </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <p class="govuk-!-margin-bottom-1 govuk-!-margin-top-0 govuk-label--xs statement" data-qa="statement">
-        {{ data.statement }} </p>
+      <p class="govuk-!-margin-bottom-1 govuk-!-margin-top-0 govuk-label--xs statement" data-qa="statement">{{ data.statement }}</p>
     </div>
   </div>
   <hr />

--- a/server/views/pages/statement/your-statement.html
+++ b/server/views/pages/statement/your-statement.html
@@ -54,8 +54,7 @@ govukCheckboxes %} {% from "govuk/components/error-summary/macro.njk" import gov
   </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <p class="govuk-!-margin-bottom-1 govuk-!-margin-top-0 govuk-label--xs statement" data-qa="statement">
-        {{ data.statement }} </p>
+      <p class="govuk-!-margin-bottom-1 govuk-!-margin-top-0 govuk-label--xs statement" data-qa="statement">{{ data.statement }}</p>
     </div>
   </div>
   <hr />


### PR DESCRIPTION
…g to an Add Comments page

http://localhost:3000/reportId/add-comment-to-statement

The previous journey was for user to view and amend the Statement on the same page.
The button to access the Statement page was on the Incidents page
The journey has been changed so that the the Incidents page only has a view button. This takes user to the Statement page which displays the initial statement plus any additional comments.
From here the user can either click Continue to go back to the Incidents page or click Add comment to go to the new page.
The new page displays the same information as the Statement page but also has a text box to accept another comment.
The user then has the option to either Save a new comment (and go back to the Incidents page) or Cancel and return to the previous page.