### PR TITLE
DCS-249 Fixing issue where offender moves after a report is created.

### DIFF
--- a/helm_deploy/secrets-example.yaml
+++ b/helm_deploy/secrets-example.yaml
@@ -3,5 +3,7 @@ secrets:
   APPINSIGHTS_INSTRUMENTATIONKEY: somesecretvalue 
   API_CLIENT_ID: somesecretvalue
   API_CLIENT_SECRET: somesecretvalue
+  SYSTEM_CLIENT_ID: somesecretvalue
+  SYSTEM_CLIENT_SECRET: somesecretvalue
   NOTIFY_API_KEY: somesecretvalue
   SESSION_SECRET: somesecretvalue

--- a/helm_deploy/use-of-force/templates/_envs.tpl
+++ b/helm_deploy/use-of-force/templates/_envs.tpl
@@ -43,6 +43,18 @@ env:
         name: {{ template "app.name" . }}
         key: API_CLIENT_SECRET
 
+  - name: SYSTEM_CLIENT_ID
+    valueFrom:
+      secretKeyRef:
+        name: {{ template "app.name" . }}
+        key: SYSTEM_CLIENT_ID
+
+  - name: SYSTEM_CLIENT_SECRET
+    valueFrom:
+      secretKeyRef:
+        name: {{ template "app.name" . }}
+        key: SYSTEM_CLIENT_SECRET
+
   - name: APPINSIGHTS_INSTRUMENTATIONKEY
     valueFrom:
       secretKeyRef:

--- a/helm_deploy/use-of-force/templates/secrets.yaml
+++ b/helm_deploy/use-of-force/templates/secrets.yaml
@@ -7,5 +7,7 @@ data:
   APPINSIGHTS_INSTRUMENTATIONKEY: {{ .Values.secrets.APPINSIGHTS_INSTRUMENTATIONKEY | b64enc | quote }}
   API_CLIENT_ID: {{ .Values.secrets.API_CLIENT_ID | b64enc | quote }} 
   API_CLIENT_SECRET: {{ .Values.secrets.API_CLIENT_SECRET | b64enc | quote }}
+  SYSTEM_CLIENT_ID: {{ .Values.secrets.SYSTEM_CLIENT_ID | b64enc | quote }}
+  SYSTEM_CLIENT_SECRET: {{ .Values.secrets.SYSTEM_CLIENT_SECRET | b64enc | quote }}
   NOTIFY_API_KEY: {{ .Values.secrets.NOTIFY_API_KEY | b64enc | quote }}
   SESSION_SECRET: {{ .Values.secrets.SESSION_SECRET | b64enc | quote }}

--- a/integration-tests/mockApis/elite2api.js
+++ b/integration-tests/mockApis/elite2api.js
@@ -65,7 +65,7 @@ module.exports = {
     return stubFor({
       request: {
         method: 'POST',
-        urlPattern: `/api/bookings/offenders`,
+        urlPattern: `/api/bookings/offenders\\?activeOnly=false`,
         bodyPatterns: [{ equalToJson: ['A1234AC'] }],
       },
       response: {

--- a/server/app.js
+++ b/server/app.js
@@ -42,6 +42,7 @@ module.exports = function createApp({
   userService,
   reviewService,
   reportingService,
+  systemToken,
 }) {
   const app = express()
 
@@ -246,12 +247,13 @@ module.exports = function createApp({
       reportService,
       involvedStaffService,
       reviewService,
+      systemToken,
     })
   )
 
   app.use(
     '/api/',
-    createApiRouter({ authenticationMiddleware, offenderService, reportingService, involvedStaffService })
+    createApiRouter({ authenticationMiddleware, offenderService, reportingService, involvedStaffService, systemToken })
   )
 
   app.use((req, res, next) => {

--- a/server/config.js
+++ b/server/config.js
@@ -63,6 +63,8 @@ module.exports = {
       },
       apiClientId: get('API_CLIENT_ID', 'use-of-force-client', requiredInProduction),
       apiClientSecret: get('API_CLIENT_SECRET', 'clientsecret', requiredInProduction),
+      systemClientId: get('SYSTEM_CLIENT_ID', get('API_CLIENT_ID', 'use-of-force-system'), requiredInProduction),
+      systemClientSecret: get('SYSTEM_CLIENT_SECRET', get('API_CLIENT_SECRET', 'clientsecret'), requiredInProduction),
     },
     elite2: {
       url: get('ELITE2API_ENDPOINT_URL', 'http://localhost:8080', requiredInProduction),

--- a/server/data/elite2ClientBuilder.js
+++ b/server/data/elite2ClientBuilder.js
@@ -31,7 +31,7 @@ module.exports = token => {
       return userGet({ path })
     },
     async getOffenders(offenderNos) {
-      const path = `${apiUrl}/api/bookings/offenders`
+      const path = `${apiUrl}/api/bookings/offenders?activeOnly=false`
       return userPost({ path, data: offenderNos })
     },
     async getUser() {
@@ -81,7 +81,7 @@ function userGetBuilder(token) {
 
       return raw ? result : result.body
     } catch (error) {
-      logger.warn(error, 'Error calling elite2api')
+      logger.warn(error, `Error calling elite2api: ${path}`)
       throw error
     }
   }
@@ -106,7 +106,7 @@ function userPostBuilder(token) {
 
       return raw ? result : result.body
     } catch (error) {
-      logger.warn(error, 'Error calling elite2api')
+      logger.warn(error, `Error calling elite2api: ${path}`)
       throw error
     }
   }

--- a/server/data/elite2ClientBuilder.test.js
+++ b/server/data/elite2ClientBuilder.test.js
@@ -75,7 +75,7 @@ describe('elite2Client', () => {
 
     it('should return data from api', async () => {
       fakeElite2Api
-        .post('/api/bookings/offenders', offenderNos)
+        .post('/api/bookings/offenders?activeOnly=false', offenderNos)
         .matchHeader('authorization', `Bearer ${token}`)
         .reply(200, offenders)
 

--- a/server/index.js
+++ b/server/index.js
@@ -10,7 +10,7 @@ const statementsClient = require('./data/statementsClient')
 const reportingClient = require('./data/reportingClient')
 
 const elite2ClientBuilder = require('./data/elite2ClientBuilder')
-const authClientBuilder = require('./data/authClientBuilder')
+const { authClientBuilder, systemToken } = require('./data/authClientBuilder')
 
 const createSignInService = require('./authentication/signInService')
 
@@ -52,6 +52,7 @@ const app = createApp({
   userService,
   reviewService,
   reportingService,
+  systemToken,
 })
 
 module.exports = app

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -3,7 +3,13 @@ const path = require('path')
 const httpError = require('http-errors')
 const asyncMiddleware = require('../middleware/asyncMiddleware')
 
-module.exports = function Index({ authenticationMiddleware, offenderService, reportingService, involvedStaffService }) {
+module.exports = function Index({
+  authenticationMiddleware,
+  offenderService,
+  reportingService,
+  involvedStaffService,
+  systemToken,
+}) {
   const router = express.Router()
 
   router.use(authenticationMiddleware())
@@ -36,7 +42,7 @@ module.exports = function Index({ authenticationMiddleware, offenderService, rep
 
       const { reportId, username } = req.params
 
-      await involvedStaffService.addInvolvedStaff(res.locals.user.token, reportId, username)
+      await involvedStaffService.addInvolvedStaff(systemToken(res.locals.user.username), reportId, username)
       res.json({ result: 'ok' })
     })
   )
@@ -73,7 +79,7 @@ module.exports = function Index({ authenticationMiddleware, offenderService, rep
       const agencyId = res.locals.user.activeCaseLoadId
 
       const results = await reportingService.getMostOftenInvolvedPrisoners(
-        res.locals.user.token,
+        systemToken(res.locals.user.username),
         agencyId,
         parseInt(month, 10),
         parseInt(year, 10)

--- a/server/routes/api.test.js
+++ b/server/routes/api.test.js
@@ -14,7 +14,12 @@ const involvedStaffService = {
   addInvolvedStaff: jest.fn(),
 }
 
-const route = createRouter({ authenticationMiddleware, reportingService, involvedStaffService })
+const route = createRouter({
+  authenticationMiddleware,
+  reportingService,
+  involvedStaffService,
+  systemToken: username => `${username}-token`,
+})
 
 let app
 
@@ -38,7 +43,7 @@ describe('api', () => {
           expect(res.body).toEqual({ result: 'ok' })
         })
 
-      expect(involvedStaffService.addInvolvedStaff).toBeCalledWith('token', '1', 'sally')
+      expect(involvedStaffService.addInvolvedStaff).toBeCalledWith('user1-token', '1', 'sally')
     })
 
     it('should not resolve for reviewer', async () => {
@@ -102,7 +107,7 @@ describe('api', () => {
             expect(res.text).toContain('Some,Csv,Content for prisoners')
           })
 
-        expect(reportingService.getMostOftenInvolvedPrisoners).toBeCalledWith('token', 'LEI', 10, 2019)
+        expect(reportingService.getMostOftenInvolvedPrisoners).toBeCalledWith('user1-token', 'LEI', 10, 2019)
       })
 
       it('should not render for standard user', async () => {

--- a/server/routes/incidents.test.js
+++ b/server/routes/incidents.test.js
@@ -32,6 +32,7 @@ const route = createRouter({
   involvedStaffService,
   offenderService,
   reviewService,
+  systemToken: username => `${username}-token`,
 })
 
 let app

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -16,11 +16,19 @@ module.exports = function Index({
   reportService,
   involvedStaffService,
   reviewService,
+  systemToken,
 }) {
   const router = express.Router()
 
-  const incidents = CreateIncidentRoutes({ reportService, involvedStaffService, offenderService, reviewService })
-  const statements = CreateStatementRoutes({ statementService, offenderService })
+  const incidents = CreateIncidentRoutes({
+    reportService,
+    involvedStaffService,
+    offenderService,
+    reviewService,
+    systemToken,
+  })
+
+  const statements = CreateStatementRoutes({ statementService, offenderService, systemToken })
 
   const createReport = CreateReportRoutes({
     reportService,

--- a/server/routes/statements.js
+++ b/server/routes/statements.js
@@ -5,7 +5,7 @@ const { processInput } = require('../services/validation')
 const { links } = require('../config.js')
 const { StatementStatus } = require('../config/types')
 
-module.exports = function CreateReportRoutes({ statementService, offenderService }) {
+module.exports = function CreateReportRoutes({ statementService, offenderService, systemToken }) {
   const getOffenderNames = (token, incidents) => {
     const offenderNos = incidents.map(incident => incident.offenderNo)
     return offenderService.getOffenderNames(token, offenderNos)
@@ -24,7 +24,10 @@ module.exports = function CreateReportRoutes({ statementService, offenderService
       const awaiting = await statementService.getStatements(req.user.username, StatementStatus.PENDING)
       const completed = await statementService.getStatements(req.user.username, StatementStatus.SUBMITTED)
 
-      const namesByOffenderNumber = await getOffenderNames(res.locals.user.token, [...awaiting, ...completed])
+      const namesByOffenderNumber = await getOffenderNames(systemToken(res.locals.user.username), [
+        ...awaiting,
+        ...completed,
+      ])
       const awaitingStatements = awaiting.map(toStatement(namesByOffenderNumber))
       const completedStatements = completed.map(toStatement(namesByOffenderNumber))
 
@@ -47,7 +50,10 @@ module.exports = function CreateReportRoutes({ statementService, offenderService
 
       const errors = req.flash('errors')
       const statement = await statementService.getStatementForUser(req.user.username, reportId, StatementStatus.PENDING)
-      const offenderDetail = await offenderService.getOffenderDetails(res.locals.user.token, statement.bookingId)
+      const offenderDetail = await offenderService.getOffenderDetails(
+        systemToken(res.locals.user.username),
+        statement.bookingId
+      )
       const { displayName, offenderNo } = offenderDetail
 
       res.render('pages/statement/write-your-statement', {
@@ -93,7 +99,10 @@ module.exports = function CreateReportRoutes({ statementService, offenderService
       const { reportId } = req.params
 
       const statement = await statementService.getStatementForUser(req.user.username, reportId, StatementStatus.PENDING)
-      const offenderDetail = await offenderService.getOffenderDetails(res.locals.user.token, statement.bookingId)
+      const offenderDetail = await offenderService.getOffenderDetails(
+        systemToken(res.locals.user.username),
+        statement.bookingId
+      )
       const { displayName, offenderNo } = offenderDetail
       const errors = req.flash('errors')
       res.render('pages/statement/check-your-statement', {
@@ -133,7 +142,10 @@ module.exports = function CreateReportRoutes({ statementService, offenderService
         StatementStatus.SUBMITTED
       )
 
-      const offenderDetail = await offenderService.getOffenderDetails(res.locals.user.token, statement.bookingId)
+      const offenderDetail = await offenderService.getOffenderDetails(
+        systemToken(res.locals.user.username),
+        statement.bookingId
+      )
       const { displayName, offenderNo } = offenderDetail
       res.render('pages/statement/your-statement', {
         data: {
@@ -153,7 +165,10 @@ module.exports = function CreateReportRoutes({ statementService, offenderService
         reportId,
         StatementStatus.SUBMITTED
       )
-      const offenderDetail = await offenderService.getOffenderDetails(res.locals.user.token, statement.bookingId)
+      const offenderDetail = await offenderService.getOffenderDetails(
+        systemToken(res.locals.user.username),
+        statement.bookingId
+      )
       const { displayName, offenderNo } = offenderDetail
 
       return res.render('pages/statement/add-comment-to-statement', {

--- a/server/routes/statements.test.js
+++ b/server/routes/statements.test.js
@@ -22,7 +22,12 @@ const offenderService = {
   getOffenderNames: () => [],
   getOffenderDetails: () => ({ displayName: 'Jimmy Choo', offenderNo: '123456' }),
 }
-const route = createRouter({ authenticationMiddleware, statementService, offenderService })
+const route = createRouter({
+  authenticationMiddleware,
+  statementService,
+  offenderService,
+  systemToken: username => `${username}-token`,
+})
 
 let app
 


### PR DESCRIPTION
Previously the prisoner name would go missing if the prisoner moved to a caseload that wasn't in the user's list.

This also fixes a similar issue when a prisoner is released.

All these places where we use the system token don't allow injecting a booking id directly - they only load a prisoner referenced from a report that belongs to the current user (or any user on any report if a reviewer).