### PR TITLE
DCS-129 Storing overdue date on statement creation

### DIFF
--- a/integration-tests/db/db.js
+++ b/integration-tests/db/db.js
@@ -63,14 +63,20 @@ const seedReport = ({
     )
 }
 
+const deleteRows = table =>
+  db.queryWithoutTransaction({
+    text: format('delete from %I', table),
+  })
+
+const clearAllTables = async () => {
+  await deleteRows('statement_amendments')
+  await deleteRows('statement')
+  await deleteRows('report')
+}
+
 module.exports = {
   clearDb() {
-    const drops = ['report', 'statement'].map(table =>
-      db.queryWithoutTransaction({
-        text: format('delete from %I', table),
-      })
-    )
-    return Promise.all(drops)
+    return clearAllTables()
   },
 
   getCurrentDraft({ bookingId, formName }) {

--- a/integration-tests/db/db.js
+++ b/integration-tests/db/db.js
@@ -53,7 +53,13 @@ const seedReport = ({
     .then(
       result =>
         involvedStaff.length &&
-        statementsClient.createStatements(result.rows[0].id, new Date(), involvedStaff, db.queryWithoutTransaction)
+        statementsClient.createStatements(
+          result.rows[0].id,
+          new Date(),
+          new Date(),
+          involvedStaff,
+          db.queryWithoutTransaction
+        )
     )
 }
 

--- a/job/reminders/reminderSender.js
+++ b/job/reminders/reminderSender.js
@@ -2,12 +2,6 @@ const moment = require('moment')
 const logger = require('../../log')
 
 module.exports = (notificationService, incidentClient) => {
-  const isOverdue = (now, { submittedDate }) => {
-    const startdate = moment(submittedDate)
-    const daysSinceReportSubmitted = now.diff(startdate, 'days')
-    return daysSinceReportSubmitted >= 3
-  }
-
   const getNextReminderDate = ({ nextReminderDate }) => {
     const startdate = moment(nextReminderDate)
     return startdate.add(1, 'day').toDate()
@@ -33,13 +27,13 @@ module.exports = (notificationService, incidentClient) => {
       await notificationService.sendReporterStatementReminder(reminder.recipientEmail, {
         reporterName: reminder.reporterName,
         incidentDate: reminder.incidentDate,
-        reportSubmittedDate: reminder.submittedDate,
+        overdueDate: reminder.overdueDate,
       })
     } else {
       await notificationService.sendInvolvedStaffStatementReminder(reminder.recipientEmail, {
         involvedName: reminder.recipientName,
         incidentDate: reminder.incidentDate,
-        reportSubmittedDate: reminder.submittedDate,
+        overdueDate: reminder.overdueDate,
       })
     }
     const nextReminderDate = getNextReminderDate(reminder)
@@ -47,12 +41,10 @@ module.exports = (notificationService, incidentClient) => {
   }
 
   return {
-    isOverdue,
     getNextReminderDate,
-    send: (reminder, now = moment()) => {
+    send: reminder => {
       logger.info('processing reminder', reminder)
-
-      return isOverdue(now, reminder) ? handleOverdue(reminder) : handleReminder(reminder)
+      return reminder.isOverdue ? handleOverdue(reminder) : handleReminder(reminder)
     },
   }
 }

--- a/server/data/incidentClient.js
+++ b/server/data/incidentClient.js
@@ -49,9 +49,9 @@ const submitReport = (userId, bookingId, submittedDate) => {
             set status = $1
             ,   submitted_date = $2
             ,   updated_date = now()
-          where user_id = $3
-          and booking_id = $4
-          and status = $5
+          where r.user_id = $3
+          and r.booking_id = $4
+          and r.status = $5
           and r.sequence_no = ${maxSequenceForBooking}`,
     values: [ReportStatus.SUBMITTED.value, submittedDate, userId, bookingId, ReportStatus.IN_PROGRESS.value],
   })
@@ -60,9 +60,9 @@ const submitReport = (userId, bookingId, submittedDate) => {
 const getCurrentDraftReport = async (userId, bookingId, query = db.query) => {
   const results = await query({
     text: `select id, incident_date "incidentDate", form_response "form" from report r
-          where user_id = $1
-          and booking_id = $2
-          and status = $3
+          where r.user_id = $1
+          and r.booking_id = $2
+          and r.status = $3
           and r.sequence_no = ${maxSequenceForBooking}`,
     values: [userId, bookingId, ReportStatus.IN_PROGRESS.value],
   })
@@ -78,7 +78,7 @@ const getReport = async (userId, reportId, query = db.query) => {
           , form_response "form"
           , booking_id "bookingId"
           from report r
-          where user_id = $1 and id = $2`,
+          where r.user_id = $1 and r.id = $2`,
     values: [userId, reportId],
   })
   return results.rows[0]
@@ -153,7 +153,7 @@ const getNextNotificationReminder = async () => {
           ,       s.overdue_date <= now()  "isOverdue"
           from statement s
           left join report r on r.id = s.report_id
-          where next_reminder_date < now() and s.statement_status = $1
+          where s.next_reminder_date < now() and s.statement_status = $1
           order by s.id
           for update of s skip locked
           LIMIT 1`,

--- a/server/data/incidentClient.js
+++ b/server/data/incidentClient.js
@@ -147,9 +147,10 @@ const getNextNotificationReminder = async () => {
           ,       s.name                   "recipientName"
           ,       s.next_reminder_date     "nextReminderDate"  
           ,       r.reporter_name          "reporterName"
-          ,       r.submitted_date         "submittedDate"
           ,       r.incident_date          "incidentDate"
           ,       r.user_id = s.user_id    "isReporter"
+          ,       s.overdue_date           "overdueDate"
+          ,       s.overdue_date <= now()  "isOverdue"
           from statement s
           left join report r on r.id = s.report_id
           where next_reminder_date < now() and s.statement_status = $1

--- a/server/data/incidentClient.test.js
+++ b/server/data/incidentClient.test.js
@@ -19,9 +19,9 @@ describe('getCurrentDraftReport', () => {
 
     expect(db.query).toBeCalledWith({
       text: `select id, incident_date "incidentDate", form_response "form" from report r
-          where user_id = $1
-          and booking_id = $2
-          and status = $3
+          where r.user_id = $1
+          and r.booking_id = $2
+          and r.status = $3
           and r.sequence_no = (select max(r2.sequence_no) from report r2 where r2.booking_id = r.booking_id and user_id = r.user_id)`,
       values: ['user1', -1, ReportStatus.IN_PROGRESS.value],
     })
@@ -72,7 +72,7 @@ test('getReport', () => {
           , form_response "form"
           , booking_id "bookingId"
           from report r
-          where user_id = $1 and id = $2`,
+          where r.user_id = $1 and r.id = $2`,
     values: ['user1', 'report1'],
   })
 })
@@ -129,9 +129,9 @@ test('submitReport', () => {
             set status = $1
             ,   submitted_date = $2
             ,   updated_date = now()
-          where user_id = $3
-          and booking_id = $4
-          and status = $5
+          where r.user_id = $3
+          and r.booking_id = $4
+          and r.status = $5
           and r.sequence_no = (select max(r2.sequence_no) from report r2 where r2.booking_id = r.booking_id and user_id = r.user_id)`,
     values: [ReportStatus.SUBMITTED.value, 'date1', 'user1', 'booking1', ReportStatus.IN_PROGRESS.value],
   })
@@ -198,7 +198,7 @@ test('getNextNotificationReminder', () => {
           ,       s.overdue_date <= now()  "isOverdue"
           from statement s
           left join report r on r.id = s.report_id
-          where next_reminder_date < now() and s.statement_status = $1
+          where s.next_reminder_date < now() and s.statement_status = $1
           order by s.id
           for update of s skip locked
           LIMIT 1`,

--- a/server/data/incidentClient.test.js
+++ b/server/data/incidentClient.test.js
@@ -192,9 +192,10 @@ test('getNextNotificationReminder', () => {
           ,       s.name                   "recipientName"
           ,       s.next_reminder_date     "nextReminderDate"  
           ,       r.reporter_name          "reporterName"
-          ,       r.submitted_date         "submittedDate"
           ,       r.incident_date          "incidentDate"
           ,       r.user_id = s.user_id    "isReporter"
+          ,       s.overdue_date           "overdueDate"
+          ,       s.overdue_date <= now()  "isOverdue"
           from statement s
           left join report r on r.id = s.report_id
           where next_reminder_date < now() and s.statement_status = $1

--- a/server/data/statementsClient.js
+++ b/server/data/statementsClient.js
@@ -98,7 +98,7 @@ const submitStatement = (userId, reportId, query = db.query) => {
   })
 }
 
-const createStatements = async (reportId, firstReminder, staff, query = db.query) => {
+const createStatements = async (reportId, firstReminder, overdueDate, staff, query = db.query) => {
   const rows = staff.map(s => [
     reportId,
     s.staffId,
@@ -106,11 +106,12 @@ const createStatements = async (reportId, firstReminder, staff, query = db.query
     s.name,
     s.email,
     firstReminder,
+    overdueDate,
     StatementStatus.PENDING.value,
   ])
   const results = await query({
     text: format(
-      'insert into statement (report_id, staff_id, user_id, name, email, next_reminder_date, statement_status) VALUES %L returning id',
+      'insert into statement (report_id, staff_id, user_id, name, email, next_reminder_date, overdue_date, statement_status) VALUES %L returning id',
       rows
     ),
   })

--- a/server/data/statementsClient.test.js
+++ b/server/data/statementsClient.test.js
@@ -71,7 +71,7 @@ test('saveAdditionalComment', () => {
 test('createStatements', async () => {
   db.query.mockReturnValue({ rows: [{ id: 1 }, { id: 2 }] })
 
-  const ids = await statementsClient.createStatements('incident-1', 'date1', [
+  const ids = await statementsClient.createStatements('incident-1', 'date1', 'date2', [
     { staffId: 0, userId: 1, name: 'aaaa', email: 'aaaa@gov.uk' },
     { staffId: 1, userId: 2, name: 'bbbb', email: 'bbbb@gov.uk' },
   ])
@@ -79,9 +79,9 @@ test('createStatements', async () => {
   expect(ids).toEqual([1, 2])
   expect(db.query).toBeCalledWith({
     text:
-      `insert into statement (report_id, staff_id, user_id, name, email, next_reminder_date, statement_status) VALUES ` +
-      `('incident-1', '0', '1', 'aaaa', 'aaaa@gov.uk', 'date1', 'PENDING'), ` +
-      `('incident-1', '1', '2', 'bbbb', 'bbbb@gov.uk', 'date1', 'PENDING') returning id`,
+      `insert into statement (report_id, staff_id, user_id, name, email, next_reminder_date, overdue_date, statement_status) VALUES ` +
+      `('incident-1', '0', '1', 'aaaa', 'aaaa@gov.uk', 'date1', 'date2', 'PENDING'), ` +
+      `('incident-1', '1', '2', 'bbbb', 'bbbb@gov.uk', 'date1', 'date2', 'PENDING') returning id`,
   })
 })
 

--- a/server/middleware/authorisationMiddleware.test.js
+++ b/server/middleware/authorisationMiddleware.test.js
@@ -52,4 +52,3 @@ describe('authorisationMiddleware', () => {
     expect(res.locals.user.isReviewer).toEqual(false)
   })
 })
- 

--- a/server/middleware/authorisationMiddleware.test.js
+++ b/server/middleware/authorisationMiddleware.test.js
@@ -52,3 +52,4 @@ describe('authorisationMiddleware', () => {
     expect(res.locals.user.isReviewer).toEqual(false)
   })
 })
+ 

--- a/server/services/involvedStaffService.js
+++ b/server/services/involvedStaffService.js
@@ -84,7 +84,7 @@ module.exports = function createReportService({ incidentClient, statementsClient
     return [...addedStaff, ...exist]
   }
 
-  const save = async (reportId, reportSubmittedDate, currentUser) => {
+  const save = async (reportId, reportSubmittedDate, overdueDate, currentUser) => {
     const involvedStaff = await getDraftInvolvedStaff(reportId)
 
     const staffToCreateStatmentsFor = await getStaffRequiringStatements(currentUser, involvedStaff)
@@ -97,7 +97,7 @@ module.exports = function createReportService({ incidentClient, statementsClient
     }))
 
     const firstReminderDate = moment(reportSubmittedDate).add(1, 'day')
-    await statementsClient.createStatements(reportId, firstReminderDate.toDate(), staff)
+    await statementsClient.createStatements(reportId, firstReminderDate.toDate(), overdueDate.toDate(), staff)
     return staff
   }
 

--- a/server/services/involvedStaffService.test.js
+++ b/server/services/involvedStaffService.test.js
@@ -225,11 +225,14 @@ describe('lookup', () => {
 
 describe('save', () => {
   let reportSubmittedDate
+  let overdueDate
+
   let expectedFirstReminderDate
 
   beforeEach(() => {
     reportSubmittedDate = moment('2019-09-06 21:26:18')
     expectedFirstReminderDate = moment('2019-09-07 21:26:18')
+    overdueDate = moment(reportSubmittedDate).add(3, 'days')
   })
 
   test('when user has already added themselves', async () => {
@@ -254,23 +257,28 @@ describe('save', () => {
       },
     ])
 
-    await service.save('form1', reportSubmittedDate, { name: 'Bob Smith', staffId: 3, username: 'Bob' })
+    await service.save('form1', reportSubmittedDate, overdueDate, { name: 'Bob Smith', staffId: 3, username: 'Bob' })
 
-    expect(statementsClient.createStatements).toBeCalledWith('form1', expectedFirstReminderDate.toDate(), [
-      { email: 'bn@email', name: 'June Smith', staffId: 1, userId: 'June' },
-      {
-        email: 'cn@email',
-        name: 'Jenny Walker',
-        staffId: 2,
-        userId: 'Jenny',
-      },
-      {
-        email: 'an@email',
-        name: 'Bob Smith',
-        staffId: 3,
-        userId: 'Bob',
-      },
-    ])
+    expect(statementsClient.createStatements).toBeCalledWith(
+      'form1',
+      expectedFirstReminderDate.toDate(),
+      overdueDate.toDate(),
+      [
+        { email: 'bn@email', name: 'June Smith', staffId: 1, userId: 'June' },
+        {
+          email: 'cn@email',
+          name: 'Jenny Walker',
+          staffId: 2,
+          userId: 'Jenny',
+        },
+        {
+          email: 'an@email',
+          name: 'Bob Smith',
+          staffId: 3,
+          userId: 'Bob',
+        },
+      ]
+    )
   })
 
   test('when user is not already added', async () => {
@@ -301,22 +309,27 @@ describe('save', () => {
       ],
     })
 
-    await service.save('form1', reportSubmittedDate, { name: 'Bob Smith', staffId: 3, username: 'Bob' })
-    expect(statementsClient.createStatements).toBeCalledWith('form1', expectedFirstReminderDate.toDate(), [
-      { email: 'bn@email', name: 'June Smith', staffId: 1, userId: 'June' },
-      {
-        email: 'cn@email',
-        name: 'Jenny Walker',
-        staffId: 2,
-        userId: 'Jenny',
-      },
-      {
-        email: 'an@email',
-        name: 'Bob Smith',
-        staffId: 3,
-        userId: 'Bob',
-      },
-    ])
+    await service.save('form1', reportSubmittedDate, overdueDate, { name: 'Bob Smith', staffId: 3, username: 'Bob' })
+    expect(statementsClient.createStatements).toBeCalledWith(
+      'form1',
+      expectedFirstReminderDate.toDate(),
+      overdueDate.toDate(),
+      [
+        { email: 'bn@email', name: 'June Smith', staffId: 1, userId: 'June' },
+        {
+          email: 'cn@email',
+          name: 'Jenny Walker',
+          staffId: 2,
+          userId: 'Jenny',
+        },
+        {
+          email: 'an@email',
+          name: 'Bob Smith',
+          staffId: 3,
+          userId: 'Bob',
+        },
+      ]
+    )
   })
 
   test('fail to find current user', async () => {
@@ -342,7 +355,7 @@ describe('save', () => {
     })
 
     await expect(
-      service.save('form1', reportSubmittedDate, { name: 'Bob Smith', staffId: 3, username: 'Bob' })
+      service.save('form1', reportSubmittedDate, overdueDate, { name: 'Bob Smith', staffId: 3, username: 'Bob' })
     ).rejects.toThrow(`Could not retrieve user details for 'Bob', missing: 'true', not verified: 'false'`)
   })
 })

--- a/server/services/notificationService.js
+++ b/server/services/notificationService.js
@@ -15,25 +15,15 @@ const createNotificationService = emailClient => {
 
   const asTime = date => moment(date).format('HH:mm')
 
-  const asDeadlineDate = date =>
-    moment(date)
-      .add(3, 'days')
-      .format('dddd D MMMM')
-
-  const asDeadlineTime = date =>
-    moment(date)
-      .add(3, 'days')
-      .format('HH:mm')
-
-  const sendReporterStatementReminder = async (emailAddress, { reporterName, incidentDate, reportSubmittedDate }) =>
+  const sendReporterStatementReminder = async (emailAddress, { reporterName, incidentDate, overdueDate }) =>
     emailClient
       .sendEmail(reporter.REMINDER, emailAddress, {
         personalisation: {
           REPORTER_NAME: reporterName,
           INCIDENT_DATE: asDate(incidentDate),
           INCIDENT_TIME: asTime(incidentDate),
-          DEADLINE_DATE: asDeadlineDate(reportSubmittedDate),
-          DEADLINE_TIME: asDeadlineTime(reportSubmittedDate),
+          DEADLINE_DATE: asDate(overdueDate),
+          DEADLINE_TIME: asTime(overdueDate),
           LINK: emailUrl,
         },
         reference: null,
@@ -41,18 +31,15 @@ const createNotificationService = emailClient => {
       .then(({ body }) => logger.info(`Send statement reminder, successful for reporter: '${reporterName}'`, body))
       .catch(({ message }) => logger.error(`Send statement reminder, failed for reporter: '${reporterName}'`, message))
 
-  const sendInvolvedStaffStatementReminder = async (
-    emailAddress,
-    { involvedName, incidentDate, reportSubmittedDate }
-  ) =>
+  const sendInvolvedStaffStatementReminder = async (emailAddress, { involvedName, incidentDate, overdueDate }) =>
     emailClient
       .sendEmail(involvedStaff.REMINDER, emailAddress, {
         personalisation: {
           INVOLVED_NAME: involvedName,
           INCIDENT_DATE: asDate(incidentDate),
           INCIDENT_TIME: asTime(incidentDate),
-          DEADLINE_DATE: asDeadlineDate(reportSubmittedDate),
-          DEADLINE_TIME: asDeadlineTime(reportSubmittedDate),
+          DEADLINE_DATE: asDate(overdueDate),
+          DEADLINE_TIME: asTime(overdueDate),
           LINK: emailUrl,
         },
         reference: null,
@@ -94,10 +81,7 @@ const createNotificationService = emailClient => {
         logger.error(`Send statement overdue, failed for involved staff: '${involvedName}'`, message)
       )
 
-  const sendStatementRequest = async (
-    emailAddress,
-    { reporterName, involvedName, incidentDate, reportSubmittedDate }
-  ) =>
+  const sendStatementRequest = async (emailAddress, { reporterName, involvedName, incidentDate, overdueDate }) =>
     emailClient
       .sendEmail(involvedStaff.REQUEST, emailAddress, {
         personalisation: {
@@ -105,8 +89,8 @@ const createNotificationService = emailClient => {
           REPORTER_NAME: reporterName,
           INCIDENT_DATE: asDate(incidentDate),
           INCIDENT_TIME: asTime(incidentDate),
-          DEADLINE_DATE: asDeadlineDate(reportSubmittedDate),
-          DEADLINE_TIME: asDeadlineTime(reportSubmittedDate),
+          DEADLINE_DATE: asDate(overdueDate),
+          DEADLINE_TIME: asTime(overdueDate),
           LINK: emailUrl,
         },
         reference: null,

--- a/server/services/notificationService.test.js
+++ b/server/services/notificationService.test.js
@@ -24,12 +24,12 @@ afterEach(() => {
 describe('send reporter notifications', () => {
   test('sendReporterStatementReminder', async () => {
     const incidentDate = new Date(2019, 1, 12, 15, 45)
-    const submittedDate = new Date(2019, 1, 13, 16, 45)
+    const overdueDate = new Date(2019, 1, 16, 16, 45)
 
     await service.sendReporterStatementReminder('user@email.com', {
       reporterName: 'Jane Smith',
       incidentDate,
-      reportSubmittedDate: submittedDate,
+      overdueDate,
     })
 
     expect(client.sendEmail).toBeCalledWith(reporter.REMINDER, 'user@email.com', {
@@ -64,12 +64,12 @@ describe('send reporter notifications', () => {
 describe('send involved staff notifications', () => {
   test('sendInvolvedStaffStatementReminder', async () => {
     const incidentDate = new Date(2019, 1, 12, 15, 45)
-    const submittedDate = new Date(2019, 1, 13, 16, 45)
+    const overdueDate = new Date(2019, 1, 16, 16, 45)
 
     await service.sendInvolvedStaffStatementReminder('user@email.com', {
       involvedName: 'Jane Smith',
       incidentDate,
-      reportSubmittedDate: submittedDate,
+      overdueDate,
     })
 
     expect(client.sendEmail).toBeCalledWith(involvedStaff.REMINDER, 'user@email.com', {
@@ -102,13 +102,13 @@ describe('send involved staff notifications', () => {
 
   test('sendStatementRequest', async () => {
     const incidentDate = new Date(2019, 1, 12, 15, 45)
-    const submittedDate = new Date(2019, 1, 13, 16, 45)
+    const overdueDate = new Date(2019, 1, 16, 16, 45)
 
     await service.sendStatementRequest('user@email.com', {
       reporterName: 'Jane Smith',
       involvedName: 'Thelma Jones',
       incidentDate,
-      reportSubmittedDate: submittedDate,
+      overdueDate,
     })
 
     expect(client.sendEmail).toBeCalledWith(involvedStaff.REQUEST, 'user@email.com', {

--- a/server/services/reportService.test.js
+++ b/server/services/reportService.test.js
@@ -47,11 +47,12 @@ describe('submit', () => {
     involvedStaffService.save.mockReturnValue([])
 
     const now = moment('2019-09-06 21:26:18')
+    const deadline = moment(now).add(3, 'days')
     const result = await service.submit(currentUser, 'booking-1', now)
 
     expect(result).toEqual('form-1')
     expect(involvedStaffService.save).toBeCalledTimes(1)
-    expect(involvedStaffService.save).toBeCalledWith('form-1', now, currentUser)
+    expect(involvedStaffService.save).toBeCalledWith('form-1', now, deadline, currentUser)
 
     expect(incidentClient.submitReport).toBeCalledTimes(1)
     expect(incidentClient.submitReport).toBeCalledWith(currentUser.username, 'booking-1', now.toDate())
@@ -66,17 +67,18 @@ describe('submit', () => {
     ])
 
     const now = moment('2019-09-06 21:26:18')
-    await service.submit(currentUser, 'booking-1', now)
+    const deadline = moment(now).add(3, 'days')
+    await service.submit(currentUser, 'booking-1', now, deadline)
 
     expect(notificationService.sendStatementRequest).toBeCalledTimes(2)
     expect(notificationService.sendStatementRequest.mock.calls).toEqual([
       [
         'user1@example.com',
-        { incidentDate: 'today', involvedName: 'June', reporterName: 'Bob Smith', reportSubmittedDate: now },
+        { incidentDate: 'today', involvedName: 'June', reporterName: 'Bob Smith', overdueDate: deadline },
       ],
       [
         'user3@example.com',
-        { incidentDate: 'today', involvedName: 'Alice', reporterName: 'Bob Smith', reportSubmittedDate: now },
+        { incidentDate: 'today', involvedName: 'Alice', reporterName: 'Bob Smith', overdueDate: deadline },
       ],
     ])
   })


### PR DESCRIPTION
Storing at creation rather than having to derive what it is later. This will make it easier to query whether a statement is overdue in queries and simplifies the reminder sending a bit.