### PR TITLE
DCS-223 Adding temporary endpoint to add missed staff

### DIFF
--- a/integration-tests/db/db.js
+++ b/integration-tests/db/db.js
@@ -58,7 +58,12 @@ const seedReport = ({
     .then(
       result =>
         involvedStaff.length &&
-        statementsClient.createStatements(result.rows[0].id, new Date(), overdueDate, involvedStaff)
+        statementsClient.createStatements({
+          reportId: result.rows[0].id,
+          firstReminder: new Date(),
+          overdueDate,
+          staff: involvedStaff,
+        })
     )
 }
 

--- a/server/app.js
+++ b/server/app.js
@@ -249,7 +249,10 @@ module.exports = function createApp({
     })
   )
 
-  app.use('/api/', createApiRouter({ authenticationMiddleware, offenderService, reportingService }))
+  app.use(
+    '/api/',
+    createApiRouter({ authenticationMiddleware, offenderService, reportingService, involvedStaffService })
+  )
 
   app.use((req, res, next) => {
     next(new Error('Not found'))

--- a/server/data/incidentClient.js
+++ b/server/data/incidentClient.js
@@ -58,14 +58,14 @@ const submitReport = (userId, bookingId, submittedDate, client = nonTransactiona
   })
 }
 
-const markCompleted = (reportId, client = nonTransactionalClient) => {
+const changeStatus = (reportId, startState, endState, client = nonTransactionalClient) => {
   return client.query({
     text: `update report r
             set status = $1
             ,   updated_date = now()
           where id = $2
           and status = $3`,
-    values: [ReportStatus.COMPLETE.value, reportId, ReportStatus.SUBMITTED.value],
+    values: [endState.value, reportId, startState.value],
   })
 }
 
@@ -103,7 +103,8 @@ const getReportForReviewer = async reportId => {
           , submitted_date "submittedDate"
           , reporter_name "reporterName"
           , form_response "form"
-          , booking_id "bookingId"
+          , booking_id    "bookingId"
+          , status
           from report r
           where r.id = $1`,
     values: [reportId],
@@ -230,7 +231,7 @@ module.exports = {
   createDraftReport,
   updateDraftReport,
   submitReport,
-  markCompleted,
+  changeStatus,
   getCurrentDraftReport,
   getReport,
   getReports,

--- a/server/data/incidentClient.test.js
+++ b/server/data/incidentClient.test.js
@@ -53,7 +53,8 @@ test('getReportForReviewer', () => {
           , submitted_date "submittedDate"
           , reporter_name "reporterName"
           , form_response "form"
-          , booking_id "bookingId"
+          , booking_id    "bookingId"
+          , status
           from report r
           where r.id = $1`,
     values: ['report1'],
@@ -176,8 +177,8 @@ test('submitReport', () => {
   })
 })
 
-test('markCompleted', () => {
-  incidentClient.markCompleted('report1')
+test('changeStatus', () => {
+  incidentClient.changeStatus('report1', ReportStatus.SUBMITTED, ReportStatus.COMPLETE)
 
   expect(db.query).toBeCalledWith({
     text: `update report r

--- a/server/data/statementsClient.js
+++ b/server/data/statementsClient.js
@@ -140,7 +140,7 @@ const getNumberOfPendingStatements = async (reportId, client = nonTransactionalC
   return parseInt(rows[0].count, 10)
 }
 
-const createStatements = async (reportId, firstReminder, overdueDate, staff, client = nonTransactionalClient) => {
+const createStatements = async ({ reportId, firstReminder, overdueDate, staff, client = nonTransactionalClient }) => {
   const rows = staff.map(s => [
     reportId,
     s.staffId,
@@ -160,6 +160,14 @@ const createStatements = async (reportId, firstReminder, overdueDate, staff, cli
   return results.rows.reduce((result, staffMember) => ({ ...result, [staffMember.userId]: staffMember.id }), {})
 }
 
+const isStatementPresentForUser = async (reportId, username, client = nonTransactionalClient) => {
+  const { rows } = await client.query({
+    text: `select count(*) from statement where report_id = $1 and user_id = $2`,
+    values: [reportId, username],
+  })
+  return parseInt(rows[0].count, 10) > 0
+}
+
 module.exports = {
   getStatements,
   getStatementForUser,
@@ -171,4 +179,5 @@ module.exports = {
   getAdditionalComments,
   saveAdditionalComment,
   getNumberOfPendingStatements,
+  isStatementPresentForUser,
 }

--- a/server/data/statementsClient.test.js
+++ b/server/data/statementsClient.test.js
@@ -71,10 +71,15 @@ test('saveAdditionalComment', () => {
 test('createStatements', async () => {
   db.query.mockReturnValue({ rows: [{ id: 1, userId: 'a' }, { id: 2, userId: 'b' }] })
 
-  const ids = await statementsClient.createStatements('incident-1', 'date1', 'date2', [
-    { staffId: 0, userId: 1, name: 'aaaa', email: 'aaaa@gov.uk' },
-    { staffId: 1, userId: 2, name: 'bbbb', email: 'bbbb@gov.uk' },
-  ])
+  const ids = await statementsClient.createStatements({
+    reportId: 'incident-1',
+    firstReminder: 'date1',
+    overdueDate: 'date2',
+    staff: [
+      { staffId: 0, userId: 1, name: 'aaaa', email: 'aaaa@gov.uk' },
+      { staffId: 1, userId: 2, name: 'bbbb', email: 'bbbb@gov.uk' },
+    ],
+  })
 
   expect(ids).toEqual({ a: 1, b: 2 })
   expect(db.query).toBeCalledWith({
@@ -164,5 +169,17 @@ test('getStatementForReviewer', () => {
     left join statement s on r.id = s.report_id
     where s.id = $1`,
     values: ['statement1'],
+  })
+})
+
+test('isStatementPresentForUser', async () => {
+  db.query.mockReturnValue({ rows: [{ count: 1 }] })
+
+  const result = await statementsClient.isStatementPresentForUser('report-1', 'user-1')
+
+  expect(result).toEqual(true)
+  expect(db.query).toBeCalledWith({
+    text: `select count(*) from statement where report_id = $1 and user_id = $2`,
+    values: ['report-1', 'user-1'],
   })
 })

--- a/server/index.js
+++ b/server/index.js
@@ -28,7 +28,7 @@ const eventPublisher = require('./services/eventPublisher')(appInsightsClient)
 // pass in dependencies of service
 
 const userService = createUserService(elite2ClientBuilder, authClientBuilder)
-const involvedStaffService = createInvolvedStaffService({ incidentClient, statementsClient, userService })
+const involvedStaffService = createInvolvedStaffService({ incidentClient, statementsClient, userService, db })
 const notificationService = notificationServiceFactory(eventPublisher)
 const offenderService = createOffenderService(elite2ClientBuilder)
 const reportService = createReportService({

--- a/server/routes/api.test.js
+++ b/server/routes/api.test.js
@@ -10,78 +10,114 @@ const reportingService = {
   getMostOftenInvolvedPrisoners: jest.fn(),
 }
 
-const route = createRouter({ authenticationMiddleware, reportingService })
+const involvedStaffService = {
+  addInvolvedStaff: jest.fn(),
+}
+
+const route = createRouter({ authenticationMiddleware, reportingService, involvedStaffService })
 
 let app
 
 describe('api', () => {
   beforeEach(() => {
     app = appSetup(route, userSupplier)
-    reportingService.getMostOftenInvolvedStaff.mockResolvedValue('Some,Csv,Content for involved staff')
-    reportingService.getMostOftenInvolvedPrisoners.mockResolvedValue('Some,Csv,Content for prisoners')
   })
 
   afterEach(() => {
     jest.resetAllMocks()
   })
 
-  describe('GET /reports/mostOftenInvolvedStaff/:year/:month', () => {
-    it('should render for reviewer', async () => {
+  describe('add involved staff', () => {
+    it('should resolve for reviewer', async () => {
       userSupplier.mockReturnValue(reviewerUser)
 
       await request(app)
-        .get('/reports/mostOftenInvolvedStaff/2019/10')
-        .expect('Content-Type', 'text/csv; charset=utf-8')
-        .expect('Content-Disposition', `attachment; filename="involved-staff-LEI-10-2019.csv"`)
+        .get('/report/1/involved-staff/sally')
+        .expect('Content-Type', 'application/json; charset=utf-8')
         .expect(res => {
-          expect(res.text).toContain('Some,Csv,Content for involved staff')
+          expect(res.body).toEqual({ result: 'ok' })
         })
 
-      expect(reportingService.getMostOftenInvolvedStaff).toBeCalledWith('LEI', 10, 2019)
+      expect(involvedStaffService.addInvolvedStaff).toBeCalledWith('token', '1', 'sally')
     })
 
-    it('should not render for standard user', async () => {
+    it('should not resolve for reviewer', async () => {
       userSupplier.mockReturnValue(user)
 
       await request(app)
-        .get('/reports/mostOftenInvolvedStaff/2019/10')
-        .expect('Content-Type', /text\/html/)
+        .get('/report/1/involved-staff/sally')
         .expect(401)
         .expect(res => {
           expect(res.text).toContain('Not authorised to access this resource')
         })
 
-      expect(reportingService.getMostOftenInvolvedStaff).not.toBeCalled()
+      expect(involvedStaffService.addInvolvedStaff).not.toBeCalled()
     })
   })
 
-  describe('GET /reports/mostOftenInvolvedPrisoners/:year/:month', () => {
-    it('should render for reviewer', async () => {
-      userSupplier.mockReturnValue(reviewerUser)
+  describe('reporting', () => {
+    beforeEach(() => {
+      reportingService.getMostOftenInvolvedStaff.mockResolvedValue('Some,Csv,Content for involved staff')
+      reportingService.getMostOftenInvolvedPrisoners.mockResolvedValue('Some,Csv,Content for prisoners')
+    })
+    describe('GET /reports/mostOftenInvolvedStaff/:year/:month', () => {
+      it('should render for reviewer', async () => {
+        userSupplier.mockReturnValue(reviewerUser)
 
-      await request(app)
-        .get('/reports/mostOftenInvolvedPrisoners/2019/10')
-        .expect('Content-Type', 'text/csv; charset=utf-8')
-        .expect('Content-Disposition', `attachment; filename="prisoners-LEI-10-2019.csv"`)
-        .expect(res => {
-          expect(res.text).toContain('Some,Csv,Content for prisoners')
-        })
+        await request(app)
+          .get('/reports/mostOftenInvolvedStaff/2019/10')
+          .expect('Content-Type', 'text/csv; charset=utf-8')
+          .expect('Content-Disposition', `attachment; filename="involved-staff-LEI-10-2019.csv"`)
+          .expect(res => {
+            expect(res.text).toContain('Some,Csv,Content for involved staff')
+          })
 
-      expect(reportingService.getMostOftenInvolvedPrisoners).toBeCalledWith('token', 'LEI', 10, 2019)
+        expect(reportingService.getMostOftenInvolvedStaff).toBeCalledWith('LEI', 10, 2019)
+      })
+
+      it('should not render for standard user', async () => {
+        userSupplier.mockReturnValue(user)
+
+        await request(app)
+          .get('/reports/mostOftenInvolvedStaff/2019/10')
+          .expect('Content-Type', /text\/html/)
+          .expect(401)
+          .expect(res => {
+            expect(res.text).toContain('Not authorised to access this resource')
+          })
+
+        expect(reportingService.getMostOftenInvolvedStaff).not.toBeCalled()
+      })
     })
 
-    it('should not render for standard user', async () => {
-      userSupplier.mockReturnValue(user)
+    describe('GET /reports/mostOftenInvolvedPrisoners/:year/:month', () => {
+      it('should render for reviewer', async () => {
+        userSupplier.mockReturnValue(reviewerUser)
 
-      await request(app)
-        .get('/reports/mostOftenInvolvedPrisoners/2019/10')
-        .expect('Content-Type', /text\/html/)
-        .expect(401)
-        .expect(res => {
-          expect(res.text).toContain('Not authorised to access this resource')
-        })
+        await request(app)
+          .get('/reports/mostOftenInvolvedPrisoners/2019/10')
+          .expect('Content-Type', 'text/csv; charset=utf-8')
+          .expect('Content-Disposition', `attachment; filename="prisoners-LEI-10-2019.csv"`)
+          .expect(res => {
+            expect(res.text).toContain('Some,Csv,Content for prisoners')
+          })
 
-      expect(reportingService.getMostOftenInvolvedPrisoners).not.toBeCalled()
+        expect(reportingService.getMostOftenInvolvedPrisoners).toBeCalledWith('token', 'LEI', 10, 2019)
+      })
+
+      it('should not render for standard user', async () => {
+        userSupplier.mockReturnValue(user)
+
+        await request(app)
+          .get('/reports/mostOftenInvolvedPrisoners/2019/10')
+          .expect('Content-Type', /text\/html/)
+          .expect(401)
+          .expect(res => {
+            expect(res.text).toContain('Not authorised to access this resource')
+          })
+
+        expect(reportingService.getMostOftenInvolvedPrisoners).not.toBeCalled()
+      })
     })
   })
 })

--- a/server/services/involvedStaffService.js
+++ b/server/services/involvedStaffService.js
@@ -1,6 +1,8 @@
 const moment = require('moment')
+const logger = require('../../log.js')
+const { ReportStatus } = require('../config/types')
 
-module.exports = function createReportService({ incidentClient, statementsClient, userService }) {
+module.exports = function createReportService({ incidentClient, statementsClient, userService, db }) {
   const getDraftInvolvedStaff = reportId => incidentClient.getDraftInvolvedStaff(reportId)
 
   const removeMissingDraftInvolvedStaff = async (userId, bookingId) => {
@@ -49,25 +51,29 @@ module.exports = function createReportService({ incidentClient, statementsClient
     return involvedStaff
   }
 
+  const loadUser = async (token, username) => {
+    const { success, exist = [], missing = [], notVerified = [] } = await userService.getUsers(token, [username])
+
+    if (!success) {
+      throw new Error(
+        `Could not retrieve user details for '${username}', missing: '${Boolean(
+          missing.length
+        )}', not verified: '${Boolean(notVerified.length)}'`
+      )
+    }
+    const [user] = exist
+    return user
+  }
+
   const getStaffRequiringStatements = async (currentUser, addedStaff) => {
     const userAlreadyAdded = addedStaff.find(user => currentUser.username === user.username)
     if (userAlreadyAdded) {
       return addedStaff
     }
-    // If current user hasn't added themselves, then add them to the list.
-    const { success, exist = [], missing = [], notVerified = [] } = await userService.getUsers(currentUser.token, [
-      currentUser.username,
-    ])
+    // Current user hasn't added themselves, so add them to the list.
+    const foundUser = await loadUser(currentUser.token, currentUser.username)
 
-    if (!success) {
-      throw new Error(
-        `Could not retrieve user details for '${currentUser.username}', missing: '${Boolean(
-          missing.length
-        )}', not verified: '${Boolean(notVerified.length)}'`
-      )
-    }
-
-    return [...addedStaff, ...exist]
+    return [...addedStaff, foundUser]
   }
 
   const save = async (reportId, reportSubmittedDate, overdueDate, currentUser, client) => {
@@ -83,20 +89,60 @@ module.exports = function createReportService({ incidentClient, statementsClient
     }))
 
     const firstReminderDate = moment(reportSubmittedDate).add(1, 'day')
-    const userIdsToStatementIds = await statementsClient.createStatements(
+    const userIdsToStatementIds = await statementsClient.createStatements({
       reportId,
-      firstReminderDate.toDate(),
-      overdueDate.toDate(),
+      firstReminder: firstReminderDate.toDate(),
+      overdueDate: overdueDate.toDate(),
       staff,
-      client
-    )
+      client,
+    })
     return staff.map(staffMember => ({ ...staffMember, statementId: userIdsToStatementIds[staffMember.userId] }))
+  }
+
+  const addInvolvedStaff = async (token, reportId, username) => {
+    logger.info(`Adding involved staff with username: ${username} to report: '${reportId}'`)
+    const foundUser = await loadUser(token, username)
+    logger.info(`found staff: '${foundUser}'`)
+
+    const report = await incidentClient.getReportForReviewer(reportId)
+    if (!report) {
+      throw new Error(`Report: '${reportId}' does not exist`)
+    }
+
+    if (await statementsClient.isStatementPresentForUser(reportId, username)) {
+      throw new Error(`Staff member already exists: '${username}' on report: '${reportId}'`)
+    }
+
+    await db.inTransaction(async client => {
+      await statementsClient.createStatements({
+        reportId,
+        firstReminder: null,
+        overdueDate: moment(report.submittedDate)
+          .add(3, 'day')
+          .toDate(),
+        staff: [
+          {
+            staffId: foundUser.staffId,
+            userId: foundUser.username,
+            name: foundUser.name,
+            email: foundUser.email,
+          },
+        ],
+        client,
+      })
+
+      if (report.status === ReportStatus.COMPLETE.value) {
+        logger.info(`There are now pending statements on : ${reportId}, moving from 'COMPLETE' to 'SUBMITTED'`)
+        await incidentClient.changeStatus(reportId, ReportStatus.COMPLETE, ReportStatus.SUBMITTED, client)
+      }
+    })
   }
 
   return {
     getInvolvedStaff,
     removeMissingDraftInvolvedStaff,
     getDraftInvolvedStaff,
+    addInvolvedStaff,
     save,
     lookup,
   }

--- a/server/services/statementService.js
+++ b/server/services/statementService.js
@@ -1,6 +1,6 @@
 const R = require('ramda')
 const logger = require('../../log.js')
-const { StatementStatus } = require('../config/types')
+const { StatementStatus, ReportStatus } = require('../config/types')
 const statementConfig = require('../config/forms/statementForm')
 const { processInput } = require('./validation')
 
@@ -41,7 +41,7 @@ module.exports = function createStatementService({ statementsClient, incidentCli
 
       if (pendingStatementCount === 0) {
         logger.info(`All statements complete on : ${reportId}, marking as complete`)
-        await incidentClient.markCompleted(reportId, client)
+        await incidentClient.changeStatus(reportId, ReportStatus.SUBMITTED, ReportStatus.COMPLETE, client)
       }
     })
   }

--- a/server/services/statementService.test.js
+++ b/server/services/statementService.test.js
@@ -1,8 +1,8 @@
 const serviceCreator = require('./statementService')
-const { StatementStatus } = require('../config/types')
+const { StatementStatus, ReportStatus } = require('../config/types')
 
 const incidentClient = {
-  markCompleted: jest.fn(),
+  changeStatus: jest.fn(),
 }
 
 const statementsClient = {
@@ -109,7 +109,7 @@ describe('statmentService', () => {
 
       expect(statementsClient.submitStatement).toBeCalledTimes(1)
       expect(statementsClient.submitStatement).toBeCalledWith('user1', 'incident-1', client)
-      expect(incidentClient.markCompleted).not.toHaveBeenCalled()
+      expect(incidentClient.changeStatus).not.toHaveBeenCalled()
     })
 
     test('marks report as complete if no pending statements', async () => {
@@ -120,7 +120,12 @@ describe('statmentService', () => {
       expect(statementsClient.submitStatement).toBeCalledTimes(1)
       expect(statementsClient.submitStatement).toBeCalledWith('user1', 'incident-1', client)
 
-      expect(incidentClient.markCompleted).toHaveBeenCalledWith('incident-1', client)
+      expect(incidentClient.changeStatus).toHaveBeenCalledWith(
+        'incident-1',
+        ReportStatus.SUBMITTED,
+        ReportStatus.COMPLETE,
+        client
+      )
     })
   })
 


### PR DESCRIPTION
We have already received 5 requests to add involved staff members to a report as they
were missed when the report was raised.

We have worked out a process to do this but its fiddly, easy to get wrong and very time consuming.
It also involves manually running db statements.

The idea is to add the ability for coordinators to be able to do this through the
application which will require input from design and additional time (We have a ticket on the backlog for this).

As a temporary fix, this change adds an endpoint that can be called by internal staff to add
these member easily.

We don't have any auth setup for api style endpoints so I've made this easy to trigger from
a browser as a logged in user.