### PR TITLE
DCS-387 Adding monitoring and tweaking job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,8 @@ commands:
               --namespace=${KUBE_ENV_NAMESPACE} \
               --values ~/git/helm_deploy/values-<< parameters.env >>.yaml \
               --values - \
-              --set image.tag="${APP_VERSION}"
+              --set image.tag="${APP_VERSION}" \
+              --set namespace="${KUBE_ENV_NAMESPACE}"
 
 executors:
   deployer:

--- a/helm_deploy/use-of-force/templates/job.yaml
+++ b/helm_deploy/use-of-force/templates/job.yaml
@@ -4,7 +4,7 @@ metadata:
   name: send-reminders
 spec:
   schedule: "*/5 * * * *"
-  concurrencyPolicy: Forbid
+  concurrencyPolicy: Replace
   jobTemplate:
     spec:
       template:
@@ -17,3 +17,4 @@ spec:
             - job/sendReminders
 {{ include "deployment.envs" . | nindent 12 }}
           restartPolicy: Never
+          activeDeadlineSeconds: 240

--- a/helm_deploy/use-of-force/templates/monitoring.yaml
+++ b/helm_deploy/use-of-force/templates/monitoring.yaml
@@ -1,0 +1,25 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ .Values.namespace }}
+spec:
+  groups:
+  - name: use-of-force
+    rules:
+    - alert: KubeCronJobRunning
+      annotations:
+        message: CronJob {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.cronjob {{ "}}" }} was scheduled to start over 10 minutes ago
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecronjobrunning
+      expr: time() - kube_cronjob_next_schedule_time{job="kube-state-metrics", namespace="{{ .Values.namespace }}"} > 600
+      for: 10m
+      labels:
+        severity: digital-prison-service
+    - alert: KubeJobCompletion
+      annotations:
+        message: CronJob {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.job_name {{ "}}" }} failed.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobcompletion
+      expr: |-
+        kube_job_spec_completions{job="kube-state-metrics"} - kube_job_status_succeeded{job="kube-state-metrics", namespace="{{ .Values.namespace }}"} > 0
+      for: 10m
+      labels:
+        severity: digital-prison-service


### PR DESCRIPTION
Altering job to use the replace concurrency policy. This should kill an existing job if it lasts longer
than the next scheduled start time and start a new pod.

Also setting a deadline to ensure that the job ends if it lasts longer than 4 minutes

(The job runs every 5 minutes and processes up to 50 reminders which is generally very fast)

Also adding 2 prometheus checks:
1.) to check that the previous schedule time was less than 10 minutes
2.) to check that no recents jobs failed