### PR TITLE
DCS-192 Deriving agency id by active caseload

### DIFF
--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -24,13 +24,15 @@ module.exports = function Index({ authenticationMiddleware, offenderService, rep
   })
 
   router.get(
-    '/reports/mostOftenInvolvedStaff/:agencyId/:year/:month',
+    '/reports/mostOftenInvolvedStaff/:year/:month',
     asyncMiddleware(async (req, res) => {
       if (!res.locals.user.isReviewer) {
         throw httpError(401, 'Not authorised to access this resource')
       }
 
-      const { agencyId, year, month } = req.params
+      const { year, month } = req.params
+      const agencyId = res.locals.user.activeCaseLoadId
+
       const results = await reportingService.getMostOftenInvolvedStaff(
         agencyId,
         parseInt(month, 10),
@@ -43,13 +45,15 @@ module.exports = function Index({ authenticationMiddleware, offenderService, rep
   )
 
   router.get(
-    '/reports/mostOftenInvolvedPrisoners/:agencyId/:year/:month',
+    '/reports/mostOftenInvolvedPrisoners/:year/:month',
     asyncMiddleware(async (req, res) => {
       if (!res.locals.user.isReviewer) {
         throw httpError(401, 'Not authorised to access this resource')
       }
 
-      const { agencyId, year, month } = req.params
+      const { year, month } = req.params
+      const agencyId = res.locals.user.activeCaseLoadId
+
       const results = await reportingService.getMostOftenInvolvedPrisoners(
         res.locals.user.token,
         agencyId,

--- a/server/routes/api.test.js
+++ b/server/routes/api.test.js
@@ -25,12 +25,12 @@ describe('api', () => {
     jest.resetAllMocks()
   })
 
-  describe('GET /reports/mostOftenInvolvedStaff/:agencyId/:year/:month', () => {
+  describe('GET /reports/mostOftenInvolvedStaff/:year/:month', () => {
     it('should render for reviewer', async () => {
       userSupplier.mockReturnValue(reviewerUser)
 
       await request(app)
-        .get('/reports/mostOftenInvolvedStaff/LEI/2019/10')
+        .get('/reports/mostOftenInvolvedStaff/2019/10')
         .expect('Content-Type', 'text/csv; charset=utf-8')
         .expect('Content-Disposition', `attachment; filename="involved-staff-LEI-10-2019.csv"`)
         .expect(res => {
@@ -44,7 +44,7 @@ describe('api', () => {
       userSupplier.mockReturnValue(user)
 
       await request(app)
-        .get('/reports/mostOftenInvolvedStaff/LEI/2019/10')
+        .get('/reports/mostOftenInvolvedStaff/2019/10')
         .expect('Content-Type', /text\/html/)
         .expect(401)
         .expect(res => {
@@ -55,12 +55,12 @@ describe('api', () => {
     })
   })
 
-  describe('GET /reports/mostOftenInvolvedPrisoners/:agencyId/:year/:month', () => {
+  describe('GET /reports/mostOftenInvolvedPrisoners/:year/:month', () => {
     it('should render for reviewer', async () => {
       userSupplier.mockReturnValue(reviewerUser)
 
       await request(app)
-        .get('/reports/mostOftenInvolvedPrisoners/LEI/2019/10')
+        .get('/reports/mostOftenInvolvedPrisoners/2019/10')
         .expect('Content-Type', 'text/csv; charset=utf-8')
         .expect('Content-Disposition', `attachment; filename="prisoners-LEI-10-2019.csv"`)
         .expect(res => {
@@ -74,7 +74,7 @@ describe('api', () => {
       userSupplier.mockReturnValue(user)
 
       await request(app)
-        .get('/reports/mostOftenInvolvedPrisoners/LEI/2019/10')
+        .get('/reports/mostOftenInvolvedPrisoners/2019/10')
         .expect('Content-Type', /text\/html/)
         .expect(401)
         .expect(res => {

--- a/server/routes/testutils/appSetup.js
+++ b/server/routes/testutils/appSetup.js
@@ -16,6 +16,7 @@ const user = {
   username: 'user1',
   displayName: 'First Last',
   isReviewer: false,
+  activeCaseLoadId: 'MDI',
 }
 
 const reviewerUser = {
@@ -26,6 +27,8 @@ const reviewerUser = {
   username: 'user1',
   displayName: 'First Last',
   isReviewer: true,
+  activeCaseLoadId: 1,
+  activeCaseLoadId: 'LEI',
 }
 
 const appSetup = (route, userSupplier = () => user) => {


### PR DESCRIPTION
We want to limit people reviewing reports to only be able to see information about their active caseloads.
This means we can prevent them from viewing data they should not be able to see and also simplifies the frontend