### PR TITLE
DCS-179 Correcting submission date 

### DIFF
--- a/server/data/incidentClient.js
+++ b/server/data/incidentClient.js
@@ -200,7 +200,7 @@ const getNextNotificationReminder = async transactionalClient => {
           ,       s.email                  "recipientEmail" 
           ,       s.name                   "recipientName"
           ,       s.next_reminder_date     "nextReminderDate"  
-          ,       s.submitted_date         "submittedDate"
+          ,       r.submitted_date         "submittedDate"
           ,       r.reporter_name          "reporterName"
           ,       r.incident_date          "incidentDate"
           ,       r.user_id = s.user_id    "isReporter"

--- a/server/data/incidentClient.test.js
+++ b/server/data/incidentClient.test.js
@@ -244,7 +244,7 @@ test('getNextNotificationReminder', () => {
           ,       s.email                  "recipientEmail" 
           ,       s.name                   "recipientName"
           ,       s.next_reminder_date     "nextReminderDate"  
-          ,       s.submitted_date         "submittedDate"
+          ,       r.submitted_date         "submittedDate"
           ,       r.reporter_name          "reporterName"
           ,       r.incident_date          "incidentDate"
           ,       r.user_id = s.user_id    "isReporter"


### PR DESCRIPTION
This should be report submitted date rather than statement submitted date.

This is currently showing "Invalid date" in the email content so reverted the email templates back to refer to incident date until we get this released. 
