### PR TITLE
DCS-394 Ensure retrieve correct incident location list

### DIFF
--- a/server/data/incidentClient.js
+++ b/server/data/incidentClient.js
@@ -73,7 +73,7 @@ const changeStatus = (reportId, startState, endState, client = nonTransactionalC
 
 const getCurrentDraftReport = async (userId, bookingId) => {
   const results = await nonTransactionalClient.query({
-    text: `select id, incident_date "incidentDate", form_response "form" from v_report r
+    text: `select id, incident_date "incidentDate", form_response "form", agency_id "agencyId" from v_report r
           where r.user_id = $1
           and r.booking_id = $2
           and r.status = $3

--- a/server/data/incidentClient.test.js
+++ b/server/data/incidentClient.test.js
@@ -19,7 +19,7 @@ describe('getCurrentDraftReport', () => {
     incidentClient.getCurrentDraftReport('user1', -1)
 
     expect(db.query).toBeCalledWith({
-      text: `select id, incident_date "incidentDate", form_response "form" from v_report r
+      text: `select id, incident_date "incidentDate", form_response "form", agency_id "agencyId" from v_report r
           where r.user_id = $1
           and r.booking_id = $2
           and r.status = $3

--- a/server/services/offenderService.js
+++ b/server/services/offenderService.js
@@ -13,15 +13,10 @@ module.exports = function createOffendersService(elite2ClientBuilder) {
         return []
       }
 
-      const unfilteredLocations = await elite2Client.getLocations(result.agencyId)
-      const locations = locationsFilter(unfilteredLocations)
-
       const displayName = `${properCaseName(result.firstName)} ${properCaseName(result.lastName)}`
-
       const { dateOfBirth } = result
 
       return {
-        locations,
         displayName,
         ...result,
         dateOfBirth,
@@ -56,10 +51,24 @@ module.exports = function createOffendersService(elite2ClientBuilder) {
     return elite2Client.getLocation(locationId)
   }
 
+  const getIncidentLocations = async (token, agencyId) => {
+    try {
+      const elite2Client = elite2ClientBuilder(token)
+
+      const unfilteredLocations = await elite2Client.getLocations(agencyId)
+      const locations = locationsFilter(unfilteredLocations)
+      return locations
+    } catch (error) {
+      logger.error(error, 'Error during getOffenderDetails')
+      throw error
+    }
+  }
+
   return {
     getOffenderDetails,
     getOffenderImage,
     getOffenderNames,
     getLocation,
+    getIncidentLocations,
   }
 }

--- a/server/services/offenderService.test.js
+++ b/server/services/offenderService.test.js
@@ -27,24 +27,16 @@ describe('getOffenderDetails', () => {
   it('should format display name', async () => {
     const details = { firstName: 'SAM', lastName: 'SMITH', dateOfBirth: '1980-12-31' }
     elite2Client.getOffenderDetails.mockReturnValue(details)
-    elite2Client.getLocations.mockReturnValue([
-      { locationType: 'BOX', userDescription: 'Box 1' },
-      { locationType: 'WING', userDescription: 'Wing A' },
-      { locationType: 'WING', userDescription: '' },
-      { locationType: 'CELL', userDescription: 'Cell A' },
-    ])
-
     const result = await service.getOffenderDetails(token, -5)
 
     expect(result).toEqual({
       ...details,
       dateOfBirth: '1980-12-31',
       displayName: 'Sam Smith',
-      locations: [],
     })
   })
 
-  it('should use the user token', async () => {
+  it('should use the token', async () => {
     const details = { firstName: 'SAM', lastName: 'SMITH' }
     elite2Client.getOffenderDetails.mockReturnValue(details)
     elite2Client.getLocations.mockReturnValue([])
@@ -79,5 +71,22 @@ describe('getOffenders', () => {
     expect(names).toEqual({ AAA: 'Smith, Sam', BBB: 'Smith, Ben' })
     expect(elite2ClientBuilder).toBeCalledWith(token)
     expect(elite2Client.getOffenders).toBeCalledWith(['AAA', 'BBB'])
+  })
+
+  describe('getIncidentLocations', () => {
+    it('should retrieve locations', async () => {
+      elite2Client.getLocations.mockReturnValue([])
+
+      const result = await service.getIncidentLocations(token, 'WRI')
+
+      expect(result).toEqual([])
+      expect(elite2Client.getLocations).toBeCalledWith('WRI')
+    })
+
+    it('should use token', async () => {
+      await service.getIncidentLocations(token, 'WRI')
+
+      expect(elite2ClientBuilder).toBeCalledWith(token)
+    })
   })
 })


### PR DESCRIPTION
This change ensures that we only retrieve internal locations from the establishment where
the incident occured, rather than the establishment that the offender currently is.

The internal location list is only needed when the draft report is being filled out but
if creating a report for an offender who has recently left prison this distinction is
important.

This change also removes loading location list when unnecessary - we previously retrieved
the list every time we accessed the offender details.