### PR TITLE
DCS-320 Fix adding broken involved staff

### DIFF
--- a/server/data/authClientBuilder.js
+++ b/server/data/authClientBuilder.js
@@ -25,7 +25,7 @@ module.exports = token => {
     async getEmail(username) {
       const path = `${apiUrl}/api/user/${username}/email`
       const { status, body } = await userGet({ path, raw: true })
-      return { ...body, username, exists: status < 400, verified: status === 200 }
+      return { email: body.email, username: body.username || username, exists: status < 400, verified: status === 200 }
     },
     async getUser(username) {
       const path = `${apiUrl}/api/user/${username}`

--- a/server/data/authClientBuilder.test.js
+++ b/server/data/authClientBuilder.test.js
@@ -19,7 +19,7 @@ describe('authClient', () => {
 
   describe('getEmail', () => {
     const userName = 'Bob'
-    const userResponse = { username: 'Bob', email: 'an@email.com' }
+    const userResponse = { username: 'BOB', email: 'an@email.com' }
 
     it('email exists', async () => {
       fakeApi
@@ -28,7 +28,7 @@ describe('authClient', () => {
         .reply(200, userResponse)
 
       const output = await client.getEmail(userName)
-      expect(output).toEqual({ username: 'Bob', email: 'an@email.com', exists: true, verified: true })
+      expect(output).toEqual({ username: 'BOB', email: 'an@email.com', exists: true, verified: true })
     })
 
     it('no verified email exists', async () => {


### PR DESCRIPTION
It is is possible to add an invalid member of staff by passing a username in the invalid case.
The staff lookup performs a case insensitive look up but we end up persisting the user provided value.

When we retrieve statements for the current user, we will do a case sensitive lookup based on the current username.
It is likely that the two versions of the usernames don’t match up.

This changes it so that we always persist the service provided username