### PR TITLE
DCS-93 correcting email template variables

### DIFF
--- a/job/reminders/reminderSender.js
+++ b/job/reminders/reminderSender.js
@@ -18,7 +18,6 @@ module.exports = (notificationService, incidentClient) => {
       await notificationService.sendReporterStatementOverdue(reminder.recipientEmail, {
         reporterName: reminder.reporterName,
         incidentDate: reminder.incidentDate,
-        reportSubmittedDate: reminder.submittedDate,
       })
     } else {
       await notificationService.sendInvolvedStaffStatementOverdue(reminder.recipientEmail, {
@@ -34,11 +33,13 @@ module.exports = (notificationService, incidentClient) => {
       await notificationService.sendReporterStatementReminder(reminder.recipientEmail, {
         reporterName: reminder.reporterName,
         incidentDate: reminder.incidentDate,
+        reportSubmittedDate: reminder.submittedDate,
       })
     } else {
       await notificationService.sendInvolvedStaffStatementReminder(reminder.recipientEmail, {
         involvedName: reminder.recipientName,
         incidentDate: reminder.incidentDate,
+        reportSubmittedDate: reminder.submittedDate,
       })
     }
     const nextReminderDate = getNextReminderDate(reminder)

--- a/job/reminders/reminderSender.test.js
+++ b/job/reminders/reminderSender.test.js
@@ -84,34 +84,110 @@ describe('getNextReminderDate', () => {
 })
 
 describe('send', () => {
+  const recipientEmail = 'smith@prison.org'
+  const involvedName = 'June'
+  const incidentDate = moment('2019-09-05 21:26:17')
+  const reporterName = 'Officer Smith'
   const now = moment('2019-09-06 21:26:17')
   const overdue = moment('2019-09-02 21:26:17')
   const notOverdue = moment('2019-09-05 21:26:17')
 
   describe('reporter', () => {
     test('sendReporterStatementReminder', async () => {
-      await send({ isReporter: true, nextReminderDate: now, submittedDate: notOverdue, statementId: -1 }, now)
+      await send(
+        {
+          isReporter: true,
+          incidentDate,
+          reporterName,
+          recipientEmail,
+          nextReminderDate: now,
+          submittedDate: notOverdue,
+          statementId: -1,
+        },
+        now
+      )
+
       expect(notificationService.sendReporterStatementReminder).toBeCalledTimes(1)
+      expect(notificationService.sendReporterStatementReminder).toBeCalledWith(recipientEmail, {
+        incidentDate,
+        reportSubmittedDate: notOverdue,
+        reporterName,
+      })
+
       expect(incidentClient.setNextReminderDate).toBeCalledWith(-1, moment('2019-09-07 21:26:17').toDate())
     })
 
     test('sendReporterStatementOverdue', async () => {
-      await send({ isReporter: true, nextReminderDate: now, submittedDate: overdue, statementId: -1 }, now)
+      await send(
+        {
+          isReporter: true,
+          incidentDate,
+          reporterName,
+          recipientEmail,
+          nextReminderDate: now,
+          submittedDate: overdue,
+          statementId: -1,
+        },
+        now
+      )
+
       expect(notificationService.sendReporterStatementOverdue).toBeCalledTimes(1)
+      expect(notificationService.sendReporterStatementOverdue).toBeCalledWith(recipientEmail, {
+        incidentDate,
+        reporterName,
+      })
+
       expect(incidentClient.setNextReminderDate).toBeCalledWith(-1, null)
     })
   })
 
   describe('involved staff', () => {
     test('sendInvolvedStaffStatementReminder', async () => {
-      await send({ isReporter: false, nextReminderDate: now, submittedDate: notOverdue, statementId: -1 }, now)
+      await send(
+        {
+          isReporter: false,
+          incidentDate,
+          reporterName,
+          recipientEmail,
+          recipientName: involvedName,
+          nextReminderDate: now,
+          submittedDate: notOverdue,
+          statementId: -1,
+        },
+        now
+      )
+
       expect(notificationService.sendInvolvedStaffStatementReminder).toBeCalledTimes(1)
+      expect(notificationService.sendInvolvedStaffStatementReminder).toBeCalledWith(recipientEmail, {
+        incidentDate,
+        reportSubmittedDate: notOverdue,
+        involvedName,
+      })
+
       expect(incidentClient.setNextReminderDate).toBeCalledWith(-1, moment('2019-09-07 21:26:17').toDate())
     })
 
     test('sendInvolvedStaffStatementOverdue', async () => {
-      await send({ isReporter: false, nextReminderDate: now, submittedDate: overdue, statementId: -1 }, now)
+      await send(
+        {
+          isReporter: false,
+          incidentDate,
+          reporterName,
+          recipientEmail,
+          recipientName: involvedName,
+          nextReminderDate: now,
+          submittedDate: overdue,
+          statementId: -1,
+        },
+        now
+      )
+
       expect(notificationService.sendInvolvedStaffStatementOverdue).toBeCalledTimes(1)
+      expect(notificationService.sendInvolvedStaffStatementOverdue).toBeCalledWith(recipientEmail, {
+        incidentDate,
+        involvedName,
+      })
+
       expect(incidentClient.setNextReminderDate).toBeCalledWith(-1, null)
     })
   })


### PR DESCRIPTION
We weren't passing through submitted date so we were calculating the deadline date based on 'now'
Fixed this and added some better tests.

Removed where we were incorrectly passing through submitted date for overdue reminders.