### PR TITLE
DCS-115: Browser page tab displays the same message as page title

### DIFF
--- a/server/routes/reportUseOfForce.js
+++ b/server/routes/reportUseOfForce.js
@@ -8,6 +8,7 @@ module.exports = function ReportUseOfForceRoutes({ reportService, offenderServic
       )
       const { form = {} } = await reportService.getCurrentDraft(req.user.username, bookingId)
       const status = reportService.getReportStatus(form)
+
       res.render('pages/report-use-of-force', {
         data: { ...res.locals.formObject, displayName, offenderNo, dateOfBirth },
         bookingId: req.params.bookingId,

--- a/server/views/formPages/incident/evidence.html
+++ b/server/views/formPages/incident/evidence.html
@@ -8,10 +8,12 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 
+{% set pageTitle = 'Evidence' %}
+
 {% block formItems %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <h1 class="govuk-heading-xl mainHeading">Evidence</h1>
+      <h1 class="govuk-heading-xl mainHeading">{{ pageTitle }} </h1>
 
       <!-- Q1 -->
       <div class="govuk-!-margin-bottom-9 govuk-form-group

--- a/server/views/formPages/incident/incidentDetails.html
+++ b/server/views/formPages/incident/incidentDetails.html
@@ -4,11 +4,14 @@
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %} 
+
+{% set pageTitle = 'Incident details' %}
+
 {% block formItems %}
 <div class="govuk-body">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <h1 class="govuk-heading-xl mainHeading">Incident details</h1>
+      <h1 class="govuk-heading-xl mainHeading">{{ pageTitle }}</h1>
       <div class="govuk-!-margin-bottom-6">
         <p class="govuk-!-margin-bottom-1">
           <span class="govuk-label--s">Prisoner:&nbsp;</span>

--- a/server/views/formPages/incident/relocationAndInjuries.html
+++ b/server/views/formPages/incident/relocationAndInjuries.html
@@ -8,12 +8,12 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
-
+{% set pageTitle = 'Relocation and injuries' %}
 {% block formItems %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full govuk-!-margin-bottom-6">
-    <h1 class="govuk-heading-xl mainHeading">Relocation and injuries</h1>
+    <h1 class="govuk-heading-xl mainHeading">{{ pageTitle }}</h1>
 
 
 

--- a/server/views/formPages/incident/useOfForceDetails.html
+++ b/server/views/formPages/incident/useOfForceDetails.html
@@ -5,11 +5,13 @@
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% import "../incidentMacros.njk" as incidentMacro %}
 
+{% set pageTitle = 'Use of force details' %}
+
 {% block formItems %}
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-xl mainHeading">Use of force details</h1>
+    <h1 class="govuk-heading-xl mainHeading">{{ pageTitle }}</h1>
 
     {% set yesNoOptions = [{
         value: true,

--- a/server/views/formPages/incident/username-does-not-exist.html
+++ b/server/views/formPages/incident/username-does-not-exist.html
@@ -2,6 +2,8 @@
 {% from "govuk/components/button/macro.njk" import govukButton %} 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %} 
 
+{% set pageTitle = 'A username you have entered does not exist' %}
+
 {% block beforeContent %}
 
 {{ govukBackLink({
@@ -14,7 +16,7 @@ href: backLink or "/"
 {% block content %}
 <div class="govuk-grid-row govuk-body">
   <div class="govuk-grid-column-three-quarters govuk-!-margin-bottom-4">
-    <h1 class="govuk-heading-xl">A username you have entered does not exist</h1>
+    <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
 
     <p>
       You have entered a username which does not exist:

--- a/server/views/pages/check-your-answers.html
+++ b/server/views/pages/check-your-answers.html
@@ -12,10 +12,14 @@ text: "Back",
 href: backLink or "/"
 }) }}
 
-{% endblock %} {% block content %}
+{% endblock %} 
+
+{% set pageTitle = 'Check your answers before sending the report' %}
+
+{% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters govuk-!-margin-bottom-9 ">
-    <h1 class="govuk-heading-xl">Check your answers before sending the report</h1>
+    <h1 class="govuk-heading-xl"> {{pageTitle}} </h1>
 
     {{
       pagesMacros.sectionHeading({

--- a/server/views/pages/error.html
+++ b/server/views/pages/error.html
@@ -1,5 +1,7 @@
 {% extends "../partials/layout.html" %}
 
+{% set pageTitle = message %}
+
 {% block content %}
 
   <main class="app-container">

--- a/server/views/pages/report-sent.html
+++ b/server/views/pages/report-sent.html
@@ -2,6 +2,8 @@
 {% from "govuk/components/button/macro.njk" import govukButton %} 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %} 
 
+{% set pageTitle = 'This report has been sent to the use of force coordinator' %}
+
 {% block beforeContent %}
 {{ govukBackLink({
   text: "Back",
@@ -12,9 +14,7 @@
 <div class="govuk-grid-row govuk-body">
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-panel info-panel">
-      <h1 class="govuk-panel__title">
-        This report has been sent to the use of force coordinator
-      </h1>
+      <h1 class="govuk-panel__title"> {{ pageTitle }} </h1>
     </div>
 
     <p>You need to write your statement.</p>

--- a/server/views/pages/report-use-of-force.html
+++ b/server/views/pages/report-use-of-force.html
@@ -1,5 +1,7 @@
 {% extends "../partials/layout.html" %}
 
+{% set pageTitle = 'Report use of force' %}
+
 {% macro section(name, label, url, value) %}
 <li class="app-task-list__item" data-qa-{{name}}={{value}}>
   {% if url %}
@@ -25,7 +27,7 @@
 {% endmacro %}
 
 {% block content %}
-<h1 class="govuk-heading-xl mainHeading">Report use of force</h1>
+<h1 class="govuk-heading-xl mainHeading">{{ pageTitle }}</h1>
 <div class="govuk-grid-row govuk-body">
   <hr />
   <div class="govuk-grid-column-one-third">

--- a/server/views/pages/statement/add-comment-to-statement.html
+++ b/server/views/pages/statement/add-comment-to-statement.html
@@ -6,6 +6,7 @@
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% set pageTitle = 'Add a comment to your statement' %}
 
 {% block content %}
 <div class="govuk-body">
@@ -18,7 +19,7 @@
     })
   }}
   {% endif %}
-  <h1 class="govuk-heading-xl mainHeading">Add a comment to your statement</h1>
+  <h1 class="govuk-heading-xl mainHeading">{{ pageTitle }}</h1>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full ">

--- a/server/views/pages/statement/check-your-statement.html
+++ b/server/views/pages/statement/check-your-statement.html
@@ -7,9 +7,11 @@
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %} 
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %} 
 
+{% set pageTitle = 'Check your statement before submitting it' %}
+
 {% block content %}
 <div class="govuk-body">
-  <h1 class="govuk-heading-xl mainHeading">Check your statement before submitting it</h1>
+  <h1 class="govuk-heading-xl mainHeading">{{ pageTitle }} </h1>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full ">

--- a/server/views/pages/statement/statement-submitted.html
+++ b/server/views/pages/statement/statement-submitted.html
@@ -2,12 +2,14 @@
 {% from "govuk/components/button/macro.njk" import govukButton %} 
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 
+{% set pageTitle = 'Your statement has been submitted' %}
+
 {% block content %}
 
 {{
     govukPanel({
         classes: "govuk-!-width-one-half",
-        titleText: "Your statement has been submitted"
+        titleText:  pageTitle 
     }) 
 }}  
 

--- a/server/views/pages/statement/write-your-statement.html
+++ b/server/views/pages/statement/write-your-statement.html
@@ -7,6 +7,8 @@
 {% from "govuk/components/checkboxes/macro.njk"import govukCheckboxes %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
+{% set pageTitle = 'Your use of force statement' %}
+
 {% block content %}
 <div class="govuk-body">
   {% if errors.length > 0 %}

--- a/server/views/pages/statement/your-statement.html
+++ b/server/views/pages/statement/your-statement.html
@@ -6,6 +6,7 @@
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% set pageTitle = 'Your use of force statement' %}
 
 {% block content %}
 <div class="govuk-body">
@@ -18,7 +19,7 @@
     })
   }}
   {% endif %}
-  <h1 class="govuk-heading-xl mainHeading">Your use of force statement</h1>
+  <h1 class="govuk-heading-xl mainHeading">{{ pageTitle }}</h1>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full ">

--- a/server/views/pages/your-report.html
+++ b/server/views/pages/your-report.html
@@ -5,6 +5,7 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% import "./pagesMacros.njk" as pagesMacros %} 
 
+{% set pageTitle = 'Use of force report' %}
 {% block beforeContent %}
 
 {{ govukBackLink({
@@ -15,7 +16,7 @@ href: backLink or "/"
 {% endblock %} {% block content %}
 <div class="govuk-grid-row govuk-body">
   <div class="govuk-grid-column-three-quarters govuk-!-margin-bottom-9 ">
-    <h1 class="govuk-heading-xl">Use of force report</h1>
+    <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
         <div class="govuk-!-margin-bottom-1">

--- a/server/views/partials/incidentPage.html
+++ b/server/views/partials/incidentPage.html
@@ -1,7 +1,9 @@
 {% extends "./layout.html" %} 
 
+{% set pageTitle = 'Use of force incidents' %}
+
     {% block content %}
-    <h1 class="govuk-heading-xl mainHeading">Use of force incidents</h1>
+    <h1 class="govuk-heading-xl mainHeading">{{ pageTitle }}</h1>
 
     <div class="govuk-tabs">
     <h2 class="govuk-tabs__title">

--- a/server/views/partials/layout.html
+++ b/server/views/partials/layout.html
@@ -1,7 +1,9 @@
 {% extends "govuk/template.njk" %}
 
+{% set pageTitle = pageTitle | default('GOV.UK - Use of force') %}
+
 {% block pageTitle %}
-  {{ pageTitle }}
+{{ pageTitle }}
 {% endblock %}
 
 {% block head %}


### PR DESCRIPTION
The browser tab was a generic GOV.UK statement previously. Have now matched it to the title of the page the tab relates to.
Have applied a generic tab message of 'GOV.UK - Use of force' as a default should there ever be a page where the title isn't set using Nunjucks