### PR TITLE
DCS-129 marking report as complete

### DIFF
--- a/integration-tests/integration/createIncident/form-submit.spec.js
+++ b/integration-tests/integration/createIncident/form-submit.spec.js
@@ -1,5 +1,5 @@
 const TasklistPage = require('../../pages/tasklistPage')
-const IncidentsPage = require('../../pages/incidentsPage')
+const YourStatementsPage = require('../../pages/yourStatementsPage')
 const SubmittedPage = require('../../pages/submittedPage')
 const { ReportStatus } = require('../../../server/config/types')
 const { expectedPayload } = require('../seedData')
@@ -76,7 +76,7 @@ context('Submit the incident report', () => {
 
     cy.go('back')
 
-    IncidentsPage.verifyOnPage()
+    YourStatementsPage.verifyOnPage()
   })
 
   it('Can exit after completing report and before creating statement', () => {
@@ -96,7 +96,7 @@ context('Submit the incident report', () => {
       .exit()
       .click()
 
-    // Exit location is configurable - in dev this points to incidents page
-    IncidentsPage.verifyOnPage()
+    // Exit location is configurable - in dev this points to / which for this user redirects to 'Your statements'
+    YourStatementsPage.verifyOnPage()
   })
 })

--- a/integration-tests/integration/createIncident/mark-reports-as-complete.spec.js
+++ b/integration-tests/integration/createIncident/mark-reports-as-complete.spec.js
@@ -1,0 +1,51 @@
+const IncidentsPage = require('../../pages/incidentsPage')
+const AllIncidentsPage = require('../../pages/allIncidentsPage')
+
+const { ReportStatus } = require('../../../server/config/types')
+
+context('All incidents page', () => {
+  const bookingId = 1001
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubOffenderDetails', bookingId)
+    cy.task('stubLocations', 'MDI')
+    cy.task('stubOffenders')
+    cy.task('stubLocation', '357591')
+    cy.task('stubUserDetailsRetrieval', 'MR ZAGATO')
+    cy.task('stubUserDetailsRetrieval', 'MRS JONES')
+    cy.task('stubUserDetailsRetrieval', 'Test User')
+  })
+
+  it('After a reviewer completes the final statement, the report is marked as complete', () => {
+    cy.task('stubReviewerLogin')
+    cy.login(bookingId)
+
+    cy.task('seedReport', {
+      status: ReportStatus.SUBMITTED,
+      involvedStaff: [
+        {
+          userId: 'Test User',
+          name: 'Test User name',
+          email: 'Test User@gov.uk',
+        },
+      ],
+    })
+
+    const incidentsPage = IncidentsPage.goTo()
+
+    incidentsPage
+      .allTabs()
+      .then(allTabs => expect(allTabs).to.deep.equal(['All incidents', 'Your statements', 'Your reports']))
+
+    incidentsPage.selectedTab().contains('All incidents')
+
+    const allIncidentsPage = AllIncidentsPage.verifyOnPage()
+
+    {
+      const { date, prisoner, reporter } = allIncidentsPage.getTodoRow(0)
+      prisoner().should('contain', 'Smith, Norman')
+      reporter().should('contain', 'James Stuart')
+      date().should(elem => expect(elem.text()).to.match(/\d{1,2} .* \d{4}/))
+    }
+  })
+})

--- a/integration-tests/integration/createIncident/mark-reports-as-complete.spec.js
+++ b/integration-tests/integration/createIncident/mark-reports-as-complete.spec.js
@@ -1,5 +1,6 @@
-const IncidentsPage = require('../../pages/incidentsPage')
+const YourStatementsPage = require('../../pages/yourStatementsPage')
 const AllIncidentsPage = require('../../pages/allIncidentsPage')
+const SubmittedStatementPage = require('../../pages/submitStatementPage')
 
 const { ReportStatus } = require('../../../server/config/types')
 
@@ -16,7 +17,7 @@ context('All incidents page', () => {
     cy.task('stubUserDetailsRetrieval', 'Test User')
   })
 
-  it('After a reviewer completes the final statement, the report is marked as complete', () => {
+  it('After the final statement is completed, the reviewer can see that the report is marked as complete', () => {
     cy.task('stubReviewerLogin')
     cy.login(bookingId)
 
@@ -31,18 +32,47 @@ context('All incidents page', () => {
       ],
     })
 
-    const incidentsPage = IncidentsPage.goTo()
+    cy.visit('/')
+    let allIncidentsPage = AllIncidentsPage.verifyOnPage()
 
-    incidentsPage
-      .allTabs()
-      .then(allTabs => expect(allTabs).to.deep.equal(['All incidents', 'Your statements', 'Your reports']))
-
-    incidentsPage.selectedTab().contains('All incidents')
-
-    const allIncidentsPage = AllIncidentsPage.verifyOnPage()
+    allIncidentsPage.getTodoRows().should('have.length', 1)
+    allIncidentsPage.getCompleteRows().should('have.length', 0)
 
     {
       const { date, prisoner, reporter } = allIncidentsPage.getTodoRow(0)
+      prisoner().should('contain', 'Smith, Norman')
+      reporter().should('contain', 'James Stuart')
+      date().should(elem => expect(elem.text()).to.match(/\d{1,2} .* \d{4}/))
+    }
+
+    allIncidentsPage.yourStatementsTab().click()
+
+    let yourStatementsPage = YourStatementsPage.verifyOnPage()
+    yourStatementsPage
+      .getTodoRow(0)
+      .startButton()
+      .click()
+
+    const submitStatementPage = SubmittedStatementPage.verifyOnPage()
+    submitStatementPage.lastTrainingMonth().select('March')
+    submitStatementPage.lastTrainingYear().type('2010')
+    submitStatementPage.jobStartYear().type('1999')
+    submitStatementPage.statement().type('This is my statement')
+
+    const confirmStatementPage = submitStatementPage.submit()
+    const statementSubmittedPage = confirmStatementPage.submit()
+    statementSubmittedPage.finish()
+
+    yourStatementsPage = YourStatementsPage.verifyOnPage()
+    yourStatementsPage.allIncidentsTab().click()
+
+    allIncidentsPage = AllIncidentsPage.verifyOnPage()
+
+    allIncidentsPage.getTodoRows().should('have.length', 0)
+    allIncidentsPage.getCompleteRows().should('have.length', 1)
+
+    {
+      const { date, prisoner, reporter } = allIncidentsPage.getCompleteRow(0)
       prisoner().should('contain', 'Smith, Norman')
       reporter().should('contain', 'James Stuart')
       date().should(elem => expect(elem.text()).to.match(/\d{1,2} .* \d{4}/))

--- a/integration-tests/integration/createIncident/view-all-incidents.spec.js
+++ b/integration-tests/integration/createIncident/view-all-incidents.spec.js
@@ -1,4 +1,4 @@
-const IncidentsPage = require('../../pages/incidentsPage')
+const YourStatementsPage = require('../../pages/yourStatementsPage')
 const AllIncidentsPage = require('../../pages/allIncidentsPage')
 
 const { ReportStatus } = require('../../../server/config/types')
@@ -31,15 +31,13 @@ context('All incidents page', () => {
       ],
     })
 
-    const incidentsPage = IncidentsPage.goTo()
+    const allIncidentsPage = AllIncidentsPage.goTo()
 
-    incidentsPage
+    allIncidentsPage
       .allTabs()
       .then(allTabs => expect(allTabs).to.deep.equal(['All incidents', 'Your statements', 'Your reports']))
 
-    incidentsPage.selectedTab().contains('All incidents')
-
-    const allIncidentsPage = AllIncidentsPage.verifyOnPage()
+    allIncidentsPage.selectedTab().contains('All incidents')
 
     {
       const { date, prisoner, reporter } = allIncidentsPage.getTodoRow(0)
@@ -53,10 +51,10 @@ context('All incidents page', () => {
     cy.task('stubLogin')
     cy.login(bookingId)
 
-    const incidentsPage = IncidentsPage.goTo()
+    const yourStatementsPage = YourStatementsPage.goTo()
 
-    incidentsPage.allTabs().then(allTabs => expect(allTabs).to.deep.equal(['Your statements', 'Your reports']))
+    yourStatementsPage.allTabs().then(allTabs => expect(allTabs).to.deep.equal(['Your statements', 'Your reports']))
 
-    incidentsPage.selectedTab().contains('Your statements')
+    yourStatementsPage.selectedTab().contains('Your statements')
   })
 })

--- a/integration-tests/integration/createIncident/view-your-report.spec.js
+++ b/integration-tests/integration/createIncident/view-your-report.spec.js
@@ -1,6 +1,5 @@
-const IncidentsPage = require('../../pages/incidentsPage')
+const YourStatementsPage = require('../../pages/yourStatementsPage')
 const YourReportPage = require('../../pages/yourReportPage')
-
 const YourReportsPage = require('../../pages/yourReportsPage')
 const { ReportStatus } = require('../../../server/config/types')
 
@@ -43,12 +42,12 @@ context('Submit statement', () => {
       ],
     })
 
-    const incidentsPage = IncidentsPage.goTo()
-    incidentsPage.selectedTab().contains('Your statements')
-    incidentsPage.yourReportsTab().click()
-    incidentsPage.selectedTab().contains('Your reports')
+    const yourStatementsPage = YourStatementsPage.goTo()
+    yourStatementsPage.selectedTab().contains('Your statements')
+    yourStatementsPage.yourReportsTab().click()
 
     const yourReportsPage = YourReportsPage.verifyOnPage()
+    yourReportsPage.selectedTab().contains('Your reports')
 
     yourReportsPage
       .getCompleteRow(0)
@@ -64,6 +63,6 @@ context('Submit statement', () => {
 
     yourReportPage.continue().click()
 
-    IncidentsPage.verifyOnPage()
+    YourStatementsPage.verifyOnPage()
   })
 })

--- a/integration-tests/integration/createIncident/view-your-reports.spec.js
+++ b/integration-tests/integration/createIncident/view-your-reports.spec.js
@@ -1,5 +1,5 @@
 const TasklistPage = require('../../pages/tasklistPage')
-const IncidentsPage = require('../../pages/incidentsPage')
+const YourStatementsPage = require('../../pages/yourStatementsPage')
 const YourReportsPage = require('../../pages/yourReportsPage')
 const { ReportStatus } = require('../../../server/config/types')
 
@@ -36,10 +36,10 @@ context('Submit statement', () => {
     newIncidentPage.fillForm()
     newIncidentPage.save()
 
-    const incidentsPage = IncidentsPage.goTo()
-    incidentsPage.selectedTab().contains('Your statements')
-    incidentsPage.yourReportsTab().click()
-    incidentsPage.selectedTab().contains('Your reports')
+    const yourStatementsPage = YourStatementsPage.goTo()
+    yourStatementsPage.selectedTab().contains('Your statements')
+    yourStatementsPage.yourReportsTab().click()
+    yourStatementsPage.selectedTab().contains('Your reports')
 
     const yourReportsPage = YourReportsPage.verifyOnPage()
 

--- a/integration-tests/integration/statements/save-additional-comment.spec.js
+++ b/integration-tests/integration/statements/save-additional-comment.spec.js
@@ -1,7 +1,7 @@
 const SubmittedStatementPage = require('../../pages/submitStatementPage')
 
 const ViewStatementPage = require('../../pages/viewStatementPage')
-const IncidentsPage = require('../../pages/incidentsPage')
+const YourStatementsPage = require('../../pages/yourStatementsPage')
 const ViewAddCommentPage = require('../../pages/addAdditionalCommentPage')
 const { ReportStatus } = require('../../../server/config/types')
 
@@ -29,9 +29,9 @@ context('Add comments to statement', () => {
   it('A user can select a specific statement, add to it and then return back to statements page', () => {
     cy.login(bookingId)
 
-    let incidentsPage = IncidentsPage.goTo()
+    let yourStatementsPage = YourStatementsPage.goTo()
 
-    incidentsPage
+    yourStatementsPage
       .getTodoRow(0)
       .startButton()
       .click()
@@ -44,8 +44,8 @@ context('Add comments to statement', () => {
 
     const confirmStatementPage = submitStatementPage.submit()
     const statementSubmittedPage = confirmStatementPage.submit()
-    incidentsPage = statementSubmittedPage.finish()
-    incidentsPage
+    yourStatementsPage = statementSubmittedPage.finish()
+    yourStatementsPage
       .getCompleteRow(0)
       .viewButton()
       .click()
@@ -58,8 +58,8 @@ context('Add comments to statement', () => {
     viewAddCommentPage.additionalComment().type('Some new comment 1')
     viewAddCommentPage.save().click()
 
-    incidentsPage = IncidentsPage.verifyOnPage()
-    incidentsPage
+    yourStatementsPage = YourStatementsPage.verifyOnPage()
+    yourStatementsPage
       .getCompleteRow(0)
       .viewButton()
       .click()
@@ -73,8 +73,8 @@ context('Add comments to statement', () => {
     viewAddCommentPage.additionalComment(2).type('Some new comment 2')
     viewAddCommentPage.save().click()
 
-    incidentsPage = IncidentsPage.verifyOnPage()
-    incidentsPage
+    yourStatementsPage = YourStatementsPage.verifyOnPage()
+    yourStatementsPage
       .getCompleteRow(0)
       .viewButton()
       .click()
@@ -84,6 +84,6 @@ context('Add comments to statement', () => {
     viewStatementPage.viewAdditionalComment(2).should('contain', 'Some new comment 2')
     viewStatementPage.continue().click()
 
-    IncidentsPage.verifyOnPage()
+    YourStatementsPage.verifyOnPage()
   })
 })

--- a/integration-tests/integration/statements/submit-statement.spec.js
+++ b/integration-tests/integration/statements/submit-statement.spec.js
@@ -1,5 +1,5 @@
 const TasklistPage = require('../../pages/tasklistPage')
-const IncidentsPage = require('../../pages/incidentsPage')
+const YourStatementsPage = require('../../pages/yourStatementsPage')
 const SubmittedPage = require('../../pages/submittedPage')
 const SubmitStatementPage = require('../../pages/submitStatementPage')
 const ViewStatementPage = require('../../pages/viewStatementPage')
@@ -32,8 +32,8 @@ context('Submit statement', () => {
     })
 
     {
-      const incidentsPage = IncidentsPage.goTo()
-      const { date, prisoner, reporter, startButton } = incidentsPage.getTodoRow(0)
+      const yourStatementsPage = YourStatementsPage.goTo()
+      const { date, prisoner, reporter, startButton } = yourStatementsPage.getTodoRow(0)
       prisoner().should('contain', 'Smith, Norman')
       reporter().should('contain', 'James Stuart')
       date().should(elem => expect(elem.text()).to.match(/\d{1,2} .* \d{4}/))
@@ -121,8 +121,8 @@ context('Submit statement', () => {
       ],
     })
 
-    let incidentsPage = IncidentsPage.goTo()
-    incidentsPage
+    let yourStatementsPage = YourStatementsPage.goTo()
+    yourStatementsPage
       .getTodoRow(0)
       .startButton()
       .click()
@@ -141,9 +141,9 @@ context('Submit statement', () => {
 
     const statementSubmittedPage = confirmStatementPage.submit()
 
-    incidentsPage = statementSubmittedPage.finish()
+    yourStatementsPage = statementSubmittedPage.finish()
 
-    incidentsPage
+    yourStatementsPage
       .getCompleteRow(0)
       .viewButton()
       .click()

--- a/integration-tests/pages/allIncidentsPage.js
+++ b/integration-tests/pages/allIncidentsPage.js
@@ -14,7 +14,19 @@ const completeCol = (i, j) =>
 
 const incidentsPage = () =>
   page('Use of force incidents', {
+    getTodoRows: () =>
+      cy
+        .get('[data-qa=incidents-todo]')
+        .find('tbody')
+        .find('tr'),
+    getCompleteRows: () =>
+      cy
+        .get('[data-qa=incidents-complete]')
+        .find('tbody')
+        .find('tr'),
+
     getTodoRow: i => ({
+      row: () => cy.get('[data-qa=incidents-todo]'),
       date: () => todoCol(i, 0),
       prisoner: () => todoCol(i, 1),
       reporter: () => todoCol(i, 2),
@@ -31,15 +43,23 @@ const incidentsPage = () =>
           .invoke('attr', 'href')
           .then(link => link.match(/\/(.*?)\/your-statement/)[1]),
     }),
-
+    allTabs: () =>
+      cy.get(`.govuk-tabs__list-item`).spread((...rest) =>
+        rest.map(element =>
+          Cypress.$(element)
+            .text()
+            .trim()
+        )
+      ),
     selectedTab: () => cy.get('.govuk-tabs__list-item--selected'),
     yourReportsTab: () => cy.get('[data-qa="your-reports-link"]'),
+    yourStatementsTab: () => cy.get('[data-qa="your-statements-link"]'),
   })
 
 export default {
   verifyOnPage: incidentsPage,
   goTo: () => {
-    cy.visit('/')
+    cy.visit('/all-incidents')
     return incidentsPage()
   },
 }

--- a/integration-tests/pages/statementSubmittedPage.js
+++ b/integration-tests/pages/statementSubmittedPage.js
@@ -1,5 +1,5 @@
 const page = require('./page')
-const IncidentsPage = require('./incidentsPage')
+const IncidentsPage = require('./yourStatementsPage')
 
 const submitStatementPage = () =>
   page('Your statement has been submitted', {

--- a/integration-tests/pages/yourStatementsPage.js
+++ b/integration-tests/pages/yourStatementsPage.js
@@ -12,7 +12,7 @@ const completeCol = (i, j) =>
     .find('td')
     .eq(j)
 
-const incidentsPage = () =>
+const yourStatementsPage = () =>
   page('Use of force incidents', {
     getTodoRow: i => ({
       date: () => todoCol(i, 0),
@@ -42,12 +42,13 @@ const incidentsPage = () =>
         )
       ),
     yourReportsTab: () => cy.get('[data-qa="your-reports-link"]'),
+    allIncidentsTab: () => cy.get('[data-qa="all-incidents-link"]'),
   })
 
 export default {
-  verifyOnPage: incidentsPage,
+  verifyOnPage: yourStatementsPage,
   goTo: () => {
-    cy.visit('/')
-    return incidentsPage()
+    cy.visit('/your-statements')
+    return yourStatementsPage()
   },
 }

--- a/server/data/statementsClient.js
+++ b/server/data/statementsClient.js
@@ -11,11 +11,10 @@ const getStatements = (userId, status, query = db.query) => {
             , s."name"
             from statement s 
             inner join report r on s.report_id = r.id   
-          where r.status = $1 
-          and s.user_id = $2 
-          and s.statement_status = $3
+          where s.user_id = $1
+          and s.statement_status = $2
           order by r.incident_date`,
-    values: ['SUBMITTED', userId, status.value],
+    values: [userId, status.value],
   })
 }
 
@@ -98,6 +97,14 @@ const submitStatement = (userId, reportId, query = db.query) => {
   })
 }
 
+const getNumberOfPendingStatements = async reportId => {
+  const { rows } = await db.query({
+    text: `select count(*) from statement where report_id = $1 AND statement_status = $2`,
+    values: [reportId, StatementStatus.PENDING.value],
+  })
+  return parseInt(rows[0].count, 10)
+}
+
 const createStatements = async (reportId, firstReminder, overdueDate, staff, query = db.query) => {
   const rows = staff.map(s => [
     reportId,
@@ -126,4 +133,5 @@ module.exports = {
   submitStatement,
   getAdditionalComments,
   saveAdditionalComment,
+  getNumberOfPendingStatements,
 }

--- a/server/data/statementsClient.test.js
+++ b/server/data/statementsClient.test.js
@@ -19,11 +19,10 @@ test('getStatements', () => {
             , s."name"
             from statement s 
             inner join report r on s.report_id = r.id   
-          where r.status = $1 
-          and s.user_id = $2 
-          and s.statement_status = $3
+          where s.user_id = $1
+          and s.statement_status = $2
           order by r.incident_date`,
-    values: [ReportStatus.SUBMITTED.value, 'user1', StatementStatus.PENDING.value],
+    values: ['user1', StatementStatus.PENDING.value],
   })
 })
 
@@ -119,5 +118,14 @@ test('submitStatement', () => {
     and report_id = $3
     and statement_status = $4`,
     values: [StatementStatus.SUBMITTED.value, 'user1', 'incident1', StatementStatus.PENDING.value],
+  })
+})
+
+test('getNumberOfPendingStatements', () => {
+  statementsClient.getNumberOfPendingStatements('report1')
+
+  expect(db.query).toBeCalledWith({
+    text: `select count(*) from statement where report_id = $1 AND statement_status = $2`,
+    values: ['report1', StatementStatus.PENDING.value],
   })
 })

--- a/server/data/statementsClient.test.js
+++ b/server/data/statementsClient.test.js
@@ -1,6 +1,6 @@
 const statementsClient = require('./statementsClient')
 const db = require('./dataAccess/db')
-const { ReportStatus, StatementStatus } = require('../config/types')
+const { StatementStatus } = require('../config/types')
 
 jest.mock('../../server/data/dataAccess/db')
 

--- a/server/index.js
+++ b/server/index.js
@@ -29,7 +29,7 @@ const reportService = createReportService({
   involvedStaffService,
   notificationService,
 })
-const statementService = createStatementService({ statementsClient })
+const statementService = createStatementService({ statementsClient, incidentClient })
 
 const app = createApp({
   involvedStaffService,

--- a/server/middleware/authorisationMiddleware.test.js
+++ b/server/middleware/authorisationMiddleware.test.js
@@ -52,4 +52,3 @@ describe('authorisationMiddleware', () => {
     expect(res.locals.user.isReviewer).toEqual(false)
   })
 })
- 

--- a/server/middleware/authorisationMiddleware.test.js
+++ b/server/middleware/authorisationMiddleware.test.js
@@ -52,3 +52,4 @@ describe('authorisationMiddleware', () => {
     expect(res.locals.user.isReviewer).toEqual(false)
   })
 })
+ 

--- a/server/routes/incidents.js
+++ b/server/routes/incidents.js
@@ -47,8 +47,11 @@ module.exports = function CreateReportRoutes({ reportService, involvedStaffServi
     },
 
     viewYourReports: async (req, res) => {
-      const awaiting = await reportService.getReports(req.user.username, ReportStatus.IN_PROGRESS)
-      const completed = await reportService.getReports(req.user.username, ReportStatus.SUBMITTED)
+      const awaiting = await reportService.getReports(req.user.username, [ReportStatus.IN_PROGRESS])
+      const completed = await reportService.getReports(req.user.username, [
+        ReportStatus.SUBMITTED,
+        ReportStatus.COMPLETE,
+      ])
 
       const namesByOffenderNumber = await getOffenderNames(res.locals.user.token, [...awaiting, ...completed])
       const awaitingReports = awaiting.map(toReport(namesByOffenderNumber))

--- a/server/services/reportService.test.js
+++ b/server/services/reportService.test.js
@@ -107,9 +107,9 @@ describe('getReport', () => {
 describe('getReports', () => {
   test('it should call query on db', async () => {
     incidentClient.getReports.mockReturnValue({ rows: [{ id: 1 }] })
-    const result = await service.getReports('user1', ReportStatus.SUBMITTED)
+    const result = await service.getReports('user1', [ReportStatus.SUBMITTED])
     expect(result).toEqual([{ id: 1 }])
-    expect(incidentClient.getReports).toBeCalledWith('user1', ReportStatus.SUBMITTED)
+    expect(incidentClient.getReports).toBeCalledWith('user1', [ReportStatus.SUBMITTED])
   })
 })
 

--- a/server/views/pages/statement/statement-submitted.html
+++ b/server/views/pages/statement/statement-submitted.html
@@ -15,7 +15,7 @@
     govukButton({
       text: "Finish",
       name: "submit",
-      href: '/',
+      href: '/your-statements',
       classes: "govuk-button govuk-button govuk-!-margin-top-8",
       attributes: {'data-qa': 'finish'}
     })


### PR DESCRIPTION
Once all statements are complete, we need to mark the report as complete
This will mean that reviewers will be able to see the report in their
completed list.

Having to change the getreports query as once a report is complete, it
then would disappear from the reporters list of completed reports