### PR TITLE
DCS-129 Storing agency on the report level

### DIFF
--- a/migrations/20190913000000_form_db.js
+++ b/migrations/20190913000000_form_db.js
@@ -1,0 +1,21 @@
+exports.up = knex =>
+  Promise.all([
+    knex.schema.table('statement', table => {
+      table.timestamp('overdue_date')
+    }),
+    knex.schema.table('report', table => {
+      table.string('agency_id', 6)
+      table.timestamp('updated_date')
+    }),
+  ])
+
+exports.down = knex =>
+  Promise.all([
+    knex.schema.table('statement', table => {
+      table.dropColumn('overdue_date')
+    }),
+    knex.schema.table('report', table => {
+      table.dropColumn('agency_id')
+      table.dropColumn('updated_date')
+    }),
+  ])

--- a/server/data/incidentClient.test.js
+++ b/server/data/incidentClient.test.js
@@ -83,6 +83,7 @@ test('createDraftReport', async () => {
   const id = await incidentClient.createDraftReport({
     userId: 'user1',
     bookingId: 'booking-1',
+    agencyId: 'LEI',
     reporterName: 'Bob Smith',
     offenderNo: 'AA11ABC',
     incidentDate: 'date-1',
@@ -91,8 +92,8 @@ test('createDraftReport', async () => {
 
   expect(id).toEqual(id)
   expect(db.query).toBeCalledWith({
-    text: `insert into report (form_response, user_id, reporter_name, offender_no, booking_id, status, incident_date, sequence_no, created_date)
-            values ($1, CAST($2 AS VARCHAR), $3, $4, $5, $6, $7, (select COALESCE(MAX(sequence_no), 0) + 1 from report where booking_id = $5 and user_id = $2), CURRENT_TIMESTAMP)
+    text: `insert into report (form_response, user_id, reporter_name, offender_no, booking_id, agency_id, status, incident_date, sequence_no, created_date)
+            values ($1, CAST($2 AS VARCHAR), $3, $4, $5, $6, $7, $8, (select COALESCE(MAX(sequence_no), 0) + 1 from report where booking_id = $5 and user_id = $2), CURRENT_TIMESTAMP)
             returning id`,
     values: [
       { someData: true },
@@ -100,6 +101,7 @@ test('createDraftReport', async () => {
       'Bob Smith',
       'AA11ABC',
       'booking-1',
+      'LEI',
       ReportStatus.IN_PROGRESS.value,
       'date-1',
     ],
@@ -110,7 +112,11 @@ test('updateDraftReport', () => {
   incidentClient.updateDraftReport('formId', 'date-1', {})
 
   expect(db.query).toBeCalledWith({
-    text: 'update report r set form_response = $1, incident_date = COALESCE($2, r.incident_date) where r.id = $3',
+    text: `update report r
+            set form_response = $1
+            ,   incident_date = COALESCE($2,   r.incident_date)
+            ,   updated_date = now()
+            where r.id = $3`,
     values: [{}, 'date-1', 'formId'],
   })
 })
@@ -119,11 +125,14 @@ test('submitReport', () => {
   incidentClient.submitReport('user1', 'booking1', 'date1')
 
   expect(db.query).toBeCalledWith({
-    text: `update report r set status = $1, submitted_date = $2
-    where user_id = $3
-    and booking_id = $4
-    and status = $5
-    and r.sequence_no = (select max(r2.sequence_no) from report r2 where r2.booking_id = r.booking_id and user_id = r.user_id)`,
+    text: `update report r
+            set status = $1
+            ,   submitted_date = $2
+            ,   updated_date = now()
+          where user_id = $3
+          and booking_id = $4
+          and status = $5
+          and r.sequence_no = (select max(r2.sequence_no) from report r2 where r2.booking_id = r.booking_id and user_id = r.user_id)`,
     values: [ReportStatus.SUBMITTED.value, 'date1', 'user1', 'booking1', ReportStatus.IN_PROGRESS.value],
   })
 })

--- a/server/middleware/authorisationMiddleware.test.js
+++ b/server/middleware/authorisationMiddleware.test.js
@@ -52,4 +52,3 @@ describe('authorisationMiddleware', () => {
     expect(res.locals.user.isReviewer).toEqual(false)
   })
 })
- 

--- a/server/middleware/authorisationMiddleware.test.js
+++ b/server/middleware/authorisationMiddleware.test.js
@@ -52,3 +52,4 @@ describe('authorisationMiddleware', () => {
     expect(res.locals.user.isReviewer).toEqual(false)
   })
 })
+ 

--- a/server/services/reportService.js
+++ b/server/services/reportService.js
@@ -39,11 +39,12 @@ module.exports = function createReportService({
       return formId
     }
     const elite2Client = elite2ClientBuilder(token)
-    const { offenderNo } = await elite2Client.getOffenderDetails(bookingId)
+    const { offenderNo, agencyId } = await elite2Client.getOffenderDetails(bookingId)
     const id = await incidentClient.createDraftReport({
       userId,
       reporterName,
       bookingId,
+      agencyId,
       offenderNo,
       incidentDate,
       formResponse: formObject,

--- a/server/services/reportService.test.js
+++ b/server/services/reportService.test.js
@@ -35,7 +35,7 @@ beforeEach(() => {
 
   service = serviceCreator({ incidentClient, elite2ClientBuilder, involvedStaffService, notificationService })
   incidentClient.getCurrentDraftReport.mockReturnValue({ id: 'form-1', a: 'b', incidentDate: 'today' })
-  elite2Client.getOffenderDetails.mockReturnValue({ offenderNo: 'AA123ABC' })
+  elite2Client.getOffenderDetails.mockReturnValue({ offenderNo: 'AA123ABC', agencyId: 'MDI' })
 })
 
 afterEach(() => {
@@ -151,6 +151,7 @@ describe('update', () => {
     expect(incidentClient.createDraftReport).toBeCalledWith({
       userId: 'user1',
       bookingId: 1,
+      agencyId: 'MDI',
       offenderNo: 'AA123ABC',
       reporterName: 'Bob Smith',
       formResponse: formObject,


### PR DESCRIPTION
To allow us to filter by agencies that reviewers are allowed to see

Also adding an updated_date to reports and setting when updating reports. 

Putting in place an overdue date column on statements which will allow us to easily query if statements are overdue or not