### PR TITLE
DCS-119 Add edit navigation to check-your-answers

### DIFF
--- a/integration-tests/integration/reportPages/check-your-answers.spec.js
+++ b/integration-tests/integration/reportPages/check-your-answers.spec.js
@@ -1,0 +1,210 @@
+const TasklistPage = require('../../pages/tasklistPage')
+const UserDoesNotExistPage = require('../../pages/userDoesNotExistPage')
+const CheckAnswersPage = require('../../pages/checkAnswersPage')
+
+const IncidentDetailsPage = require('../../pages/newIncidentPage')
+const UseOfForceDetailsPage = require('../../pages/detailsPage')
+const RelocationAndInjuriesPage = require('../../pages/relocationAndInjuriesPage')
+const EvidencePage = require('../../pages/evidencePage')
+
+const { ReportStatus } = require('../../../server/config/types')
+
+context('Check your answers page', () => {
+  const bookingId = 1001
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubOffenderDetails', bookingId)
+    cy.task('stubLocations', 'MDI')
+    cy.task('stubOffenders')
+    cy.task('stubLocation', '357591')
+    cy.task('stubUserDetailsRetrieval', 'MR_ZAGATO')
+    cy.task('stubUserDetailsRetrieval', 'MRS_JONES')
+    cy.task('stubUserDetailsRetrieval', 'Test User')
+
+    cy.task('seedReport', {
+      status: ReportStatus.IN_PROGRESS,
+      involvedStaff: [],
+    })
+  })
+
+  it('Can edit answers from check your answers page ', () => {
+    cy.task('stubLogin')
+    cy.login(bookingId)
+
+    const tasklistPage = TasklistPage.visit(bookingId)
+    const checkAnswersPage = tasklistPage.goToAnswerPage()
+
+    canEditIncidentDetailsPage({
+      checkAnswersPage,
+      initialValue: 'Yes',
+      operation: page => page.clickSave(),
+      finalValue: 'No',
+    })
+
+    canEditUseOfForceDetailsPage({
+      checkAnswersPage,
+      initialValue: 'Yes',
+      operation: page => page.clickSave(),
+      finalValue: 'No',
+    })
+
+    canEditRelocationAndInjuriesPage({
+      checkAnswersPage,
+      initialValue: 'Yes',
+      operation: page => page.clickSave(),
+      finalValue: 'No',
+    })
+
+    canEditEvidencePage({
+      checkAnswersPage,
+      initialValue: 'Yes',
+      operation: page => page.clickSave(),
+      finalValue: 'No',
+    })
+  })
+
+  it('Can cancel editing answers from check your answers page ', () => {
+    cy.task('stubLogin')
+    cy.login(bookingId)
+
+    const tasklistPage = TasklistPage.visit(bookingId)
+    const checkAnswersPage = tasklistPage.goToAnswerPage()
+
+    canEditIncidentDetailsPage({
+      checkAnswersPage,
+      initialValue: 'Yes',
+      operation: page => page.clickCancel(),
+      finalValue: 'Yes',
+    })
+
+    canEditUseOfForceDetailsPage({
+      checkAnswersPage,
+      initialValue: 'Yes',
+      operation: page => page.clickCancel(),
+      finalValue: 'Yes',
+    })
+
+    canEditRelocationAndInjuriesPage({
+      checkAnswersPage,
+      initialValue: 'Yes',
+      operation: page => page.clickCancel(),
+      finalValue: 'Yes',
+    })
+
+    canEditEvidencePage({
+      checkAnswersPage,
+      initialValue: 'Yes',
+      operation: page => page.clickCancel(),
+      finalValue: 'Yes',
+    })
+  })
+
+  const canEditIncidentDetailsPage = ({ checkAnswersPage, initialValue, operation, finalValue }) => {
+    checkAnswersPage.useOfForcePlanned().contains(initialValue)
+    checkAnswersPage.editIncidentDetailsLink().click()
+    const incidentDetailsPage = IncidentDetailsPage.verifyOnPage()
+    incidentDetailsPage.forceType.check('false')
+    operation(incidentDetailsPage)
+    const revisitedAnswersPage = CheckAnswersPage.verifyOnPage()
+    revisitedAnswersPage.useOfForcePlanned().contains(finalValue)
+  }
+
+  const canEditUseOfForceDetailsPage = ({ checkAnswersPage, initialValue, operation, finalValue }) => {
+    checkAnswersPage.positiveCommunicationUsed().contains(initialValue)
+    checkAnswersPage.editUseOfForceDetailsLink().click()
+    const useOfForceDetailsPage = UseOfForceDetailsPage.verifyOnPage()
+    useOfForceDetailsPage.postiveCommunication().check('false')
+    operation(useOfForceDetailsPage)
+    const revisitedAnswersPage = CheckAnswersPage.verifyOnPage()
+    revisitedAnswersPage.positiveCommunicationUsed().contains(finalValue)
+  }
+
+  const canEditRelocationAndInjuriesPage = ({ checkAnswersPage, initialValue, operation, finalValue }) => {
+    checkAnswersPage.prisonerCompliant().contains(initialValue)
+    checkAnswersPage.editRelocationAndInjuriesLink().click()
+    const relocationAndInjuriesPage = RelocationAndInjuriesPage.verifyOnPage()
+    relocationAndInjuriesPage.prisonerCompliant().check('false')
+    operation(relocationAndInjuriesPage)
+    const revisitedAnswersPage = CheckAnswersPage.verifyOnPage()
+    revisitedAnswersPage.prisonerCompliant().contains(finalValue)
+  }
+
+  const canEditEvidencePage = ({ checkAnswersPage, initialValue, operation, finalValue }) => {
+    checkAnswersPage.photosTaken().contains(initialValue)
+    checkAnswersPage.editEvidenceLink().click()
+    const evidencePage = EvidencePage.verifyOnPage()
+    evidencePage.photosTaken().check('false')
+    operation(evidencePage)
+    const revisitedAnswersPage = CheckAnswersPage.verifyOnPage()
+    revisitedAnswersPage.photosTaken().contains(finalValue)
+  }
+
+  describe('Redirect logic around adding invalid staff to incident details whilst editting ', () => {
+    it('Attempt to save invalid staff', () => {
+      cy.task('stubLogin')
+      cy.login(bookingId)
+
+      const tasklistPage = TasklistPage.visit(bookingId)
+      const checkAnswersPage = tasklistPage.goToAnswerPage()
+      checkAnswersPage.editIncidentDetailsLink().click()
+      let incidentDetailsPage = IncidentDetailsPage.verifyOnPage()
+
+      // attempt to enter invalid user
+      incidentDetailsPage
+        .staffInvolved(0)
+        .name()
+        .type('AAAA')
+      incidentDetailsPage.clickSave()
+
+      // prevented from leaving without addressing issue
+      let userDoesNotExistPage = UserDoesNotExistPage.verifyOnPage()
+
+      // return back to incident page, don't do anything and try again
+      userDoesNotExistPage.return().click()
+      incidentDetailsPage = IncidentDetailsPage.verifyOnPage()
+      incidentDetailsPage.clickSave()
+
+      // Still prevented from leaving with out fixing issues
+      userDoesNotExistPage = UserDoesNotExistPage.verifyOnPage()
+      // fix issue
+      userDoesNotExistPage.continue().click()
+
+      // allowed through and correctly redirect to check-your-answers
+      CheckAnswersPage.verifyOnPage()
+    })
+
+    it('Still need to resolve invalid staff, even if cancelling out half way', () => {
+      cy.task('stubLogin')
+      cy.login(bookingId)
+
+      const tasklistPage = TasklistPage.visit(bookingId)
+      const checkAnswersPage = tasklistPage.goToAnswerPage()
+      checkAnswersPage.editIncidentDetailsLink().click()
+      let incidentDetailsPage = IncidentDetailsPage.verifyOnPage()
+
+      // attempt to enter invalid user
+      incidentDetailsPage
+        .staffInvolved(0)
+        .name()
+        .type('AAAA')
+      incidentDetailsPage.clickSave()
+
+      // prevented from leaving without addressing issue
+      let userDoesNotExistPage = UserDoesNotExistPage.verifyOnPage()
+
+      // return back to incident page, don't do anything and try to cancel
+      userDoesNotExistPage.return().click()
+      incidentDetailsPage = IncidentDetailsPage.verifyOnPage()
+      incidentDetailsPage.clickCancel()
+
+      // Still prevented from leaving with out fixing issues
+      userDoesNotExistPage = UserDoesNotExistPage.verifyOnPage()
+
+      // fix issue
+      userDoesNotExistPage.continue().click()
+
+      // allowed through and correctly redirect to check-your-answers
+      CheckAnswersPage.verifyOnPage()
+    })
+  })
+})

--- a/integration-tests/integration/reportPages/enter-use-of-force-details.spec.js
+++ b/integration-tests/integration/reportPages/enter-use-of-force-details.spec.js
@@ -1,5 +1,5 @@
 const TasklistPage = require('../../pages/tasklistPage')
-const useOfForceDetailsPageFactory = require('../../pages/detailsPage')
+const UseOfForceDetailsPage = require('../../pages/detailsPage')
 
 context('Submitting details page form', () => {
   const bookingId = 1001
@@ -82,7 +82,7 @@ context('Submitting details page form', () => {
     const relocationAndInjuriesPage = fillFormAndSave({ restraintPositions: ['STANDING', 'KNEELING'] })
     relocationAndInjuriesPage.back().click()
 
-    const detailsPage = useOfForceDetailsPageFactory()
+    const detailsPage = UseOfForceDetailsPage.verifyOnPage()
     detailsPage.postiveCommunication().should('have.value', 'true')
     detailsPage.personalProtectionTechniques().should('have.value', 'true')
     detailsPage.batonDrawn().should('have.value', 'true')

--- a/integration-tests/pages/checkAnswersPage.js
+++ b/integration-tests/pages/checkAnswersPage.js
@@ -2,9 +2,19 @@ const page = require('./page')
 
 const clickSubmit = () => cy.get('[data-submit]').click()
 
-export default () =>
+const checkAnswersPage = () =>
   page('Check your answers before sending the report', {
-    verifyInputs: () => {
+    editIncidentDetailsLink: () => cy.get('[data-qa="incidentDetails-link"'),
+    editUseOfForceDetailsLink: () => cy.get('[data-qa="useOfForceDetails-link"'),
+    editRelocationAndInjuriesLink: () => cy.get('[data-qa="relocationAndInjuries-link"'),
+    editEvidenceLink: () => cy.get('[data-qa="evidence-link"'),
+
+    useOfForcePlanned: () => cy.get('[data-qa="incidentType"]'),
+    positiveCommunicationUsed: () => cy.get('[data-qa="positiveCommunication"]'),
+    prisonerCompliant: () => cy.get('[data-qa="compliancy"]'),
+    photosTaken: () => cy.get('[data-qa="photographs"]'),
+
+    verifyInputs() {
       cy.get('[data-qa="incidentDate"]')
         .invoke('text')
         .invoke('trim')
@@ -14,7 +24,7 @@ export default () =>
         .invoke('trim')
         .should('match', /\d{2}:\d{2}/)
       cy.get('[data-qa="location"]').contains('ASSO A Wing')
-      cy.get('[data-qa="incidentType"]').contains('Yes')
+      this.useOfForcePlanned().contains('Yes')
       cy.get('[data-qa="staffInvolved"]')
         .contains('MR_ZAGATO')
         .contains('MRS_JONES')
@@ -22,7 +32,7 @@ export default () =>
         .contains('Witness A')
         .contains('Tom Jones')
 
-      cy.get('[data-qa="positiveCommunication"]').contains('Yes')
+      this.positiveCommunicationUsed().contains('Yes')
       cy.get('[data-qa="personalProtection"]').contains('Yes')
       cy.get('[data-qa="batonDrawn"]').contains('Yes and used')
       cy.get('[data-qa="pavaDrawn"]').contains('Yes and used')
@@ -30,7 +40,7 @@ export default () =>
       cy.get('[data-qa="restraintUsed"]').contains('Yes - standing, on back, face down, kneeling')
 
       cy.get('[data-qa="prisonerRelocation"]').contains('Segregation unit')
-      cy.get('[data-qa="compliancy"]').contains('Yes')
+      this.prisonerCompliant().contains('Yes')
       cy.get('[data-qa="healthcareStaffPresent"]').contains('Dr Smith')
       cy.get('[data-qa="f213"]').contains('Dr Taylor')
       cy.get('[data-qa="prisonerHospitalisation"]').contains('Yes')
@@ -49,7 +59,7 @@ export default () =>
         .contains('This evidence was collected from the prisoner 2')
         .contains('Bagged evidence 3')
         .contains('Clothes samples')
-      cy.get('[data-qa="photographs"]').contains('Yes')
+      this.photosTaken().contains('Yes')
       cy.get('[data-qa="cctv"]').contains('Not known')
       cy.get('[data-qa="bodyCameras"]').contains('Yes - 123, 789, 456')
     },
@@ -57,3 +67,5 @@ export default () =>
     clickSubmit,
     backToTasklist: () => cy.get('[data-qa="return-to-tasklist"]'),
   })
+
+export default { verifyOnPage: checkAnswersPage }

--- a/integration-tests/pages/detailsPage.js
+++ b/integration-tests/pages/detailsPage.js
@@ -1,7 +1,7 @@
 const page = require('./page')
-const relocationAndInjuriesPage = require('./relocationAndInjuriesPage')
+const RelocationAndInjuriesPage = require('./relocationAndInjuriesPage')
 
-export default () =>
+const useOfForceDetailsPage = () =>
   page('Use of force details', {
     postiveCommunication: () => cy.get('[name="positiveCommunication"]'),
     personalProtectionTechniques: () => cy.get('[name="personalProtectionTechniques"]'),
@@ -46,16 +46,17 @@ export default () =>
       return cy.get('.govuk-error-summary')
     },
 
-    clickSave() {
-      cy.get('[data-qa="save-and-continue"]').click()
-    },
+    clickSave: () => cy.get('[data-qa="save-and-continue"]').click(),
+    clickCancel: () => cy.get('[data-qa="cancel"]').click(),
 
     save() {
       this.clickSave()
-      return relocationAndInjuriesPage()
+      return RelocationAndInjuriesPage.verifyOnPage()
     },
 
     saveAndReturnToUseOfForce() {
       return cy.get('[data-qa="save-and-return"]').click()
     },
   })
+
+export default { verifyOnPage: useOfForceDetailsPage }

--- a/integration-tests/pages/evidencePage.js
+++ b/integration-tests/pages/evidencePage.js
@@ -1,9 +1,10 @@
 const page = require('./page')
-const checkAnswersPage = require('./checkAnswersPage')
+const CheckAnswersPage = require('./checkAnswersPage')
 
-export default () =>
+const evidencePage = () =>
   page('Evidence', {
-    fillForm: () => {
+    photosTaken: () => cy.get('[name="photographsTaken"]'),
+    fillForm() {
       cy.get('[name="baggedEvidence"]').check('true')
       cy.get('[name="evidenceTagAndDescription[0][evidenceTagReference]"]').type('Bagged evidence 1')
       cy.get('[name="evidenceTagAndDescription[0][description]"]').type(
@@ -17,7 +18,7 @@ export default () =>
       cy.get('[data-qa-add-another-tag = true]').click()
       cy.get('[name="evidenceTagAndDescription[2][evidenceTagReference]"]').type('Bagged evidence 3')
       cy.get('[name="evidenceTagAndDescription[2][description]"]').type('Clothes samples')
-      cy.get('[name="photographsTaken"]').check('true')
+      this.photosTaken().check('true')
       cy.get('[name="cctvRecording"]').check('NOT_KNOWN')
       cy.get('[name="bodyWornCamera"]').check('YES')
       cy.get('[name="bodyWornCameraNumbers[0][cameraNum]"]').type('123')
@@ -34,6 +35,10 @@ export default () =>
 
     save: () => {
       cy.get('[data-qa="save-and-continue"]').click()
-      return checkAnswersPage()
+      return CheckAnswersPage.verifyOnPage()
     },
+    clickSave: () => cy.get('[data-qa="save-and-continue"]').click(),
+    clickCancel: () => cy.get('[data-qa="cancel"]').click(),
   })
+
+export default { verifyOnPage: evidencePage }

--- a/integration-tests/pages/newIncidentPage.js
+++ b/integration-tests/pages/newIncidentPage.js
@@ -1,5 +1,5 @@
 const page = require('./page')
-const detailsPage = require('./detailsPage')
+const UseOfForceDetailsPage = require('./detailsPage')
 
 const incidentDetailsPage = () =>
   page('Incident details', {
@@ -70,10 +70,10 @@ const incidentDetailsPage = () =>
 
     save: () => {
       cy.get('[data-qa="save-and-continue"]').click()
-      return detailsPage()
+      return UseOfForceDetailsPage.verifyOnPage()
     },
-
     clickSave: () => cy.get('[data-qa="save-and-continue"]').click(),
+    clickCancel: () => cy.get('[data-qa="cancel"]').click(),
   })
 
 export default { verifyOnPage: incidentDetailsPage }

--- a/integration-tests/pages/relocationAndInjuriesPage.js
+++ b/integration-tests/pages/relocationAndInjuriesPage.js
@@ -1,11 +1,12 @@
 const page = require('./page')
-const evidencePage = require('./evidencePage')
+const EvidencePage = require('./evidencePage')
 
-export default () =>
+const relocationAndInjuriesPage = () =>
   page('Relocation and injuries', {
-    fillForm: () => {
+    prisonerCompliant: () => cy.get('[name="relocationCompliancy"]'),
+    fillForm() {
       cy.get('[name="prisonerRelocation"]').select('Segregation unit')
-      cy.get('[name="relocationCompliancy"]').check('true')
+      this.prisonerCompliant().check('true')
       cy.get('[name="healthcareInvolved"]').check('true')
       cy.get('[name="healthcarePractionerName"]').type('Dr Smith')
       cy.get('[name="prisonerInjuries"]').check('true')
@@ -26,6 +27,10 @@ export default () =>
     },
     save: () => {
       cy.get('[data-qa="save-and-continue"]').click()
-      return evidencePage()
+      return EvidencePage.verifyOnPage()
     },
+    clickSave: () => cy.get('[data-qa="save-and-continue"]').click(),
+    clickCancel: () => cy.get('[data-qa="cancel"]').click(),
   })
+
+export default { verifyOnPage: relocationAndInjuriesPage }

--- a/integration-tests/pages/tasklistPage.js
+++ b/integration-tests/pages/tasklistPage.js
@@ -1,6 +1,6 @@
 const NewIncidentPage = require('./newIncidentPage')
-const checkAnswersPage = require('./checkAnswersPage')
-const detailsPage = require('./detailsPage')
+const CheckAnswersPage = require('./checkAnswersPage')
+const UseOfForceDetailsPage = require('./detailsPage')
 const page = require('./page')
 
 const tasklistPage = () =>
@@ -11,12 +11,12 @@ const tasklistPage = () =>
     },
     goToUseOfForceDetailsPage: () => {
       cy.get('[data-qa-details-link]').click()
-      return detailsPage()
+      return UseOfForceDetailsPage.verifyOnPage()
     },
     checkYourAnswersLink: () => cy.get('[data-qa-check-answers-link]'),
     goToAnswerPage() {
       this.checkYourAnswersLink().click()
-      return checkAnswersPage()
+      return CheckAnswersPage.verifyOnPage()
     },
     offenderName: () => cy.get('[data-qa="offender-name"]'),
     nomisId: () => cy.get('[data-qa="nomis-id"]'),

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
       ".circleci/*",
       "migrations/*",
       "node_modules/*",
-      "test/*"
+      "test/*",
+      "integration-tests/*"
     ],
     "delay": "2500",
     "ext": "js,json,html,njk"

--- a/server/config/types.js
+++ b/server/config/types.js
@@ -44,6 +44,7 @@ const StatementStatus = {
 const Destinations = {
   CONTINUE: 'continue',
   TASKLIST: 'back-to-task-list',
+  CHECK_YOUR_ANSWERS: 'check-your-answers',
 }
 
 module.exports = {

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -50,20 +50,32 @@ module.exports = function Index({
 
   get(reportPath('report-use-of-force'), reportUseOfForce.view)
 
-  get(reportPath('incident-details'), createReport.viewIncidentDetails)
+  get(reportPath('incident-details'), createReport.viewIncidentDetails({ edit: false }))
   post(reportPath('incident-details'), createReport.submit('incidentDetails'))
+  get(reportPath('edit-incident-details'), createReport.viewIncidentDetails({ edit: true }))
+  post(reportPath('edit-incident-details'), createReport.submitEdit('incidentDetails'))
+
   get(reportPath('username-does-not-exist'), createReport.viewUsernameDoesNotExist)
   post(reportPath('username-does-not-exist'), createReport.submitUsernameDoesNotExist)
 
   get(reportPath('use-of-force-details'), createReport.view('useOfForceDetails'))
   post(reportPath('use-of-force-details'), createReport.submit('useOfForceDetails'))
+  get(reportPath('edit-use-of-force-details'), createReport.viewEdit('useOfForceDetails'))
+  post(reportPath('edit-use-of-force-details'), createReport.submitEdit('useOfForceDetails'))
+
   get(reportPath('relocation-and-injuries'), createReport.view('relocationAndInjuries'))
   post(reportPath('relocation-and-injuries'), createReport.submit('relocationAndInjuries'))
+  get(reportPath('edit-relocation-and-injuries'), createReport.viewEdit('relocationAndInjuries'))
+  post(reportPath('edit-relocation-and-injuries'), createReport.submitEdit('relocationAndInjuries'))
+
   get(reportPath('evidence'), createReport.view('evidence'))
   post(reportPath('evidence'), createReport.submit('evidence'))
+  get(reportPath('edit-evidence'), createReport.viewEdit('evidence'))
+  post(reportPath('edit-evidence'), createReport.submitEdit('evidence'))
 
   get(reportPath('check-your-answers'), checkYourAnswers.view)
   post(reportPath('check-your-answers'), checkYourAnswers.submit)
+  get(`${reportPath('cancel-edit')}/:formName`, createReport.cancelEdit)
 
   get('/:reportId/report-sent', incidents.viewReportSent)
 

--- a/server/views/formPages/formTemplate.html
+++ b/server/views/formPages/formTemplate.html
@@ -42,7 +42,7 @@
       name: "submit",
       href: '/report/' + data.bookingId + '/cancel-edit/' + formName,
       classes: "govuk-button govuk-button--secondary govuk-!-margin-left-3",
-      attributes: {'data-qa': 'save-and-return'}
+      attributes: {'data-qa': 'cancel'}
     }) }}
 
 

--- a/server/views/formPages/formTemplate.html
+++ b/server/views/formPages/formTemplate.html
@@ -28,20 +28,42 @@
 
   {% endblock %}
 
-  {{ govukButton({
-    text: "Save and continue",
-    name: "submit",
-    value: 'save-and-continue',
-    attributes: {'data-qa': 'save-and-continue'}
-  }) }}
+  {% if editMode %}
 
-  {{ govukButton({
-    text: "Save and return to report use of force",
-    name: "submit",
-    value: 'save-and-return',
-    classes: "govuk-button govuk-button--secondary govuk-!-margin-left-3",
-    attributes: {'data-qa': 'save-and-return'}
-  }) }}
+    {{ govukButton({
+      text: "Save",
+      name: "submit",
+      value: 'save-and-continue',
+      attributes: {'data-qa': 'save-and-continue'}
+    }) }}
+
+    {{ govukButton({
+      text: "Cancel",
+      name: "submit",
+      href: '/report/' + data.bookingId + '/cancel-edit/' + formName,
+      classes: "govuk-button govuk-button--secondary govuk-!-margin-left-3",
+      attributes: {'data-qa': 'save-and-return'}
+    }) }}
+
+
+  {% else %}
+
+    {{ govukButton({
+      text: "Save and continue",
+      name: "submit",
+      value: 'save-and-continue',
+      attributes: {'data-qa': 'save-and-continue'}
+    }) }}
+
+    {{ govukButton({
+      text: "Save and return to report use of force",
+      name: "submit",
+      value: 'save-and-return',
+      classes: "govuk-button govuk-button--secondary govuk-!-margin-left-3",
+      attributes: {'data-qa': 'save-and-return'}
+    }) }}
+
+  {% endif %}
 
 </form>
 

--- a/server/views/formPages/incident/username-does-not-exist.html
+++ b/server/views/formPages/incident/username-does-not-exist.html
@@ -43,11 +43,14 @@ href: backLink or "/"
             attributes: { 'data-qa': 'continue', 'data-submit': true }
           })
         }}
+
+        {% set formName = 'edit-incident-details' if data.nextDestination == 'check-your-answers'  else 'incident-details' %}
+
         {{
           govukButton({
             text: 'Return to incident details',
             name: 'submit',
-            href: '/report/' + data.bookingId + '/incident-details',
+            href:  '/report/' + data.bookingId + '/' + formName,
             classes: 'govuk-button govuk-button--secondary govuk-!-margin-left-3',
             attributes: { 'data-qa': 'return-to-incident-details' }
           })

--- a/server/views/pages/pagesMacros.njk
+++ b/server/views/pages/pagesMacros.njk
@@ -4,7 +4,7 @@
     {{obj.title}}
     {% if obj.url %}  
       <span class="govuk-body govuk-!-margin-top-1 float-right">
-        <a class="govuk-link" href= '{{obj.url}}' >
+        <a class="govuk-link" data-qa='{{obj.id}}-link' href='{{obj.url}}' >
           Change<span class="govuk-visually-hidden"> {{obj.title}} </span>
         </a>
       </span>

--- a/server/views/pages/reportDetailMacro.njk
+++ b/server/views/pages/reportDetailMacro.njk
@@ -5,7 +5,7 @@
     {{
       pagesMacros.sectionHeading({
         title: 'Incident details',
-        url:  '/report/' + bookingId + '/incident-details' if bookingId  
+        url:  '/report/' + bookingId + '/edit-incident-details' if bookingId
       })
     }}
     {{pagesMacros.tableRow({
@@ -54,7 +54,7 @@
     {{
       pagesMacros.sectionHeading({
         title: 'Use of force details',
-        url:  '/report/' + bookingId + '/use-of-force-details' if bookingId  
+        url:  '/report/' + bookingId + '/edit-use-of-force-details' if bookingId
       })
     }}
     {{
@@ -103,7 +103,7 @@
     {{
       pagesMacros.sectionHeading({
         title: 'Relocation and injuries',
-        url:  '/report/' + bookingId + '/relocation-and-injuries' if bookingId  
+        url:  '/report/' + bookingId + '/edit-relocation-and-injuries' if bookingId
       })
     }}
     {{
@@ -168,7 +168,7 @@
     {{
       pagesMacros.sectionHeading({
         title: 'Evidence',
-        url:  '/report/' + bookingId + '/evidence' if bookingId
+        url:  '/report/' + bookingId + '/edit-evidence' if bookingId
       })
     }}
     {{

--- a/server/views/pages/reportDetailMacro.njk
+++ b/server/views/pages/reportDetailMacro.njk
@@ -4,6 +4,7 @@
 {% macro detail(data, bookingId) %}
     {{
       pagesMacros.sectionHeading({
+        id: 'incidentDetails', 
         title: 'Incident details',
         url:  '/report/' + bookingId + '/edit-incident-details' if bookingId
       })
@@ -53,6 +54,7 @@
 
     {{
       pagesMacros.sectionHeading({
+        id: 'useOfForceDetails',
         title: 'Use of force details',
         url:  '/report/' + bookingId + '/edit-use-of-force-details' if bookingId
       })
@@ -102,6 +104,7 @@
 
     {{
       pagesMacros.sectionHeading({
+        id: 'relocationAndInjuries',
         title: 'Relocation and injuries',
         url:  '/report/' + bookingId + '/edit-relocation-and-injuries' if bookingId
       })
@@ -167,6 +170,7 @@
 
     {{
       pagesMacros.sectionHeading({
+        id: 'evidence',
         title: 'Evidence',
         url:  '/report/' + bookingId + '/edit-evidence' if bookingId
       })


### PR DESCRIPTION
Generally navigation through the form follows a linear path:

tasklist -> incident-details -> uof-details -> r-and-i -> evidence -> check-answers

If you select a link from the tasklist page then you can drop in the linear journey at any point, e.g::

tasklist -> r-and-i -> evidence -> check-answers

Previously, the edit links on check-your-answers would do the same. 

This change alters this so if you click save after visiting a form from the check-your answers it will redirect you back to check-your-answers.

If you click cancel from any form, visited from check-your-answers it will just take you back to check-your-answers without persisting anything

This is more complicated if you select to do this for incident details as we need to ensure that all the users are valid and present the user-not-found page if they are not. You can't visit check-your-answers unless are the answers are valid