### PR TITLE
DCS-374 Tidying up job and fixing issue around overdue unverified users

### DIFF
--- a/job/reminders/emailResolver.js
+++ b/job/reminders/emailResolver.js
@@ -1,3 +1,5 @@
+const logger = require('../../log')
+
 class EmailResolver {
   constructor(authClientBuilder, systemToken, statementsClient) {
     this.authClientBuilder = authClientBuilder
@@ -6,13 +8,18 @@ class EmailResolver {
   }
 
   async resolveEmail(transactionalClient, userId, reportId) {
+    logger.info(`Checking to see if previously unverified user: ${userId} now has verified email for statement`)
+
     const authClient = this.authClientBuilder(await this.systemToken())
     const { verified, email } = await authClient.getEmail(userId)
     if (verified) {
+      logger.info('Found verified email')
       await this.statementsClient.setEmail(userId, reportId, email, transactionalClient)
-      return email
+      return true
     }
-    return null
+    logger.info(`User still not verified`)
+
+    return false
   }
 }
 

--- a/job/reminders/emailResolver.test.js
+++ b/job/reminders/emailResolver.test.js
@@ -28,7 +28,7 @@ describe('resolve emails', () => {
 
     const email = await emailResolver.resolveEmail(client, 'user1', 'report1')
 
-    expect(email).toEqual(null)
+    expect(email).toEqual(false)
 
     expect(authClientBuilder).toHaveBeenCalledWith('token-1')
     expect(authClient.getEmail).toHaveBeenCalledWith('user1')
@@ -40,7 +40,7 @@ describe('resolve emails', () => {
 
     const email = await emailResolver.resolveEmail(client, 'user1', 'report1')
 
-    expect(email).toEqual('user@gov.uk')
+    expect(email).toEqual(true)
 
     expect(authClientBuilder).toHaveBeenCalledWith('token-1')
     expect(authClient.getEmail).toHaveBeenCalledWith('user1')

--- a/job/reminders/reminderPoller.test.js
+++ b/job/reminders/reminderPoller.test.js
@@ -1,8 +1,8 @@
+const moment = require('moment')
 const reminderPoller = require('./reminderPoller')
 
 const reminderSender = { send: jest.fn(), setNextReminderDate: jest.fn() }
 
-const eventPublisher = { publish: jest.fn() }
 const client = { inTransaction: true }
 
 const db = {
@@ -14,13 +14,14 @@ const db = {
 
 const incidentClient = {
   getNextNotificationReminder: jest.fn(),
+  setNextReminderDate: jest.fn(),
 }
 
 const emailResolver = {
   resolveEmail: jest.fn(),
 }
 
-const poll = reminderPoller(db, incidentClient, reminderSender, eventPublisher, emailResolver)
+const poll = reminderPoller(db, incidentClient, reminderSender, emailResolver)
 
 afterEach(() => {
   jest.resetAllMocks()
@@ -32,41 +33,62 @@ describe('poll for reminders', () => {
 
     expect(count).toEqual(0)
     expect(reminderSender.send).toBeCalledTimes(0)
-
-    expect(eventPublisher.publish).toBeCalledTimes(2)
-    expect(eventPublisher.publish.mock.calls).toEqual([
-      [{ name: 'StartingToSendReminders' }],
-      [
-        {
-          name: 'FinishedSendingReminders',
-          properties: { totalSent: 0 },
-        },
-      ],
-    ])
   })
 
   test('successfully poll one reminder', async () => {
-    incidentClient.getNextNotificationReminder.mockResolvedValueOnce({ reminder: 1, email: 'user@gov.uk' })
+    incidentClient.getNextNotificationReminder.mockResolvedValueOnce({ reminder: 1, recipientEmail: 'user@gov.uk' })
+
+    const count = await poll()
+
+    expect(count).toEqual(1)
+    expect(reminderSender.send).toBeCalledTimes(1)
+  })
+
+  test('process reminders for unverified user', async () => {
+    incidentClient.getNextNotificationReminder
+      .mockResolvedValueOnce({
+        statementId: 1,
+        nextReminderDate: moment('2019-01-10 10:30:43.122'),
+        reportId: 2,
+        userId: 'BOB',
+      })
+      .mockResolvedValueOnce({
+        statementId: 2,
+        nextReminderDate: moment('2019-01-10 10:32:43.122'),
+        reportId: 3,
+        userId: 'BARRY',
+        recipientEmail: 'user@gov.uk',
+      })
+
+    emailResolver.resolveEmail.mockResolvedValue(null)
 
     const count = await poll()
 
     expect(count).toEqual(1)
     expect(reminderSender.send).toBeCalledTimes(1)
 
-    expect(eventPublisher.publish).toBeCalledTimes(2)
-    expect(eventPublisher.publish.mock.calls).toEqual([
-      [{ name: 'StartingToSendReminders' }],
-      [
-        {
-          name: 'FinishedSendingReminders',
-          properties: { totalSent: 1 },
-        },
-      ],
-    ])
+    expect(emailResolver.resolveEmail).toHaveBeenCalledWith(client, 'BOB', 2)
+    expect(incidentClient.setNextReminderDate).toHaveBeenCalledWith(
+      1,
+      moment('2019-01-11T10:30:43.122Z').toDate(),
+      client
+    )
+    expect(incidentClient.setNextReminderDate).toHaveBeenCalledWith(
+      2,
+      moment('2019-01-11T10:32:43.122Z').toDate(),
+      client
+    )
   })
 
-  test('process reminder for unverified user', async () => {
-    incidentClient.getNextNotificationReminder.mockResolvedValueOnce({ reminder: 1, reportId: 2, userId: 'BOB' })
+  test('Overdue reminder for unverified user leads to never reminding again', async () => {
+    incidentClient.getNextNotificationReminder.mockResolvedValueOnce({
+      statementId: 1,
+      nextReminderDate: moment('2019-01-10 10:30:43.122'),
+      reportId: 2,
+      userId: 'BOB',
+      isOverdue: true,
+    })
+
     emailResolver.resolveEmail.mockResolvedValue(null)
 
     const count = await poll()
@@ -74,18 +96,28 @@ describe('poll for reminders', () => {
     expect(count).toEqual(0)
     expect(reminderSender.send).toBeCalledTimes(0)
 
-    expect(eventPublisher.publish).toBeCalledTimes(2)
-    expect(eventPublisher.publish.mock.calls).toEqual([
-      [{ name: 'StartingToSendReminders' }],
-      [
-        {
-          name: 'FinishedSendingReminders',
-          properties: { totalSent: 0 },
-        },
-      ],
-    ])
-    expect(reminderSender.setNextReminderDate).toBeCalledTimes(1)
     expect(emailResolver.resolveEmail).toHaveBeenCalledWith(client, 'BOB', 2)
+    expect(incidentClient.setNextReminderDate).toHaveBeenCalledWith(1, null, client)
+  })
+
+  test('Overdue reminder for verified user leads to allowing to pick up on next poll', async () => {
+    incidentClient.getNextNotificationReminder.mockResolvedValueOnce({
+      statementId: 1,
+      nextReminderDate: moment('2019-01-10 10:30:43.122'),
+      reportId: 2,
+      userId: 'BOB',
+      isOverdue: true,
+    })
+
+    emailResolver.resolveEmail.mockResolvedValue('user@gov.uk')
+
+    const count = await poll()
+
+    expect(count).toEqual(0)
+    expect(reminderSender.send).toBeCalledTimes(0)
+
+    expect(emailResolver.resolveEmail).toHaveBeenCalledWith(client, 'BOB', 2)
+    expect(incidentClient.setNextReminderDate).not.toHaveBeenCalled()
   })
 
   test('process reminder for recently verified user', async () => {
@@ -94,39 +126,18 @@ describe('poll for reminders', () => {
 
     const count = await poll()
 
-    expect(count).toEqual(1)
-    expect(reminderSender.send).toBeCalledTimes(1)
-
-    expect(eventPublisher.publish).toBeCalledTimes(2)
-    expect(eventPublisher.publish.mock.calls).toEqual([
-      [{ name: 'StartingToSendReminders' }],
-      [
-        {
-          name: 'FinishedSendingReminders',
-          properties: { totalSent: 1 },
-        },
-      ],
-    ])
+    expect(count).toEqual(0)
+    expect(reminderSender.send).toBeCalledTimes(0)
     expect(emailResolver.resolveEmail).toHaveBeenCalledWith(client, 'BOB', 2)
+    expect(incidentClient.setNextReminderDate).not.toHaveBeenCalled()
   })
 
   test('infinite reminders - only process 50 reminders in one go', async () => {
-    incidentClient.getNextNotificationReminder.mockResolvedValue({ reminder: 1, email: 'user@gov.uk' })
+    incidentClient.getNextNotificationReminder.mockResolvedValue({ reminder: 1, recipientEmail: 'user@gov.uk' })
 
     const count = await poll()
 
     expect(count).toEqual(50)
     expect(reminderSender.send).toBeCalledTimes(50)
-
-    expect(eventPublisher.publish).toBeCalledTimes(2)
-    expect(eventPublisher.publish.mock.calls).toEqual([
-      [{ name: 'StartingToSendReminders' }],
-      [
-        {
-          name: 'FinishedSendingReminders',
-          properties: { totalSent: 50 },
-        },
-      ],
-    ])
   })
 })

--- a/job/reminders/reminderSender.js
+++ b/job/reminders/reminderSender.js
@@ -1,15 +1,9 @@
-const moment = require('moment')
 const logger = require('../../log')
 
-module.exports = (notificationService, incidentClient) => {
-  const getNextReminderDate = ({ nextReminderDate }) => {
-    const startdate = moment(nextReminderDate)
-    return startdate.add(1, 'day').toDate()
-  }
-
+module.exports = notificationService => {
   const context = ({ statementId, reportId }) => ({ statementId, reportId })
 
-  const handleOverdue = async (client, reminder) => {
+  const handleOverdue = async reminder => {
     if (reminder.isReporter) {
       await notificationService.sendReporterStatementOverdue(
         reminder.recipientEmail,
@@ -31,18 +25,9 @@ module.exports = (notificationService, incidentClient) => {
         context(reminder)
       )
     }
-    await incidentClient.setNextReminderDate(reminder.statementId, null, client)
   }
 
-  const setNextReminderDate = async (client, reminder) => {
-    const nextReminderDate = getNextReminderDate(reminder)
-    logger.info(
-      `Setting next reminder date of: '${nextReminderDate}' for staff: '${reminder.userId}', statementId: '${reminder.statementId}'`
-    )
-    await incidentClient.setNextReminderDate(reminder.statementId, nextReminderDate, client)
-  }
-
-  const handleReminder = async (client, reminder) => {
+  const handleReminder = async reminder => {
     if (reminder.isReporter) {
       await notificationService.sendReporterStatementReminder(
         reminder.recipientEmail,
@@ -66,15 +51,16 @@ module.exports = (notificationService, incidentClient) => {
         context(reminder)
       )
     }
-    await setNextReminderDate(client, reminder)
   }
 
   return {
-    getNextReminderDate,
-    setNextReminderDate,
-    send: (client, reminder) => {
+    send: async reminder => {
       logger.info('processing reminder', reminder)
-      return reminder.isOverdue ? handleOverdue(client, reminder) : handleReminder(client, reminder)
+      if (reminder.isOverdue) {
+        await handleOverdue(reminder)
+      } else {
+        await handleReminder(reminder)
+      }
     },
   }
 }

--- a/job/reminders/reminderSender.test.js
+++ b/job/reminders/reminderSender.test.js
@@ -8,35 +8,11 @@ const notificationService = {
   sendInvolvedStaffStatementOverdue: jest.fn(),
 }
 
-const client = jest.fn()
-
-const incidentClient = {
-  setNextReminderDate: jest.fn(),
-}
-
 afterEach(() => {
   jest.resetAllMocks()
 })
 
-const { getNextReminderDate, send } = reminderSender(notificationService, incidentClient)
-
-describe('getNextReminderDate', () => {
-  const checkGetNextReminderDate = val =>
-    expect(moment(getNextReminderDate({ nextReminderDate: moment(val) })).format('YYYY-MM-DD HH:mm:ss'))
-
-  test('normal day', async () => {
-    checkGetNextReminderDate('2019-09-06 21:26:17').toEqual('2019-09-07 21:26:17')
-  })
-
-  test('end of month', async () => {
-    checkGetNextReminderDate('2019-09-30 21:26:17').toEqual('2019-10-01 21:26:17')
-  })
-
-  test('leap year', async () => {
-    checkGetNextReminderDate('2020-02-28 23:59:59').toEqual('2020-02-29 23:59:59')
-    checkGetNextReminderDate('2020-02-29 23:59:59').toEqual('2020-03-01 23:59:59')
-  })
-})
+const { send } = reminderSender(notificationService)
 
 describe('send', () => {
   const recipientEmail = 'smith@prison.org'
@@ -64,7 +40,7 @@ describe('send', () => {
 
   describe('reporter', () => {
     test('sendReporterStatementReminder', async () => {
-      await send(client, {
+      await send({
         ...reminder,
         isReporter: true,
         nextReminderDate: now,
@@ -84,12 +60,10 @@ describe('send', () => {
         },
         expectedContext
       )
-
-      expect(incidentClient.setNextReminderDate).toBeCalledWith(-1, moment('2019-09-07 21:26:17').toDate(), client)
     })
 
     test('sendReporterStatementOverdue', async () => {
-      await send(client, {
+      await send({
         ...reminder,
         isReporter: true,
         nextReminderDate: now,
@@ -108,14 +82,12 @@ describe('send', () => {
         },
         expectedContext
       )
-
-      expect(incidentClient.setNextReminderDate).toBeCalledWith(-1, null, client)
     })
   })
 
   describe('involved staff', () => {
     test('sendInvolvedStaffStatementReminder', async () => {
-      await send(client, {
+      await send({
         ...reminder,
         isReporter: false,
         nextReminderDate: now,
@@ -134,12 +106,10 @@ describe('send', () => {
         },
         expectedContext
       )
-
-      expect(incidentClient.setNextReminderDate).toBeCalledWith(-1, moment('2019-09-07 21:26:17').toDate(), client)
     })
 
     test('sendInvolvedStaffStatementOverdue', async () => {
-      await send(client, {
+      await send({
         ...reminder,
         isReporter: false,
         nextReminderDate: now,
@@ -157,8 +127,6 @@ describe('send', () => {
         },
         expectedContext
       )
-
-      expect(incidentClient.setNextReminderDate).toBeCalledWith(-1, null, client)
     })
   })
 })


### PR DESCRIPTION
We only send a reminder for the first 3 days that a staff member hasn't filled in their statement.
After that we send an overdue email and exclude that item from future polling.

For unverified users we weren't excluding them from being claimed by the polling process after they were overdue.

Simplified the poller a bit, by not explicitly handling newly verified users and instead allowing them to be naturally be picked up on the next poll

Also fixing issue where picking up an unverified user would prematurely stop the polling. Now unverified users are excluded from polling stats but do not lead to the poller to think that all reminders have been processed