### PR TITLE
DCS-151 Correcting navigation around statements

### DIFF
--- a/server/routes/statements.js
+++ b/server/routes/statements.js
@@ -146,19 +146,6 @@ module.exports = function CreateReportRoutes({ statementService, offenderService
       })
     },
 
-    saveAdditionalComment: async (req, res) => {
-      const { reportId } = req.params
-      const statement = await statementService.getStatementForUser(
-        req.user.username,
-        reportId,
-        StatementStatus.SUBMITTED
-      )
-      if (req.body.additionalComment && req.body.additionalComment.trim().length) {
-        await statementService.saveAdditionalComment(statement.id, req.body.additionalComment)
-      }
-      return res.redirect(`/`)
-    },
-
     viewAddCommentToStatement: async (req, res) => {
       const { reportId } = req.params
       const statement = await statementService.getStatementForUser(
@@ -169,9 +156,6 @@ module.exports = function CreateReportRoutes({ statementService, offenderService
       const offenderDetail = await offenderService.getOffenderDetails(res.locals.user.token, statement.bookingId)
       const { displayName, offenderNo } = offenderDetail
 
-      if (req.body.additionalComment && req.body.additionalComment.trim().length) {
-        await statementService.saveAdditionalComment(statement.id, req.body.additionalComment)
-      }
       return res.render('pages/statement/add-comment-to-statement', {
         data: {
           reportId,
@@ -181,6 +165,19 @@ module.exports = function CreateReportRoutes({ statementService, offenderService
           lastTrainingMonth: moment.months(statement.lastTrainingMonth),
         },
       })
+    },
+
+    saveAdditionalComment: async (req, res) => {
+      const { reportId } = req.params
+      const statement = await statementService.getStatementForUser(
+        req.user.username,
+        reportId,
+        StatementStatus.SUBMITTED
+      )
+      if (req.body.additionalComment && req.body.additionalComment.trim().length) {
+        await statementService.saveAdditionalComment(statement.id, req.body.additionalComment)
+      }
+      return res.redirect(`/your-statements`)
     },
   }
 }

--- a/server/routes/statements.test.js
+++ b/server/routes/statements.test.js
@@ -121,7 +121,7 @@ describe('POST /:reportId/add-comment-to-statement', () => {
       .post('/-1/add-comment-to-statement')
       .send('additionalComment=statement1&submit=true')
       .expect(302)
-      .expect('Location', '/')
+      .expect('Location', '/your-statements')
       .expect(() => {
         expect(statementService.saveAdditionalComment).toBeCalledWith(1, 'statement1')
       }))

--- a/server/views/pages/statement/your-statement.html
+++ b/server/views/pages/statement/your-statement.html
@@ -89,7 +89,7 @@
       govukButton({
         text: 'Continue',
         name: 'continue',
-        href: '/',
+        href: '/your-statements',
         classes: 'govuk-button  govuk-!-margin-top-5',
         attributes: { 'data-qa': 'continue' }
       })


### PR DESCRIPTION
Navigation around viewing statements and adding comments did not really make sense for reviewer as in a few places it was redirecting to `/` - which for reviewers means `/all-incidents`.

These have been changed to /your-statements as the user will be in viewing and modifying statements mode.