### PR TITLE
DCS-336 Adding frontend to allow coordinators to soft delete reports

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -253,7 +253,12 @@ module.exports = function createApp({
 
   app.use(
     '/api/',
-    createApiRouter({ authenticationMiddleware, offenderService, reportingService, involvedStaffService, systemToken })
+    createApiRouter({
+      authenticationMiddleware,
+      offenderService,
+      reportingService,
+      systemToken,
+    })
   )
 
   app.use((req, res, next) => {

--- a/server/data/authClientBuilder.js
+++ b/server/data/authClientBuilder.js
@@ -45,7 +45,7 @@ module.exports = {
 
   async systemToken(username) {
     const systemClientToken = await getSystemClientToken(username)
-    return systemClientToken.token
+    return systemClientToken.access_token
   },
 }
 

--- a/server/data/authClientBuilder.test.js
+++ b/server/data/authClientBuilder.test.js
@@ -6,7 +6,7 @@ describe('authClient', () => {
   let fakeApi
   let client
 
-  const token = { token: 'token-1' }
+  const token = { access_token: 'token-1' }
 
   beforeEach(() => {
     fakeApi = nock(config.apis.oauth2.url)
@@ -87,7 +87,7 @@ describe('authClient', () => {
         .reply(200, token)
 
       const output = await systemToken(userName)
-      expect(output).toEqual(token.token)
+      expect(output).toEqual(token.access_token)
     })
 
     it('without username', async () => {
@@ -98,7 +98,7 @@ describe('authClient', () => {
         .reply(200, token)
 
       const output = await systemToken()
-      expect(output).toEqual(token.token)
+      expect(output).toEqual(token.access_token)
     })
   })
 })

--- a/server/middleware/authorisationMiddleware.js
+++ b/server/middleware/authorisationMiddleware.js
@@ -1,9 +1,19 @@
 const jwtDecode = require('jwt-decode')
 
+const COORDINATOR = 'ROLE_USE_OF_FORCE_COORDINATOR'
+const REVIEWER = 'ROLE_USE_OF_FORCE_REVIEWER'
+
 module.exports = (req, res, next) => {
   if (res.locals && res.locals.user && res.locals.user.token) {
     const { authorities: roles = [] } = jwtDecode(res.locals.user.token)
-    res.locals.user = { isReviewer: roles.includes('ROLE_USE_OF_FORCE_REVIEWER'), ...res.locals.user }
+
+    const isAnyOf = options => options.some(role => roles.includes(role))
+
+    res.locals.user = {
+      isReviewer: isAnyOf([REVIEWER, COORDINATOR]),
+      isCoordinator: isAnyOf([COORDINATOR]),
+      ...res.locals.user,
+    }
     return next()
   }
   req.session.returnTo = req.originalUrl

--- a/server/middleware/authorisationMiddleware.test.js
+++ b/server/middleware/authorisationMiddleware.test.js
@@ -28,27 +28,71 @@ describe('authorisationMiddleware', () => {
     },
   })
 
-  test('Should populate isReviewer for reviewer', () => {
-    const res = createResWithToken({ authorities: ['ROLE_USE_OF_FORCE_REVIEWER'] })
+  describe('isReviewer', () => {
+    test('Should populate isReviewer for reviewer', () => {
+      const res = createResWithToken({ authorities: ['ROLE_USE_OF_FORCE_REVIEWER'] })
 
-    authorisationMiddleware(req, res, next)
+      authorisationMiddleware(req, res, next)
 
-    expect(res.locals.user.isReviewer).toEqual(true)
+      expect(res.locals.user.isReviewer).toEqual(true)
+    })
+
+    test('Should populate isReviewer for coordinator', () => {
+      const res = createResWithToken({ authorities: ['ROLE_USE_OF_FORCE_COORDINATOR'] })
+
+      authorisationMiddleware(req, res, next)
+
+      expect(res.locals.user.isReviewer).toEqual(true)
+    })
+
+    test('Should populate isReviewer for standard user', () => {
+      const res = createResWithToken({ authorities: [] })
+
+      authorisationMiddleware(req, res, next)
+
+      expect(res.locals.user.isReviewer).toEqual(false)
+    })
+
+    test('Should populate isReviewer when no authorities at all', () => {
+      const res = createResWithToken()
+
+      authorisationMiddleware(req, res, next)
+
+      expect(res.locals.user.isReviewer).toEqual(false)
+    })
   })
 
-  test('Should populate isReviewer for standard user', () => {
-    const res = createResWithToken({ authorities: [] })
+  describe('isCoordinator', () => {
+    test('Should populate isCoordinator for reviewer', () => {
+      const res = createResWithToken({ authorities: ['ROLE_USE_OF_FORCE_REVIEWER'] })
 
-    authorisationMiddleware(req, res, next)
+      authorisationMiddleware(req, res, next)
 
-    expect(res.locals.user.isReviewer).toEqual(false)
-  })
+      expect(res.locals.user.isCoordinator).toEqual(false)
+    })
 
-  test('Should populate isReviewer when no authorities at all', () => {
-    const res = createResWithToken()
+    test('Should populate isCoordinator for coordinator', () => {
+      const res = createResWithToken({ authorities: ['ROLE_USE_OF_FORCE_COORDINATOR'] })
 
-    authorisationMiddleware(req, res, next)
+      authorisationMiddleware(req, res, next)
 
-    expect(res.locals.user.isReviewer).toEqual(false)
+      expect(res.locals.user.isCoordinator).toEqual(true)
+    })
+
+    test('Should populate isCoordinator for standard user', () => {
+      const res = createResWithToken({ authorities: [] })
+
+      authorisationMiddleware(req, res, next)
+
+      expect(res.locals.user.isCoordinator).toEqual(false)
+    })
+
+    test('Should populate isCoordinator when no authorities at all', () => {
+      const res = createResWithToken()
+
+      authorisationMiddleware(req, res, next)
+
+      expect(res.locals.user.isCoordinator).toEqual(false)
+    })
   })
 })

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -3,13 +3,7 @@ const path = require('path')
 const httpError = require('http-errors')
 const asyncMiddleware = require('../middleware/asyncMiddleware')
 
-module.exports = function Index({
-  authenticationMiddleware,
-  offenderService,
-  reportingService,
-  involvedStaffService,
-  systemToken,
-}) {
+module.exports = function Index({ authenticationMiddleware, offenderService, reportingService, systemToken }) {
   const router = express.Router()
 
   router.use(authenticationMiddleware())
@@ -28,24 +22,6 @@ module.exports = function Index({
         res.sendFile(placeHolder)
       })
   })
-
-  /**
-   * TODO: integrate this into the app properly once we have designs and time.
-   * This is currently a GET to get around CSRF issues and to allow access via a browser using current authenticated session :-/
-   */
-  router.get(
-    '/report/:reportId/involved-staff/:username',
-    asyncMiddleware(async (req, res) => {
-      if (!res.locals.user.isReviewer) {
-        throw httpError(401, 'Not authorised to access this resource')
-      }
-
-      const { reportId, username } = req.params
-
-      await involvedStaffService.addInvolvedStaff(systemToken(res.locals.user.username), reportId, username)
-      res.json({ result: 'ok' })
-    })
-  )
 
   router.get(
     '/reports/mostOftenInvolvedStaff/:year/:month',
@@ -79,7 +55,7 @@ module.exports = function Index({
       const agencyId = res.locals.user.activeCaseLoadId
 
       const results = await reportingService.getMostOftenInvolvedPrisoners(
-        systemToken(res.locals.user.username),
+        await systemToken(res.locals.user.username),
         agencyId,
         parseInt(month, 10),
         parseInt(year, 10)

--- a/server/routes/api.test.js
+++ b/server/routes/api.test.js
@@ -10,15 +10,10 @@ const reportingService = {
   getMostOftenInvolvedPrisoners: jest.fn(),
 }
 
-const involvedStaffService = {
-  addInvolvedStaff: jest.fn(),
-}
-
 const route = createRouter({
   authenticationMiddleware,
   offenderService: {},
   reportingService,
-  involvedStaffService,
   systemToken: username => `${username}-token`,
 })
 
@@ -31,34 +26,6 @@ describe('api', () => {
 
   afterEach(() => {
     jest.resetAllMocks()
-  })
-
-  describe('add involved staff', () => {
-    it('should resolve for reviewer', async () => {
-      userSupplier.mockReturnValue(reviewerUser)
-
-      await request(app)
-        .get('/report/1/involved-staff/sally')
-        .expect('Content-Type', 'application/json; charset=utf-8')
-        .expect(res => {
-          expect(res.body).toEqual({ result: 'ok' })
-        })
-
-      expect(involvedStaffService.addInvolvedStaff).toBeCalledWith('user1-token', '1', 'sally')
-    })
-
-    it('should not resolve for reviewer', async () => {
-      userSupplier.mockReturnValue(user)
-
-      await request(app)
-        .get('/report/1/involved-staff/sally')
-        .expect(401)
-        .expect(res => {
-          expect(res.text).toContain('Not authorised to access this resource')
-        })
-
-      expect(involvedStaffService.addInvolvedStaff).not.toBeCalled()
-    })
   })
 
   describe('reporting', () => {

--- a/server/routes/coordinator.js
+++ b/server/routes/coordinator.js
@@ -1,0 +1,38 @@
+const httpError = require('http-errors')
+
+module.exports = function Index({ reportService, involvedStaffService, systemToken }) {
+  /**
+   * TODO: integrate this into the app properly once we have designs and time.
+   * This is currently a GET to get around CSRF issues and to allow access via a browser using current authenticated session :-/
+   */
+  return {
+    addInvolvedStaff: async (req, res) => {
+      if (!res.locals.user.isCoordinator) {
+        throw httpError(401, 'Not authorised to access this resource')
+      }
+
+      const { reportId, username } = req.params
+
+      await involvedStaffService.addInvolvedStaff(await systemToken(res.locals.user.username), reportId, username)
+      res.json({ result: 'ok' })
+    },
+
+    deleteConfirm: async (req, res) => {
+      if (!res.locals.user.isCoordinator) {
+        throw httpError(401, 'Not authorised to access this resource')
+      }
+      res.render('pages/coordinator/confirm-deletion.html', { reportId: req.params.reportId })
+    },
+
+    deleteReport: async (req, res) => {
+      if (!res.locals.user.isCoordinator) {
+        throw httpError(401, 'Not authorised to access this resource')
+      }
+
+      const { reportId } = req.params
+
+      await reportService.deleteReport(res.locals.user.username, reportId)
+      res.redirect('/')
+    },
+  }
+}

--- a/server/routes/coordinator.test.js
+++ b/server/routes/coordinator.test.js
@@ -1,0 +1,151 @@
+const request = require('supertest')
+const { appWithAllRoutes, user, reviewerUser, coordinatorUser } = require('./testutils/appSetup')
+
+const userSupplier = jest.fn()
+
+const involvedStaffService = {
+  addInvolvedStaff: jest.fn(),
+}
+const reportService = {
+  deleteReport: jest.fn(),
+}
+
+let app
+
+describe('coordinator', () => {
+  beforeEach(() => {
+    app = appWithAllRoutes(
+      {
+        involvedStaffService,
+        reportService,
+      },
+      userSupplier
+    )
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('add involved staff', () => {
+    it('should resolve for coordinator', async () => {
+      userSupplier.mockReturnValue(coordinatorUser)
+
+      await request(app)
+        .get('/report/1/involved-staff/sally')
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+        .expect(res => {
+          expect(res.body).toEqual({ result: 'ok' })
+        })
+
+      expect(involvedStaffService.addInvolvedStaff).toBeCalledWith('user1-token', '1', 'sally')
+    })
+
+    it('should not resolve for reviewer', async () => {
+      userSupplier.mockReturnValue(reviewerUser)
+
+      await request(app)
+        .get('/report/1/involved-staff/sally')
+        .expect(401)
+        .expect(res => {
+          expect(res.text).toContain('Not authorised to access this resource')
+        })
+
+      expect(involvedStaffService.addInvolvedStaff).not.toBeCalled()
+    })
+
+    it('should not resolve for user', async () => {
+      userSupplier.mockReturnValue(user)
+
+      await request(app)
+        .get('/report/1/involved-staff/sally')
+        .expect(401)
+        .expect(res => {
+          expect(res.text).toContain('Not authorised to access this resource')
+        })
+
+      expect(involvedStaffService.addInvolvedStaff).not.toBeCalled()
+    })
+  })
+
+  describe('Confirm delete', () => {
+    it('should resolve for reviewer', async () => {
+      userSupplier.mockReturnValue(coordinatorUser)
+
+      await request(app)
+        .get('/coordinator/report/1/confirm-delete')
+        .expect(200)
+        .expect('Content-Type', 'text/html; charset=utf-8')
+        .expect(res => {
+          expect(res.text).toContain('Are you you sure you want to delete report')
+        })
+    })
+
+    it('should not resolve for reviewer', async () => {
+      userSupplier.mockReturnValue(reviewerUser)
+
+      await request(app)
+        .get('/coordinator/report/1/confirm-delete')
+        .expect(401)
+        .expect(res => {
+          expect(res.text).toContain('Not authorised to access this resource')
+        })
+
+      expect(involvedStaffService.addInvolvedStaff).not.toBeCalled()
+    })
+
+    it('should not resolve for user', async () => {
+      userSupplier.mockReturnValue(user)
+
+      await request(app)
+        .get('/coordinator/report/1/confirm-delete')
+        .expect(401)
+        .expect(res => {
+          expect(res.text).toContain('Not authorised to access this resource')
+        })
+
+      expect(involvedStaffService.addInvolvedStaff).not.toBeCalled()
+    })
+  })
+
+  describe('Delete user', () => {
+    it('should resolve for coordinator', async () => {
+      userSupplier.mockReturnValue(coordinatorUser)
+
+      await request(app)
+        .post('/coordinator/report/123/delete')
+        .expect(302)
+        .expect('Location', '/')
+        .expect(() => {
+          expect(reportService.deleteReport).toHaveBeenCalledWith('user1', '123')
+        })
+    })
+
+    it('should not resolve for reviewer', async () => {
+      userSupplier.mockReturnValue(reviewerUser)
+
+      await request(app)
+        .post('/coordinator/report/123/delete')
+        .expect(401)
+        .expect(res => {
+          expect(res.text).toContain('Not authorised to access this resource')
+        })
+
+      expect(involvedStaffService.addInvolvedStaff).not.toBeCalled()
+    })
+
+    it('should not resolve for user', async () => {
+      userSupplier.mockReturnValue(user)
+
+      await request(app)
+        .post('/coordinator/report/123/delete')
+        .expect(401)
+        .expect(res => {
+          expect(res.text).toContain('Not authorised to access this resource')
+        })
+
+      expect(involvedStaffService.addInvolvedStaff).not.toBeCalled()
+    })
+  })
+})

--- a/server/routes/incidents.js
+++ b/server/routes/incidents.js
@@ -27,9 +27,12 @@ module.exports = function CreateReportRoutes({
 
   const buildReportData = async (report, res) => {
     const { id, form, incidentDate, bookingId, reporterName, submittedDate } = report
-    const offenderDetail = await offenderService.getOffenderDetails(systemToken(res.locals.user.username), bookingId)
+    const offenderDetail = await offenderService.getOffenderDetails(
+      await systemToken(res.locals.user.username),
+      bookingId
+    )
     const { description: locationDescription = '' } = await offenderService.getLocation(
-      systemToken(res.locals.user.username),
+      await systemToken(res.locals.user.username),
       form.incidentDetails.locationId
     )
     const involvedStaff = await involvedStaffService.getInvolvedStaff(id)
@@ -61,7 +64,7 @@ module.exports = function CreateReportRoutes({
 
       const { awaiting, completed } = await reviewService.getReports(res.locals.user.activeCaseLoadId)
 
-      const namesByOffenderNumber = await getOffenderNames(systemToken(res.locals.user.username), [
+      const namesByOffenderNumber = await getOffenderNames(await systemToken(res.locals.user.username), [
         ...awaiting,
         ...completed,
       ])
@@ -83,7 +86,7 @@ module.exports = function CreateReportRoutes({
         ReportStatus.COMPLETE,
       ])
 
-      const namesByOffenderNumber = await getOffenderNames(systemToken(res.locals.user.username), [
+      const namesByOffenderNumber = await getOffenderNames(await systemToken(res.locals.user.username), [
         ...awaiting,
         ...completed,
       ])
@@ -135,7 +138,10 @@ module.exports = function CreateReportRoutes({
       const report = await reviewService.getReport(reportId)
 
       const { bookingId, reporterName, submittedDate } = report
-      const offenderDetail = await offenderService.getOffenderDetails(systemToken(res.locals.user.username), bookingId)
+      const offenderDetail = await offenderService.getOffenderDetails(
+        await systemToken(res.locals.user.username),
+        bookingId
+      )
 
       const statements = await reviewService.getStatements(reportId)
 
@@ -153,7 +159,7 @@ module.exports = function CreateReportRoutes({
       const statement = await reviewService.getStatement(statementId)
 
       const offenderDetail = await offenderService.getOffenderDetails(
-        systemToken(res.locals.user.username),
+        await systemToken(res.locals.user.username),
         statement.bookingId
       )
       const { displayName, offenderNo } = offenderDetail

--- a/server/routes/incidents.test.js
+++ b/server/routes/incidents.test.js
@@ -1,5 +1,5 @@
 const request = require('supertest')
-const { appWithAllRoutes, user, reviewerUser } = require('./testutils/appSetup')
+const { appWithAllRoutes, user, reviewerUser, coordinatorUser } = require('./testutils/appSetup')
 
 const userSupplier = jest.fn()
 
@@ -92,6 +92,42 @@ describe('GET /your-report', () => {
     reportService.getReport.mockReturnValue(undefined)
     return request(app)
       .get('/1/your-report')
+      .expect(500)
+  })
+})
+
+describe('GET /view-report', () => {
+  it('should render page for reviewer', () => {
+    userSupplier.mockReturnValue(reviewerUser)
+    reviewService.getReport.mockReturnValue({ id: 1, form: { incidentDetails: {} } })
+    return request(app)
+      .get('/1/view-report')
+      .expect(200)
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain('Use of force report')
+        expect(res.text).not.toContain('Delete report')
+      })
+  })
+
+  it('should render page for coordinator', () => {
+    userSupplier.mockReturnValue(coordinatorUser)
+    reviewService.getReport.mockReturnValue({ id: 1, form: { incidentDetails: {} } })
+    return request(app)
+      .get('/1/view-report')
+      .expect(200)
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain('Use of force report')
+        expect(res.text).toContain('Delete report')
+      })
+  })
+
+  it('should fail to render page when no report', () => {
+    userSupplier.mockReturnValue(reviewerUser)
+    reviewService.getReport.mockReturnValue(undefined)
+    return request(app)
+      .get('/1/view-report')
       .expect(500)
   })
 })

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -6,8 +6,9 @@ const asyncMiddleware = require('../middleware/asyncMiddleware')
 const CreateIncidentRoutes = require('./incidents')
 const CreateStatementRoutes = require('./statements')
 const CreateReportRoutes = require('./createReport')
-const CheckYourAnswerRoutes = require('./checkYourAnswers')
-const ReportUseOfForce = require('./reportUseOfForce')
+const CreateCheckYourAnswerRoutes = require('./checkYourAnswers')
+const CreateReportUseOfForceRoutes = require('./reportUseOfForce')
+const CreateCoordinatorRoutes = require('./coordinator')
 
 module.exports = function Index({
   authenticationMiddleware,
@@ -36,9 +37,15 @@ module.exports = function Index({
     involvedStaffService,
   })
 
-  const checkYourAnswers = CheckYourAnswerRoutes({ reportService, offenderService, involvedStaffService })
+  const checkYourAnswers = CreateCheckYourAnswerRoutes({ reportService, offenderService, involvedStaffService })
 
-  const reportUseOfForce = ReportUseOfForce({ reportService, offenderService })
+  const reportUseOfForce = CreateReportUseOfForceRoutes({ reportService, offenderService })
+
+  const coordinator = CreateCoordinatorRoutes({
+    reportService,
+    involvedStaffService,
+    systemToken,
+  })
 
   router.use(authenticationMiddleware())
   router.use(bodyParser.urlencoded({ extended: false }))
@@ -106,6 +113,11 @@ module.exports = function Index({
   get('/:reportId/view-report', incidents.reviewReport)
   get('/:reportId/view-statements', incidents.reviewStatements)
   get('/:statementId/view-statement', incidents.reviewStatement)
+
+  // Coordinator
+  get('/report/:reportId/involved-staff/:username', coordinator.addInvolvedStaff)
+  get('/coordinator/report/:reportId/confirm-delete', coordinator.deleteConfirm)
+  post('/coordinator/report/:reportId/delete', coordinator.deleteReport)
 
   return router
 }

--- a/server/routes/statements.js
+++ b/server/routes/statements.js
@@ -24,7 +24,7 @@ module.exports = function CreateReportRoutes({ statementService, offenderService
       const awaiting = await statementService.getStatements(req.user.username, StatementStatus.PENDING)
       const completed = await statementService.getStatements(req.user.username, StatementStatus.SUBMITTED)
 
-      const namesByOffenderNumber = await getOffenderNames(systemToken(res.locals.user.username), [
+      const namesByOffenderNumber = await getOffenderNames(await systemToken(res.locals.user.username), [
         ...awaiting,
         ...completed,
       ])
@@ -51,7 +51,7 @@ module.exports = function CreateReportRoutes({ statementService, offenderService
       const errors = req.flash('errors')
       const statement = await statementService.getStatementForUser(req.user.username, reportId, StatementStatus.PENDING)
       const offenderDetail = await offenderService.getOffenderDetails(
-        systemToken(res.locals.user.username),
+        await systemToken(res.locals.user.username),
         statement.bookingId
       )
       const { displayName, offenderNo } = offenderDetail
@@ -99,7 +99,7 @@ module.exports = function CreateReportRoutes({ statementService, offenderService
 
       const statement = await statementService.getStatementForUser(req.user.username, reportId, StatementStatus.PENDING)
       const offenderDetail = await offenderService.getOffenderDetails(
-        systemToken(res.locals.user.username),
+        await systemToken(res.locals.user.username),
         statement.bookingId
       )
       const { displayName, offenderNo } = offenderDetail
@@ -142,7 +142,7 @@ module.exports = function CreateReportRoutes({ statementService, offenderService
       )
 
       const offenderDetail = await offenderService.getOffenderDetails(
-        systemToken(res.locals.user.username),
+        await systemToken(res.locals.user.username),
         statement.bookingId
       )
       const { displayName, offenderNo } = offenderDetail
@@ -165,7 +165,7 @@ module.exports = function CreateReportRoutes({ statementService, offenderService
         StatementStatus.SUBMITTED
       )
       const offenderDetail = await offenderService.getOffenderDetails(
-        systemToken(res.locals.user.username),
+        await systemToken(res.locals.user.username),
         statement.bookingId
       )
       const { displayName, offenderNo } = offenderDetail

--- a/server/routes/testutils/appSetup.js
+++ b/server/routes/testutils/appSetup.js
@@ -29,6 +29,19 @@ const reviewerUser = {
   username: 'user1',
   displayName: 'First Last',
   isReviewer: true,
+  isCoordinator: false,
+  activeCaseLoadId: 'LEI',
+}
+
+const coordinatorUser = {
+  firstName: 'first',
+  lastName: 'last',
+  userId: 'id',
+  token: 'token',
+  username: 'user1',
+  displayName: 'First Last',
+  isReviewer: true,
+  isCoordinator: true,
   activeCaseLoadId: 'LEI',
 }
 
@@ -72,4 +85,4 @@ const appWithAllRoutes = (overrides = {}, userSupplier = () => user) => {
   return appSetup(route, userSupplier)
 }
 
-module.exports = { appSetup, appWithAllRoutes, user, reviewerUser }
+module.exports = { appSetup, appWithAllRoutes, user, reviewerUser, coordinatorUser }

--- a/server/views/pages/coordinator/confirm-deletion.html
+++ b/server/views/pages/coordinator/confirm-deletion.html
@@ -1,0 +1,42 @@
+{% extends "../../partials/layout.html" %} 
+{% from "govuk/components/button/macro.njk" import govukButton %} 
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %} 
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% import "../reportDetailMacro.njk" as reportDetail %} 
+
+{% set pageTitle = 'Are you you sure you want to delete report with incident id: ' + reportId  + '?' %}
+
+{% block content %}
+<div class="govuk-grid-row govuk-body">
+  <div class="govuk-grid-column-three-quarters govuk-!-margin-bottom-9 ">
+    <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <p>This will permanently delete the report and associated statements.</p>
+        <form method="post" action="/coordinator/report/{{ reportId }}/delete">
+          <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+        
+        {{
+          govukButton({
+            text: 'Confirm deletion',
+            name: 'confirm',
+            classes: 'govuk-button  govuk-!-margin-top-5',
+            attributes: { 'data-qa': 'continue' }
+          })
+        }}
+        {{
+          govukButton({
+            text: 'Cancel',
+            name: 'cancel',
+            href: '/',
+            classes: 'govuk-button--secondary float-right govuk-!-margin-top-5',
+            attributes: { 'data-qa': 'continue' }
+          })
+        }}
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+
+{% endblock %}

--- a/server/views/pages/reviewer/view-report.html
+++ b/server/views/pages/reviewer/view-report.html
@@ -31,7 +31,18 @@
         attributes: { 'data-qa': 'continue' }
       })
     }}
-  </div>
+  {% if user.isCoordinator %}
+    {{
+      govukButton({
+        text: 'Delete report',
+        name: 'delete',
+        href: '/coordinator/report/' + data.incidentId + '/confirm-delete',
+        classes: 'govuk-button govuk-button--warning float-right govuk-!-margin-top-5',
+        attributes: { 'data-qa': 'continue' }
+      })
+    }}
+  {% endif %}  
+  </div>    
 </div>
 
 {% endblock %}


### PR DESCRIPTION
A delete button appears on the view-report screen if the current user is a coordinator.
This goes to a confirmation page and clicking the button there will trigger soft delete which redirects to the home page.

Need to get content folk to look at it and suggest better text/interaction design.

Also fixing new system token bug - was trying to read an unknown property called token from the token (rather than access_token) 