### PR TITLE
DCS-376 Allow user to alway complete reports

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -257,6 +257,7 @@ module.exports = function createApp({
       authenticationMiddleware,
       offenderService,
       reportingService,
+      reportService,
       systemToken,
     })
   )

--- a/server/routes/checkYourAnswers.js
+++ b/server/routes/checkYourAnswers.js
@@ -1,7 +1,7 @@
 const { properCaseFullName } = require('../utils/utils')
 const reportSummary = require('./model/reportSummary')
 
-module.exports = function CheckAnswerRoutes({ reportService, offenderService, involvedStaffService }) {
+module.exports = function CheckAnswerRoutes({ reportService, offenderService, involvedStaffService, systemToken }) {
   const currentUserIfNotPresent = (involvedStaff, currentUser) =>
     involvedStaff.find(staff => staff.username === currentUser.username)
       ? []
@@ -20,10 +20,13 @@ module.exports = function CheckAnswerRoutes({ reportService, offenderService, in
         return res.redirect(`/`)
       }
 
-      const offenderDetail = await offenderService.getOffenderDetails(res.locals.user.token, parseInt(bookingId, 10))
+      const offenderDetail = await offenderService.getOffenderDetails(
+        await systemToken(res.locals.user.username),
+        parseInt(bookingId, 10)
+      )
 
       const { description: locationDescription = '' } = await offenderService.getLocation(
-        res.locals.user.token,
+        await systemToken(res.locals.user.username),
         form.incidentDetails.locationId
       )
 

--- a/server/routes/checkYourAnswers.test.js
+++ b/server/routes/checkYourAnswers.test.js
@@ -37,6 +37,7 @@ describe('GET /check-your-answers', () => {
       .expect('Content-Type', /html/)
       .expect(res => {
         expect(res.text).toContain('Check your answers')
+        expect(offenderService.getOffenderDetails).toHaveBeenCalledWith('user1-system-token', -35)
       })
   })
 

--- a/server/routes/coordinator.test.js
+++ b/server/routes/coordinator.test.js
@@ -47,7 +47,7 @@ describe('coordinator', () => {
           expect(res.body).toEqual({ result: 'ok' })
         })
 
-      expect(involvedStaffService.addInvolvedStaff).toBeCalledWith('user1-token', '1', 'sally')
+      expect(involvedStaffService.addInvolvedStaff).toBeCalledWith('user1-system-token', '1', 'sally')
     })
 
     it('should not resolve for reviewer', async () => {

--- a/server/routes/createReport.js
+++ b/server/routes/createReport.js
@@ -29,7 +29,7 @@ const getDestination = ({ editMode, saveAndContinue }) => {
   return saveAndContinue ? types.Destinations.CONTINUE : types.Destinations.TASKLIST
 }
 
-module.exports = function NewIncidentRoutes({ reportService, offenderService, involvedStaffService }) {
+module.exports = function NewIncidentRoutes({ reportService, offenderService, involvedStaffService, systemToken }) {
   const loadForm = async req => {
     const { bookingId } = req.params
     const { id: formId, incidentDate, form = {} } = await reportService.getCurrentDraft(req.user.username, bookingId)
@@ -97,10 +97,13 @@ module.exports = function NewIncidentRoutes({ reportService, offenderService, in
 
   const viewIncidentDetails = editMode => async (req, res) => {
     const { bookingId } = req.params
-    const offenderDetail = await offenderService.getOffenderDetails(res.locals.user.token, bookingId)
-    const { displayName, offenderNo, locations } = offenderDetail
-
     const { formId, form, incidentDate = moment() } = await loadForm(req)
+
+    const offenderDetail = await offenderService.getOffenderDetails(
+      isNilOrEmpty(formId) ? res.locals.user.token : await systemToken(res.locals.user.username),
+      bookingId
+    )
+    const { displayName, offenderNo, locations } = offenderDetail
 
     const input = firstItem(req.flash('userInput'))
 

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -35,11 +35,17 @@ module.exports = function Index({
     reportService,
     offenderService,
     involvedStaffService,
+    systemToken,
   })
 
-  const checkYourAnswers = CreateCheckYourAnswerRoutes({ reportService, offenderService, involvedStaffService })
+  const checkYourAnswers = CreateCheckYourAnswerRoutes({
+    reportService,
+    offenderService,
+    involvedStaffService,
+    systemToken,
+  })
 
-  const reportUseOfForce = CreateReportUseOfForceRoutes({ reportService, offenderService })
+  const reportUseOfForce = CreateReportUseOfForceRoutes({ reportService, offenderService, systemToken })
 
   const coordinator = CreateCoordinatorRoutes({
     reportService,

--- a/server/routes/reportUseOfForce.js
+++ b/server/routes/reportUseOfForce.js
@@ -1,14 +1,15 @@
-module.exports = function ReportUseOfForceRoutes({ reportService, offenderService }) {
+const { isNilOrEmpty } = require('../utils/utils')
+
+module.exports = function ReportUseOfForceRoutes({ reportService, offenderService, systemToken }) {
   return {
     view: async (req, res) => {
       const { bookingId } = req.params
+      const { id: formId, form = {} } = await reportService.getCurrentDraft(req.user.username, bookingId)
+      const status = reportService.getReportStatus(form)
       const { displayName, offenderNo, dateOfBirth } = await offenderService.getOffenderDetails(
-        res.locals.user.token,
+        isNilOrEmpty(formId) ? res.locals.user.token : await systemToken(res.locals.user.username),
         bookingId
       )
-      const { form = {} } = await reportService.getCurrentDraft(req.user.username, bookingId)
-      const status = reportService.getReportStatus(form)
-
       res.render('pages/report-use-of-force', {
         data: { ...res.locals.formObject, displayName, offenderNo, dateOfBirth },
         bookingId: req.params.bookingId,

--- a/server/routes/reportUseOfForce.test.js
+++ b/server/routes/reportUseOfForce.test.js
@@ -19,15 +19,29 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-  reportService.getCurrentDraft.mockReset()
+  jest.resetAllMocks()
 })
 
 describe('GET /task-list', () => {
-  it('should render page content', () =>
-    request(app)
+  it('should render page content for new report', () => {
+    reportService.getCurrentDraft.mockResolvedValue({})
+    return request(app)
       .get('/report/-35/report-use-of-force')
       .expect('Content-Type', /html/)
       .expect(res => {
         expect(res.text).toContain('Report use of force')
-      }))
+        expect(offenderService.getOffenderDetails).toBeCalledWith('token', '-35')
+      })
+  })
+
+  it('should render page content for existing report', () => {
+    reportService.getCurrentDraft.mockResolvedValue({ id: '1' })
+    return request(app)
+      .get('/report/-35/report-use-of-force')
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain('Report use of force')
+        expect(offenderService.getOffenderDetails).toBeCalledWith('user1-system-token', '-35')
+      })
+  })
 })

--- a/server/routes/testutils/appSetup.js
+++ b/server/routes/testutils/appSetup.js
@@ -79,7 +79,7 @@ const appWithAllRoutes = (overrides = {}, userSupplier = () => user) => {
     reportService: {},
     involvedStaffService: {},
     reviewService: {},
-    systemToken: username => `${username}-token`,
+    systemToken: username => `${username}-system-token`,
     ...overrides,
   })
   return appSetup(route, userSupplier)

--- a/server/services/reportService.js
+++ b/server/services/reportService.js
@@ -25,6 +25,11 @@ module.exports = function createReportService({
     return complete
   }
 
+  async function isDraftInProgress(username, bookingId) {
+    const { id } = await getCurrentDraft(username, bookingId)
+    return !isNilOrEmpty(id)
+  }
+
   async function update({ currentUser, formId, bookingId, formObject, incidentDate }) {
     const incidentDateValue = incidentDate ? incidentDate.value : null
     const formValue = !isNilOrEmpty(formObject) ? formObject : null
@@ -127,5 +132,6 @@ module.exports = function createReportService({
     submit,
     deleteReport,
     getReportStatus,
+    isDraftInProgress,
   }
 }

--- a/server/services/reportService.test.js
+++ b/server/services/reportService.test.js
@@ -52,6 +52,20 @@ afterEach(() => {
   jest.resetAllMocks()
 })
 
+describe('isDraftInProgress', () => {
+  test('report is in progress', async () => {
+    incidentClient.getCurrentDraftReport.mockResolvedValue({ id: 2 })
+    const exists = await service.isDraftInProgress('user-1', 2)
+    expect(exists).toBe(true)
+    expect(incidentClient.getCurrentDraftReport).toHaveBeenCalledWith('user-1', 2)
+  })
+  test('report is not in progress', async () => {
+    incidentClient.getCurrentDraftReport.mockResolvedValue({})
+    const exists = await service.isDraftInProgress('user-1', 2)
+    expect(exists).toBe(false)
+  })
+})
+
 describe('submit', () => {
   test('it should save statements and submit the report', async () => {
     involvedStaffService.save.mockReturnValue([])


### PR DESCRIPTION
Currently a user is prevented from continuing to complete a report if the offender leaves the current prison.
This change will allow users to always see offender details if the report already exists.
(We need to prevent prison officers from seeing offender details if they do not exist in the current establishment)

This will also enable the posibility of a monitored process that will create a draft report for a prisoner that has
already left an establishment (potentially by a coordinator). The reporter will be able to continue the draft without
being given access to other caseloads.