### PR TITLE
DCS-160: fixed blue section in page header

### DIFF
--- a/assets/sass/local.sass
+++ b/assets/sass/local.sass
@@ -12,6 +12,7 @@ div.govuk-width-container
 div.govuk-header__container
   border-bottom: 0
   padding-top: 0
+  padding-right: 0
 
 div.govuk-header__logo
   padding-top: 10px
@@ -27,17 +28,25 @@ header.govuk-header
   flex-grow: 1
   text-decoration: none
   padding-left: 0px
+  @include govuk-media-query($from: 0px)
+    margin-left: 58px
+  @include govuk-media-query($from: 360px)
+    margin-left: inherit
 
 .logo-text
   padding: 3px 15px 0 10px
-  border-right: solid white 1px
   margin-right: 15px
+  @include govuk-media-query($from: 0px)
+    border-right: none
+  @include govuk-media-query($from: 360px)
+    border-right: solid white 1px
 
 .user-block
   color: white
   float: right
   font-size: 19px
-  background-color: govuk-colour("blue")
+  background-color: #015ea5
+  height: 59px
   ul
     padding: 0
     li
@@ -47,6 +56,24 @@ header.govuk-header
         border-right: solid white 1px
   a
     color: white
+  @include govuk-media-query($from: 0px)
+    position: relative
+    bottom: 10px
+    padding-bottom: 10px
+    margin-right: -15px
+    margin-left: -20px
+    ul
+      li
+        padding: 0 20px
+  @include govuk-media-query($from: 360px)
+    position: inherit
+    bottom: 0px
+    padding-bottom: 0px
+    margin-right: 0px
+    margin-left: 0px
+    ul
+      li
+        padding: 0 30px
 
 // Task list pattern
 
@@ -116,7 +143,7 @@ header.govuk-header
   white-space: pre-wrap 
 
 .info-panel
-  background-color: govuk-colour("blue")
+  background-color: #015ea5
   color: govuk-colour("white")
 
 .float-right 

--- a/assets/sass/local.sass
+++ b/assets/sass/local.sass
@@ -1,3 +1,5 @@
+@import "palette"
+
 #global-header #logo.hmppslogo
   background: url('/public/images/logo.svg') no-repeat
 
@@ -28,24 +30,24 @@ header.govuk-header
   flex-grow: 1
   text-decoration: none
   padding-left: 0px
-  @include govuk-media-query($from: 0px)
+  @include govuk-media-query($from: mobile)
     margin-left: 58px
-  @include govuk-media-query($from: 360px)
+  @include govuk-media-query($from: desktop)
     margin-left: inherit
 
 .logo-text
   padding: 3px 15px 0 10px
   margin-right: 15px
-  @include govuk-media-query($from: 0px)
+  @include govuk-media-query($from: mobile)
     border-right: none
-  @include govuk-media-query($from: 360px)
+  @include govuk-media-query($from: desktop)
     border-right: solid white 1px
 
 .user-block
   color: white
   float: right
   font-size: 19px
-  background-color: #015ea5
+  background-color: $govuk-blue
   height: 59px
   ul
     padding: 0
@@ -56,16 +58,17 @@ header.govuk-header
         border-right: solid white 1px
   a
     color: white
-  @include govuk-media-query($from: 0px)
+  @include govuk-media-query($from: mobile)
     position: relative
     bottom: 10px
     padding-bottom: 10px
     margin-right: -15px
     margin-left: -20px
     ul
+      padding: 0 24px
       li
-        padding: 0 20px
-  @include govuk-media-query($from: 360px)
+        padding: 0 10px
+  @include govuk-media-query($from: desktop)
     position: inherit
     bottom: 0px
     padding-bottom: 0px
@@ -143,7 +146,7 @@ header.govuk-header
   white-space: pre-wrap 
 
 .info-panel
-  background-color: #015ea5
+  background-color: $govuk-blue
   color: govuk-colour("white")
 
 .float-right 

--- a/assets/sass/palette.sass
+++ b/assets/sass/palette.sass
@@ -1,0 +1,2 @@
+// Brand colours
+$govuk-blue: #005ea5


### PR DESCRIPTION
The blue section was previously slightly taller than the surrounding black bar so have reduced its height. Have also chaned the layout when screen is Samsung S5 sized. The only 2 screen sizes needed to be considered for are Samsung S5 and desktop
Note have changed the blue colour to shade #015ea5 to be consistent with DPS. Could not find a sass code equivalent to #015ea5 in the latest GDS toolkit hence have used the hex code