### PR TITLE
DCS-93 seeding initial next reminder date

### DIFF
--- a/job/reminders/reminderSender.test.js
+++ b/job/reminders/reminderSender.test.js
@@ -74,12 +74,12 @@ describe('getNextReminderDate', () => {
   })
 
   test('end of month', async () => {
-    checkGetNextReminderDate('2020-02-28 23:59:59').toEqual('2020-02-29 23:59:59')
-    checkGetNextReminderDate('2020-02-29 23:59:59').toEqual('2020-03-01 23:59:59')
+    checkGetNextReminderDate('2019-09-30 21:26:17').toEqual('2019-10-01 21:26:17')
   })
 
   test('leap year', async () => {
-    checkGetNextReminderDate('2019-09-30 21:26:17').toEqual('2019-10-01 21:26:17')
+    checkGetNextReminderDate('2020-02-28 23:59:59').toEqual('2020-02-29 23:59:59')
+    checkGetNextReminderDate('2020-02-29 23:59:59').toEqual('2020-03-01 23:59:59')
   })
 })
 

--- a/server/services/involvedStaffService.js
+++ b/server/services/involvedStaffService.js
@@ -1,3 +1,5 @@
+const moment = require('moment')
+
 module.exports = function createReportService({ incidentClient, userService }) {
   const get = reportId => {
     return incidentClient.getInvolvedStaff(reportId)
@@ -58,7 +60,7 @@ module.exports = function createReportService({ incidentClient, userService }) {
     return [...addedStaff, ...exist]
   }
 
-  const save = async (reportId, currentUser) => {
+  const save = async (reportId, reportSubmittedDate, currentUser) => {
     const involvedStaff = await get(reportId)
 
     const staffToCreateStatmentsFor = await getStaffRequiringStatements(currentUser, involvedStaff)
@@ -70,7 +72,8 @@ module.exports = function createReportService({ incidentClient, userService }) {
       email: user.email,
     }))
 
-    await incidentClient.createStatements(reportId, staff)
+    const firstReminderDate = moment(reportSubmittedDate).add(1, 'day')
+    await incidentClient.createStatements(reportId, firstReminderDate.toDate(), staff)
     return staff
   }
 

--- a/server/services/involvedStaffService.test.js
+++ b/server/services/involvedStaffService.test.js
@@ -1,3 +1,4 @@
+const moment = require('moment')
 const serviceCreator = require('./involvedStaffService')
 
 const userService = {
@@ -153,6 +154,14 @@ describe('lookup', () => {
 })
 
 describe('save', () => {
+  let reportSubmittedDate
+  let expectedFirstReminderDate
+
+  beforeEach(() => {
+    reportSubmittedDate = moment('2019-09-06 21:26:18')
+    expectedFirstReminderDate = moment('2019-09-07 21:26:18')
+  })
+
   test('when user has already added themselves', async () => {
     incidentClient.getInvolvedStaff.mockReturnValue([
       {
@@ -175,9 +184,9 @@ describe('save', () => {
       },
     ])
 
-    await service.save('form1', { name: 'Bob Smith', staffId: 3, username: 'Bob' })
+    await service.save('form1', reportSubmittedDate, { name: 'Bob Smith', staffId: 3, username: 'Bob' })
 
-    expect(incidentClient.createStatements).toBeCalledWith('form1', [
+    expect(incidentClient.createStatements).toBeCalledWith('form1', expectedFirstReminderDate.toDate(), [
       { email: 'bn@email', name: 'June Smith', staffId: 1, userId: 'June' },
       {
         email: 'cn@email',
@@ -222,9 +231,9 @@ describe('save', () => {
       ],
     })
 
-    await service.save('form1', { name: 'Bob Smith', staffId: 3, username: 'Bob' })
+    await service.save('form1', reportSubmittedDate, { name: 'Bob Smith', staffId: 3, username: 'Bob' })
 
-    expect(incidentClient.createStatements).toBeCalledWith('form1', [
+    expect(incidentClient.createStatements).toBeCalledWith('form1', expectedFirstReminderDate.toDate(), [
       { email: 'bn@email', name: 'June Smith', staffId: 1, userId: 'June' },
       {
         email: 'cn@email',
@@ -263,8 +272,8 @@ describe('save', () => {
       missing: [{}],
     })
 
-    await expect(service.save('form1', { name: 'Bob Smith', staffId: 3, username: 'Bob' })).rejects.toThrow(
-      `Could not retrieve user details for 'Bob', missing: 'true', not verified: 'false'`
-    )
+    await expect(
+      service.save('form1', reportSubmittedDate, { name: 'Bob Smith', staffId: 3, username: 'Bob' })
+    ).rejects.toThrow(`Could not retrieve user details for 'Bob', missing: 'true', not verified: 'false'`)
   })
 })

--- a/server/services/reportService.js
+++ b/server/services/reportService.js
@@ -1,3 +1,4 @@
+const moment = require('moment')
 const logger = require('../../log.js')
 const { isNilOrEmpty } = require('../utils/utils')
 const { check: getReportStatus } = require('../services/reportStatusChecker')
@@ -52,12 +53,13 @@ module.exports = function createReportService({
     )
   }
 
-  async function submit(currentUser, bookingId) {
+  async function submit(currentUser, bookingId, now = moment()) {
     const { id, incidentDate } = await getCurrentDraft(currentUser.username, bookingId)
     if (id) {
-      const staff = await involvedStaffService.save(id, currentUser)
+      const reportSubmittedDate = now
+      const staff = await involvedStaffService.save(id, reportSubmittedDate, currentUser)
       logger.info(`Submitting report for user: ${currentUser.username} and booking: ${bookingId}`)
-      await incidentClient.submitReport(currentUser.username, bookingId)
+      await incidentClient.submitReport(currentUser.username, bookingId, reportSubmittedDate.toDate())
 
       // Always ensure report is persisted before sending out notifications
       await incidentClient.commitAndStartNewTransaction()

--- a/server/services/reportService.test.js
+++ b/server/services/reportService.test.js
@@ -1,3 +1,4 @@
+const moment = require('moment')
 const serviceCreator = require('./reportService')
 
 const incidentClient = {
@@ -41,14 +42,15 @@ describe('submit', () => {
   test('it should save statements and submit the report', async () => {
     involvedStaffService.save.mockReturnValue([])
 
-    const result = await service.submit(currentUser, 'booking-1')
+    const now = moment('2019-09-06 21:26:18')
+    const result = await service.submit(currentUser, 'booking-1', now)
 
     expect(result).toEqual('form-1')
     expect(involvedStaffService.save).toBeCalledTimes(1)
-    expect(involvedStaffService.save).toBeCalledWith('form-1', currentUser)
+    expect(involvedStaffService.save).toBeCalledWith('form-1', now, currentUser)
 
     expect(incidentClient.submitReport).toBeCalledTimes(1)
-    expect(incidentClient.submitReport).toBeCalledWith(currentUser.username, 'booking-1')
+    expect(incidentClient.submitReport).toBeCalledWith(currentUser.username, 'booking-1', now.toDate())
     expect(incidentClient.commitAndStartNewTransaction).toBeCalledTimes(1)
   })
 


### PR DESCRIPTION
This seeds the initial next reminder date when the report is submitted.
The initial reminder date is the submitted date plus one.

Also fixing an issue where we weren't returning incident date as part
of the reminder item which meant the email template was defaulting
incident date and time to 'now'