### PR TITLE
Adding new missing staff page

### DIFF
--- a/integration-tests/pages/newIncidentPage.js
+++ b/integration-tests/pages/newIncidentPage.js
@@ -1,7 +1,7 @@
 const page = require('./page')
 const detailsPage = require('./detailsPage')
 
-export default () =>
+const incidentDetailsPage = () =>
   page('Incident details', {
     offenderName: () => cy.get('[data-qa=offender-name]'),
     location: () => cy.get('#locationId'),
@@ -72,4 +72,8 @@ export default () =>
       cy.get('[data-qa="save-and-continue"]').click()
       return detailsPage()
     },
+
+    clickSave: () => cy.get('[data-qa="save-and-continue"]').click(),
   })
+
+export default { verifyOnPage: incidentDetailsPage }

--- a/integration-tests/pages/tasklistPage.js
+++ b/integration-tests/pages/tasklistPage.js
@@ -1,4 +1,4 @@
-const newIncidentPage = require('./newIncidentPage')
+const NewIncidentPage = require('./newIncidentPage')
 const checkAnswersPage = require('./checkAnswersPage')
 const detailsPage = require('./detailsPage')
 const page = require('./page')
@@ -7,7 +7,7 @@ const tasklistPage = () =>
   page('Report use of force', {
     startNewForm: () => {
       cy.get('[data-qa-new-incident-link]').click()
-      return newIncidentPage()
+      return NewIncidentPage.verifyOnPage()
     },
     goToUseOfForceDetailsPage: () => {
       cy.get('[data-qa-details-link]').click()

--- a/integration-tests/pages/userDoesNotExistPage.js
+++ b/integration-tests/pages/userDoesNotExistPage.js
@@ -1,0 +1,13 @@
+const page = require('./page')
+
+const userDoesNotExistPage = () =>
+  page('A username you have entered does not exist', {
+    missingUsers: () =>
+      cy.get(`[data-qa="missing-user"]`).spread((...rest) => rest.map(element => Cypress.$(element).text())),
+    continue: () => cy.get('[data-qa=continue]'),
+    return: () => cy.get('[data-qa=return-to-incident-details]'),
+  })
+
+export default {
+  verifyOnPage: userDoesNotExistPage,
+}

--- a/server/config/types.js
+++ b/server/config/types.js
@@ -40,6 +40,11 @@ const StatementStatus = {
   SUBMITTED: { value: 'SUBMITTED', label: 'Submitted' },
 }
 
+const Destinations = {
+  CONTINUE: 'continue',
+  TASKLIST: 'back-to-task-list',
+}
+
 module.exports = {
   BodyWornCameras: Object.freeze(BodyWornCameras),
   Cctv: Object.freeze(Cctv),
@@ -47,5 +52,6 @@ module.exports = {
   RelocationLocation: Object.freeze(RelocationLocation),
   ReportStatus: Object.freeze(ReportStatus),
   StatementStatus: Object.freeze(StatementStatus),
+  Destinations: Object.freeze(Destinations),
   toLabel,
 }

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -51,6 +51,9 @@ module.exports = function Index({
 
   get(reportPath('incident-details'), createReport.viewIncidentDetails)
   post(reportPath('incident-details'), createReport.submit('incidentDetails'))
+  get(reportPath('username-does-not-exist'), createReport.viewUsernameDoesNotExist)
+  post(reportPath('username-does-not-exist'), createReport.submitUsernameDoesNotExist)
+
   get(reportPath('use-of-force-details'), createReport.view('useOfForceDetails'))
   post(reportPath('use-of-force-details'), createReport.submit('useOfForceDetails'))
   get(reportPath('relocation-and-injuries'), createReport.view('relocationAndInjuries'))

--- a/server/services/involvedStaffService.js
+++ b/server/services/involvedStaffService.js
@@ -3,6 +3,20 @@ const moment = require('moment')
 module.exports = function createReportService({ incidentClient, statementsClient, userService }) {
   const getDraftInvolvedStaff = reportId => incidentClient.getDraftInvolvedStaff(reportId)
 
+  const removeMissingDraftInvolvedStaff = async (userId, bookingId) => {
+    const { id, form = {} } = await incidentClient.getCurrentDraftReport(userId, bookingId)
+
+    const { incidentDetails = {} } = form
+    const { involvedStaff = [] } = incidentDetails
+    const updatedInvolvedStaff = involvedStaff.filter(staff => !staff.missing)
+
+    const updatedFormObject = {
+      ...form,
+      incidentDetails: { ...incidentDetails, involvedStaff: updatedInvolvedStaff },
+    }
+    await incidentClient.updateDraftReport(id, null, updatedFormObject)
+  }
+
   const getInvolvedStaff = reportId => incidentClient.getInvolvedStaff(reportId)
 
   async function lookup(token, usernames) {
@@ -109,6 +123,7 @@ module.exports = function createReportService({ incidentClient, statementsClient
 
   return {
     getInvolvedStaff,
+    removeMissingDraftInvolvedStaff,
     getDraftInvolvedStaff,
     save,
     lookup,

--- a/server/services/userService.js
+++ b/server/services/userService.js
@@ -39,7 +39,7 @@ module.exports = function createUserService(elite2ClientBuilder, authClientBuild
         exist,
         missing,
         notVerified,
-        success: missing.length === 0 && notVerified.length === 0,
+        success: notVerified.length === 0,
       }
     } catch (error) {
       logger.error('Error during getEmails: ', error.stack)

--- a/server/services/userService.test.js
+++ b/server/services/userService.test.js
@@ -107,7 +107,7 @@ describe('getUsers', () => {
       ],
       missing: [{ i: 1, exists: false, username: 'June', verified: true }],
       notVerified: [],
-      success: false,
+      success: true,
     })
   })
 

--- a/server/views/formPages/incident/username-does-not-exist.html
+++ b/server/views/formPages/incident/username-does-not-exist.html
@@ -1,0 +1,57 @@
+{% extends "../../partials/layout.html" %} 
+{% from "govuk/components/button/macro.njk" import govukButton %} 
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %} 
+
+{% block beforeContent %}
+
+{{ govukBackLink({
+text: "Back",
+href: backLink or "/"
+}) }}
+
+{% endblock %} 
+
+{% block content %}
+<div class="govuk-grid-row govuk-body">
+  <div class="govuk-grid-column-three-quarters govuk-!-margin-bottom-4">
+    <h1 class="govuk-heading-xl">A username you have entered does not exist</h1>
+
+    <p>
+      You have entered a username which does not exist:
+    </p>
+    <ul class="govuk-!-margin-left-3">
+        {% for missingUser in data.missingUsers %}
+        <li data-qa="missing-user">{{missingUser}}</li>
+        {% endfor %}     
+    </ul>
+    <p>
+      You can continue and it will be deleted from the report or you can return to incident details and change it.
+    </p>
+  </div>
+  <div class="govuk-grid-column-three-quarters">
+
+    <div>
+      <form method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+        <input type="hidden" name="nextDestination" value="{{ data.nextDestination }}" />
+        {{
+          govukButton({
+            text: 'Continue and delete',
+            classes: 'govuk-button',
+            attributes: { 'data-qa': 'continue', 'data-submit': true }
+          })
+        }}
+        {{
+          govukButton({
+            text: 'Return to incident details',
+            name: 'submit',
+            href: '/report/' + data.bookingId + '/incident-details',
+            classes: 'govuk-button govuk-button--secondary govuk-!-margin-left-3',
+            attributes: { 'data-qa': 'return-to-incident-details' }
+          })
+        }}
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
Added a new page to warn users if they enter involved staff that don't exist in nomis.
    
This gives the user the options to either automatically remove the invalid staff or to go back and correct them.
    
If the user chooses to automatically remove the users, a redirect will occur if they click back, so the incident details page will displayed and the intermediate page will not be revisitable.
    
This page appears whether the user chooses to continue or return to the tasklist, and needs to redirect to correct location after continue is selected