### PR TITLE
P.O.C of sharing whitelists

### DIFF
--- a/helm_deploy/secrets-example.yaml
+++ b/helm_deploy/secrets-example.yaml
@@ -4,3 +4,4 @@ secrets:
   API_CLIENT_ID: somesecretvalue
   API_CLIENT_SECRET: somesecretvalue
   NOTIFY_API_KEY: somesecretvalue
+  SESSION_SECRET: somesecretvalue

--- a/helm_deploy/use-of-force/templates/_helpers.tpl
+++ b/helm_deploy/use-of-force/templates/_helpers.tpl
@@ -38,3 +38,20 @@ Create a string from a list of values joined by a comma
 {{- $local := dict "first" true -}}
 {{- range $k, $v := . -}}{{- if not $local.first -}},{{- end -}}{{- $v -}}{{- $_ := set $local "first" false -}}{{- end -}}
 {{- end -}}
+
+{{/*
+Create a string from a Map<String,List<String>>. This will concat all lists which are present under the provided keys.
+*/}}
+{{ define "app.pickKeysAndMerge" }}
+    {{- $root := . -}}
+    {{- $list := (list) -}}
+    {{- range .keys -}}
+      {{- $group := pluck . $root.map -}}
+      {{- range $group -}}
+        {{- range . -}}
+          {{- $list = append $list . -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+    {{-  $list | join "," -}}
+{{- end -}}

--- a/helm_deploy/use-of-force/templates/ingress.yaml
+++ b/helm_deploy/use-of-force/templates/ingress.yaml
@@ -13,7 +13,9 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/custom-http-errors: "418"
-    {{ if .Values.ingress.enable_whitelist }}nginx.ingress.kubernetes.io/whitelist-source-range: {{ include "app.joinListWithComma" .Values.whitelist | quote }}{{ end }}
+    {{ if .Values.ingress.enable_whitelist }}
+    nginx.ingress.kubernetes.io/whitelist-source-range: {{ include "app.pickKeysAndMerge" (dict "map" .Values.whitelist_groups  "keys" .Values.whitelists) | quote }}
+    {{ end }}
 spec:
   tls:
   - hosts:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -11,7 +11,7 @@ image:
 
 ingress:
   enabled: true
-  enable_whitelist: false
+  enable_whitelist: true
   host: dev.use-of-force.service.justice.gov.uk
   cert_secret: use-of-force-cert
   path: /
@@ -22,3 +22,8 @@ env:
   ELITE2_API_URL: https://gateway.t3.nomis-api.hmpps.dsd.io/elite2api
   EXIT_LOCATION_URL: https://digital-dev.prison.service.justice.gov.uk/
   EMAIL_LOCATION_URL: https://dev.use-of-force.service.justice.gov.uk
+
+whitelists:
+  - internal
+  - ark
+  - prisons

--- a/helm_deploy/values-ips.yml
+++ b/helm_deploy/values-ips.yml
@@ -1,0 +1,49 @@
+whitelist_groups:
+
+  internal:
+    health-kick: 35.177.252.195/32
+    mojvpn: 81.134.202.29/32
+    office: 217.33.148.210/32
+    petty_france_wifi: 213.121.161.112/28
+  
+  cloudplatform:
+    cloudplatform-live1-1: 35.178.209.113/32
+    cloudplatform-live1-2: 3.8.51.207/32
+    cloudplatform-live1-3: 35.177.252.54/32
+
+  ark:
+    ark-dom1-corsham-psn: 51.247.4.0/24
+    ark-dom1-corsham: 194.33.196.0/24
+    ark-dom1-farnborough-psn: 51.247.3.0/24
+    ark-dom1-farnborough: 194.33.192.0/24
+    ark-dom1-non-live-1: 194.33.193.0/25
+    ark-dom1-non-live-2: 194.33.197.0/25
+    ark-dom1-ttp1: 195.59.75.0/24
+    ark-nps-hmcts-ttp2: 194.33.192.0/25
+    ark-nps-hmcts-ttp4: 194.33.196.0/25
+
+  prisons:
+    dxc-mitcheldean: 195.92.38.16/28
+    quantum1: 62.25.109.197/32
+    quantum2: 212.137.36.230/32
+    digitalprisons1: 52.56.112.98/32
+    digitalprisons2: 52.56.118.154/32
+    j5-phones-1: 35.177.125.252/32
+    j5-phones-2: 35.177.137.160/32
+    thameside-private-prison: 217.22.14.151/32
+    oakwood: 194.176.200.113/32
+
+  externalProbationAgencies:
+    interservfls: 51.179.196.131/32
+    sodexo-northumberland: 88.98.48.10/32
+    sodexo1: 80.86.46.16/32
+    sodexo2: 80.86.46.17/32
+    sodexo3: 80.86.46.18/32
+
+  pentesting:
+    pentester-bsi-1: 145.239.254.21/32
+    pentester-bsi-2: 54.37.241.156/30
+ 
+  other: 
+    durham-tees-valley: 51.179.193.241/32
+

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -23,17 +23,7 @@ env:
   EXIT_LOCATION_URL: https://digital-preprod.prison.service.justice.gov.uk/
   EMAIL_LOCATION_URL: https://preprod.use-of-force.service.justice.gov.uk
 
-whitelist:
-  office: "217.33.148.210/32"
-  quantum: "62.25.109.197/32"
-  quantum_alt: "212.137.36.230/32"
-  health-kick: "35.177.252.195/32"
-  digitalprisons1: "52.56.112.98/32"
-  digitalprisons2: "52.56.118.154/32"
-  mojvpn: "81.134.202.29/32"
-  j5-phones-1: "35.177.125.252/32"
-  j5-phones-2: "35.177.137.160/32"
-  dxc_webproxy1: "195.92.38.20/32"
-  dxc_webproxy2: "195.92.38.21/32"
-  dxc_webproxy3: "195.92.38.22/32"
-  dxc_webproxy4: "195.92.38.23/32"
+whitelists:
+  - internal
+  - ark
+  - prisons

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -23,21 +23,8 @@ env:
   EXIT_LOCATION_URL: https://digital.prison.service.justice.gov.uk/
   EMAIL_LOCATION_URL: https://use-of-force.service.justice.gov.uk
 
-whitelist:
-  office: '217.33.148.210/32'
-  health-kick: '35.177.252.195/32'
-  mojvpn: '81.134.202.29/32'
-  quantum: '62.25.109.197/32'
-  quantum_alt: '212.137.36.230/32'
-  digitalprisons1: '52.56.112.98/32'
-  digitalprisons2: '52.56.118.154/32'
-  j5-phones-1: '35.177.125.252/32'
-  j5-phones-2: '35.177.137.160/32'
-  dxc-mitcheldean: 195.92.38.16/28
-  ark-dom1-ttp1: "195.59.75.0/24"
-  ark-dom1-farnborough: "194.33.192.0/24"
-  ark-dom1-farnborough-psn: "51.247.3.0/24"
-  ark-dom1-corsham: "194.33.196.0/24"
-  ark-dom1-corsham-psn: "51.247.4.0/24"
-  ark-dom1-non-live-1: "194.33.193.0/25"
-  ark-dom1-non-live-2: "194.33.197.0/25"
+whitelists:
+  - internal
+  - ark
+  - prisons
+  


### PR DESCRIPTION
Suspect this is unnecessarily complex - the original idea was to share whitelists across applications but quickly realised they were very diverse so reusing chunks of whitelists might be better.

Other much simpler solutions would be:
 * No whitelists
 * 1 single whitelist we use for everything
 * 3 whitelists, one per env type

We would have a global shared `values-ips.yml` which would be pulled in the build at deploy. This defines a number of named list of ips to whitelist:
```yml
whitelist_groups:

  internal:
    cloudplatform-live1-1: 35.178.209.113/32
    cloudplatform-live1-2: 3.8.51.207/32
    cloudplatform-live1-3: 35.177.252.54/32
    ...

 prisons:
    dxc-mitcheldean: 195.92.38.16/28
    ...
```

Then in each env specific`values.yml` file in each project, a list of whitelists can be specified:
```yml
whitelists:
  - internal
  - prisons 
```
  
I also wrote a [JS script](https://github.com/andrewrlee/k8-ip-whitelist-check) to allow inspecting the changes to the ip whitelists before applying.

Though in hindsight, I think there are more [generic helm extensions](https://github.com/databus23/helm-diff) that allow you to do similar things.