### PR TITLE
DCS-49: Back links removed, Cypress tests updated

### DIFF
--- a/integration-tests/integration/reportPages/enter-incident-details.spec.js
+++ b/integration-tests/integration/reportPages/enter-incident-details.spec.js
@@ -129,8 +129,8 @@ context('Submitting details page form', () => {
   it('Can revisit saved data', () => {
     cy.login(bookingId)
 
-    const detailsPage = fillFormAndSave()
-    detailsPage.back().click()
+    fillFormAndSave()
+    cy.go('back')
 
     const updatedIncidentPage = NewIncidentPage.verifyOnPage()
     updatedIncidentPage.offenderName().contains('Norman Smith')

--- a/integration-tests/integration/reportPages/enter-use-of-force-details.spec.js
+++ b/integration-tests/integration/reportPages/enter-use-of-force-details.spec.js
@@ -79,8 +79,8 @@ context('Submitting details page form', () => {
   it('Can revisit saved data', () => {
     cy.login(bookingId)
 
-    const relocationAndInjuriesPage = fillFormAndSave({ restraintPositions: ['STANDING', 'KNEELING'] })
-    relocationAndInjuriesPage.back().click()
+    fillFormAndSave({ restraintPositions: ['STANDING', 'KNEELING'] })
+    cy.go('back')
 
     const detailsPage = UseOfForceDetailsPage.verifyOnPage()
     detailsPage.postiveCommunication().should('have.value', 'true')

--- a/integration-tests/pages/page.js
+++ b/integration-tests/pages/page.js
@@ -1,5 +1,5 @@
 export default (name, pageObject = {}) => {
   const checkOnPage = () => cy.get('h1').contains(name)
   checkOnPage()
-  return { ...pageObject, checkStillOnPage: checkOnPage, back: () => cy.get('.govuk-back-link') }
+  return { ...pageObject, checkStillOnPage: checkOnPage }
 }

--- a/server/routes/createReport.js
+++ b/server/routes/createReport.js
@@ -10,14 +10,12 @@ const formConfig = {
 }
 
 const renderForm = ({ req, res, form, formName, data = {}, editMode }) => {
-  const backLink = req.get('Referrer')
   const { bookingId } = req.params
   const pageData = firstItem(req.flash('userInput')) || form[formName]
   const errors = req.flash('errors')
   res.render(`formPages/incident/${formName}`, {
     data: { bookingId, ...pageData, ...data, types },
     formName,
-    backLink,
     errors,
     editMode,
   })

--- a/server/views/formPages/formTemplate.html
+++ b/server/views/formPages/formTemplate.html
@@ -1,16 +1,7 @@
 {% extends "../partials/layout.html" %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
-
-{% block beforeContent %}
-  {{ govukBackLink({
-    text: "Back",
-    href: backLink or '/report/' + bookingId + '/check-your-answers'
-  }) }}
-{% endblock %}
-
 
 {% block content %}
 

--- a/server/views/formPages/incident/username-does-not-exist.html
+++ b/server/views/formPages/incident/username-does-not-exist.html
@@ -1,17 +1,7 @@
 {% extends "../../partials/layout.html" %} 
 {% from "govuk/components/button/macro.njk" import govukButton %} 
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %} 
 
 {% set pageTitle = 'A username you have entered does not exist' %}
-
-{% block beforeContent %}
-
-{{ govukBackLink({
-text: "Back",
-href: backLink or "/"
-}) }}
-
-{% endblock %} 
 
 {% block content %}
 <div class="govuk-grid-row govuk-body">

--- a/server/views/pages/check-your-answers.html
+++ b/server/views/pages/check-your-answers.html
@@ -1,19 +1,9 @@
 {% extends "../partials/layout.html" %} 
 {% from "govuk/components/button/macro.njk" import govukButton %} 
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %} 
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %} 
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% import "./pagesMacros.njk" as pagesMacros %} 
 {% import "./reportDetailMacro.njk" as reportDetail %} 
-
-{% block beforeContent %}
-
-{{ govukBackLink({
-text: "Back",
-href: backLink or "/"
-}) }}
-
-{% endblock %} 
 
 {% set pageTitle = 'Check your answers before sending the report' %}
 

--- a/server/views/pages/report-sent.html
+++ b/server/views/pages/report-sent.html
@@ -1,16 +1,9 @@
 {% extends "../partials/layout.html" %} 
 {% from "govuk/components/button/macro.njk" import govukButton %} 
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %} 
 
 {% set pageTitle = 'This report has been sent to the use of force coordinator' %}
 
-{% block beforeContent %}
-{{ govukBackLink({
-  text: "Back",
-  href: backLink or "/check-answers/" + bookingId
-}) }}
-
-{% endblock %} {% block content %}
+{% block content %}
 <div class="govuk-grid-row govuk-body">
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-panel info-panel">

--- a/server/views/pages/reviewer/view-report.html
+++ b/server/views/pages/reviewer/view-report.html
@@ -1,18 +1,8 @@
 {% extends "../../partials/layout.html" %} 
 {% from "govuk/components/button/macro.njk" import govukButton %} 
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %} 
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %} 
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% import "../reportDetailMacro.njk" as reportDetail %} 
-
-{% block beforeContent %}
-
-{{ govukBackLink({
-  text: "Back",
-  href: backLink or "/"
-  }) }}
-  
-{% endblock %}
 
 {% set pageTitle = 'Use of force report' %}
 

--- a/server/views/pages/reviewer/view-statements.html
+++ b/server/views/pages/reviewer/view-statements.html
@@ -1,6 +1,5 @@
 {% extends "../../partials/layout.html" %} 
 {% from "govuk/components/button/macro.njk" import govukButton %} 
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %} 
 {% from "govuk/components/table/macro.njk" import govukTable %}
 
 {% set pageTitle = 'Use of force incident' %}

--- a/server/views/pages/your-report.html
+++ b/server/views/pages/your-report.html
@@ -1,19 +1,12 @@
 {% extends "../partials/layout.html" %} 
 {% from "govuk/components/button/macro.njk" import govukButton %} 
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %} 
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %} 
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% import "./reportDetailMacro.njk" as reportDetail %} 
 
 {% set pageTitle = 'Use of force report' %}
-{% block beforeContent %}
 
-{{ govukBackLink({
-text: "Back",
-href: backLink or "/"
-}) }}
-
-{% endblock %} {% block content %}
+{% block content %}
 <div class="govuk-grid-row govuk-body">
   <div class="govuk-grid-column-three-quarters govuk-!-margin-bottom-9 ">
     <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>


### PR DESCRIPTION
Have removed the back links from every page in the application that used them. This was needed because a loop was occurring where the back link alternated between current and previous page rather than traversing the complete browser history.

Cypress tests updated by removing  the function "back: () => cy.get('.govuk-back-link')" and replaced references to "*.back().click()" with Cypress' default of cy.go('back') as it does the same thing.