### PR TITLE
Adding ability for coordinators to add missing staff to reports

### DIFF
--- a/integration-tests/db/db.js
+++ b/integration-tests/db/db.js
@@ -6,8 +6,11 @@ const { expectedPayload } = require('../integration/seedData')
 const db = require('../../server/data/dataAccess/db')
 const incidentClient = require('../../server/data/incidentClient')
 const statementsClient = require('../../server/data/statementsClient')
+const createStatementService = require('../../server/services/statementService')
 const { ReportStatus } = require('../../server/config/types')
 const { equals } = require('../../server/utils/utils')
+
+const statementService = createStatementService({ statementsClient, incidentClient, db })
 
 const getCurrentDraft = bookingId => incidentClient.getCurrentDraftReport('TEST_USER', bookingId)
 
@@ -75,7 +78,10 @@ const submitStatement = ({ userId, reportId }) =>
       jobStartYear: 2017,
       statement: 'Things happened',
     })
-    .then(() => statementsClient.submitStatement(userId, reportId))
+    .then(() => {
+      statementService.submitStatement(userId, reportId)
+      return null
+    })
 
 const deleteRows = table => db.query({ text: format('delete from %I', table) })
 

--- a/integration-tests/integration/coordinator/add-involved-staff.spec.js
+++ b/integration-tests/integration/coordinator/add-involved-staff.spec.js
@@ -1,0 +1,226 @@
+const moment = require('moment')
+const ViewStatementsPage = require('../../pages/reviewer/viewStatementsPage')
+const AllIncidentsPage = require('../../pages/reviewer/allIncidentsPage')
+const AddInvolvedStaffPage = require('../../pages/reviewer/addInvolvedStaffPage')
+const AddInvolvedStaffResultPage = require('../../pages/reviewer/addInvolvedStaffResultPage')
+
+const ViewReportPage = require('../../pages/reviewer/viewReportPage')
+
+const { ReportStatus } = require('../../../server/config/types')
+
+context('A use of force coordinator can add involved staff', () => {
+  const bookingId = 1001
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubOffenderDetails', bookingId)
+    cy.task('stubLocations', 'MDI')
+    cy.task('stubOffenders')
+    cy.task('stubLocation', '357591')
+    cy.task('stubUserDetailsRetrieval', 'MR_ZAGATO')
+    cy.task('stubUserDetailsRetrieval', 'MRS_JONES')
+    cy.task('stubUserDetailsRetrieval', 'TEST_USER')
+    cy.task('stubUnverifiedUserDetailsRetrieval', 'UNVERIFIED_USER')
+  })
+
+  const seedReport = () =>
+    cy.task('seedReport', {
+      status: ReportStatus.SUBMITTED,
+      submittedDate: moment().toDate(),
+      agencyId: 'MDI',
+      bookingId: 1001,
+      involvedStaff: [
+        {
+          userId: 'TEST_USER',
+          name: 'TEST_USER name',
+          email: 'TEST_USER@gov.uk',
+        },
+      ],
+    })
+
+  const seedAndCompleteReport = () => {
+    seedReport()
+
+    const allIncidentsPage = AllIncidentsPage.goTo()
+    allIncidentsPage.getTodoRows().should('have.length', 1)
+    allIncidentsPage.getCompleteRows().should('have.length', 0)
+
+    const { reportId } = allIncidentsPage.getTodoRow(0)
+    reportId().then(id => cy.task('submitStatement', { userId: 'TEST_USER', reportId: id }))
+
+    cy.reload()
+
+    allIncidentsPage.getTodoRows().should('have.length', 0)
+    allIncidentsPage.getCompleteRows().should('have.length', 1)
+  }
+
+  it('A coordinator can add staff on a complete report and it will complete the report', () => {
+    cy.task('stubCoordinatorLogin')
+    cy.login(bookingId)
+
+    seedAndCompleteReport()
+
+    AllIncidentsPage.goTo()
+      .getCompleteRow(0)
+      .viewStatementsButton()
+      .click()
+
+    const viewStatementsPage = ViewStatementsPage.verifyOnPage()
+    viewStatementsPage
+      .statements()
+      .then(result =>
+        expect(result).to.deep.equal([
+          { username: 'TEST_USER name', link: 'View statement', isOverdue: false, isUnverified: false },
+        ])
+      )
+    viewStatementsPage.reportLink().click()
+
+    ViewReportPage.verifyOnPage()
+      .addInvolvedStaff()
+      .should('be.visible')
+      .click()
+
+    const addInvolvedStaffPage = AddInvolvedStaffPage.verifyOnPage()
+    addInvolvedStaffPage.username().type('MRS_JONES')
+    addInvolvedStaffPage.saveAndContinue().click()
+
+    const reportPage = ViewReportPage.verifyOnPage()
+    reportPage.deleteInvolvedStaff('MRS_JONES').should('be.visible')
+    reportPage.continue().click()
+
+    const allIncidentsPage = AllIncidentsPage.verifyOnPage()
+    allIncidentsPage.getTodoRows().should('have.length', 1)
+    allIncidentsPage.getCompleteRows().should('have.length', 0)
+    allIncidentsPage
+      .getTodoRow(0)
+      .viewStatementsButton()
+      .click()
+
+    ViewStatementsPage.verifyOnPage()
+      .statements()
+      .then(result =>
+        expect(result).to.deep.equal([
+          { username: 'MRS_JONES name', link: '', isOverdue: false, isUnverified: false },
+          { username: 'TEST_USER name', link: 'View statement', isOverdue: false, isUnverified: false },
+        ])
+      )
+  })
+
+  it('Attempting to add a missing staff member', () => {
+    cy.task('stubCoordinatorLogin')
+    cy.login(bookingId)
+
+    seedAndCompleteReport()
+
+    AllIncidentsPage.goTo()
+      .getCompleteRow(0)
+      .viewStatementsButton()
+      .click()
+
+    ViewStatementsPage.verifyOnPage()
+      .reportLink()
+      .click()
+
+    ViewReportPage.verifyOnPage()
+      .addInvolvedStaff()
+      .should('be.visible')
+      .click()
+
+    const addInvolvedStaffPage = AddInvolvedStaffPage.verifyOnPage()
+    addInvolvedStaffPage.username().type('JOHNNY')
+    addInvolvedStaffPage.saveAndContinue().click()
+
+    const warningPage = AddInvolvedStaffResultPage.verifyOnPage('The username does not exist')
+    warningPage.continue().click()
+
+    AddInvolvedStaffPage.verifyOnPage()
+  })
+
+  it('Attempting to re-add an existing staff member', () => {
+    cy.task('stubCoordinatorLogin')
+    cy.login(bookingId)
+
+    seedAndCompleteReport()
+
+    AllIncidentsPage.goTo()
+      .getCompleteRow(0)
+      .viewStatementsButton()
+      .click()
+
+    ViewStatementsPage.verifyOnPage()
+      .reportLink()
+      .click()
+
+    ViewReportPage.verifyOnPage()
+      .addInvolvedStaff()
+      .should('be.visible')
+      .click()
+
+    const addInvolvedStaffPage = AddInvolvedStaffPage.verifyOnPage()
+    addInvolvedStaffPage.username().type('TEST_USER')
+    addInvolvedStaffPage.saveAndContinue().click()
+
+    const warningPage = AddInvolvedStaffResultPage.verifyOnPage('TEST_USER name has already been added to the report')
+    warningPage.continue().click()
+
+    ViewReportPage.verifyOnPage()
+  })
+
+  it('Attempting to add an unverified staff member', () => {
+    cy.task('stubCoordinatorLogin')
+    cy.login(bookingId)
+
+    seedAndCompleteReport()
+
+    AllIncidentsPage.goTo()
+      .getCompleteRow(0)
+      .viewStatementsButton()
+      .click()
+
+    ViewStatementsPage.verifyOnPage()
+      .reportLink()
+      .click()
+
+    ViewReportPage.verifyOnPage()
+      .addInvolvedStaff()
+      .should('be.visible')
+      .click()
+
+    const addInvolvedStaffPage = AddInvolvedStaffPage.verifyOnPage()
+    addInvolvedStaffPage.username().type('UNVERIFIED_USER')
+    addInvolvedStaffPage.saveAndContinue().click()
+
+    const warningPage = AddInvolvedStaffResultPage.verifyOnPage(
+      'UNVERIFIED_USER name has not verified their email address'
+    )
+    warningPage.continue().click()
+
+    ViewReportPage.verifyOnPage()
+  })
+
+  it('A reviewer user should not be able to add staff', () => {
+    cy.task('stubReviewerLogin')
+    cy.login(bookingId)
+
+    seedReport()
+
+    const allIncidentsPage = AllIncidentsPage.goTo()
+    allIncidentsPage.getTodoRows().should('have.length', 1)
+
+    const { prisoner, reporter, viewStatementsButton } = allIncidentsPage.getTodoRow(0)
+    prisoner().contains('Smith, Norman')
+    reporter().contains('James Stuart')
+    viewStatementsButton().click()
+
+    const viewStatementsPage = ViewStatementsPage.verifyOnPage()
+
+    viewStatementsPage
+      .statements()
+      .then(result =>
+        expect(result).to.deep.equal([{ username: 'TEST_USER name', link: '', isOverdue: false, isUnverified: false }])
+      )
+
+    viewStatementsPage.reportLink().click()
+    const reportPage = ViewReportPage.verifyOnPage()
+    reportPage.addInvolvedStaff().should('not.be.visible')
+  })
+})

--- a/integration-tests/integration/coordinator/remove-involved-staff.spec.js
+++ b/integration-tests/integration/coordinator/remove-involved-staff.spec.js
@@ -39,7 +39,7 @@ context('A use of force coordinator can remove involved staff', () => {
       ],
     })
 
-  it('A reviewer can remove staff on otherwise complete report and it will complete the report', () => {
+  it('A coordinator can remove staff on otherwise complete report and it will complete the report', () => {
     cy.task('stubCoordinatorLogin')
     cy.login(bookingId)
 
@@ -57,8 +57,10 @@ context('A use of force coordinator can remove involved staff', () => {
     }
 
     let viewStatementsPage = ViewStatementsPage.verifyOnPage()
-    viewStatementsPage.getReportId().then(reportId => cy.task('submitStatement', { userId: 'TEST_USER', reportId }))
-    cy.reload()
+    viewStatementsPage
+      .getReportId()
+      .then(reportId => cy.task('submitStatement', { userId: 'TEST_USER', reportId }))
+      .then(() => cy.reload())
 
     viewStatementsPage
       .statements()

--- a/integration-tests/pages/reviewer/addInvolvedStaffPage.js
+++ b/integration-tests/pages/reviewer/addInvolvedStaffPage.js
@@ -1,0 +1,11 @@
+const page = require('../page')
+
+const addInvolvedStaff = () =>
+  page(`Add another member of staff`, {
+    username: () => cy.get("[name='username']"),
+    saveAndContinue: () => cy.get('[data-qa=continue]'),
+  })
+
+export default {
+  verifyOnPage: addInvolvedStaff,
+}

--- a/integration-tests/pages/reviewer/addInvolvedStaffResultPage.js
+++ b/integration-tests/pages/reviewer/addInvolvedStaffResultPage.js
@@ -1,0 +1,10 @@
+const page = require('../page')
+
+const resultPage = title =>
+  page(title, {
+    continue: () => cy.get('[data-qa=continue]'),
+  })
+
+export default {
+  verifyOnPage: resultPage,
+}

--- a/integration-tests/pages/reviewer/allIncidentsPage.js
+++ b/integration-tests/pages/reviewer/allIncidentsPage.js
@@ -34,7 +34,13 @@ const incidentsPage = () =>
       reporter: () => todoCol(i, 2),
       viewStatementsButton: () => todoCol(i, 3).find('a'),
       overdue: () => cy.get('[data-qa=overdue]'),
+      reportId: () =>
+        todoCol(i, 3)
+          .find('a')
+          .invoke('attr', 'href')
+          .then(link => link.match(/\/(.*?)\/view-statements/)[1]),
     }),
+
     getCompleteRow: i => ({
       date: () => completeCol(i, 0),
       prisoner: () => completeCol(i, 1),

--- a/integration-tests/pages/reviewer/viewReportPage.js
+++ b/integration-tests/pages/reviewer/viewReportPage.js
@@ -15,7 +15,9 @@ const viewReportPage = () =>
 
     verifyInputs: reportDetails.verifyInputs,
 
-    deleteInvolvedStaff: username => cy.get(`[data-qa="delete-statement-${username}"]`),
+    deleteInvolvedStaff: username => cy.get(`[data-qa="delete-staff-${username}"]`),
+
+    addInvolvedStaff: () => cy.get(`[data-qa="add-staff"]`),
 
     getReportId: () => {
       return cy.url().then(url => {

--- a/migrations/20200311000000_form_db.js
+++ b/migrations/20200311000000_form_db.js
@@ -1,0 +1,14 @@
+exports.up = async knex => {
+  await knex.raw('ALTER TABLE statement DROP CONSTRAINT involved_staff_incident_id_user_id_unique;')
+
+  await knex.raw(
+    `CREATE UNIQUE INDEX involved_staff_incident_id_user_id_unique ON statement (report_id, user_id) WHERE deleted is NULL;`
+  )
+}
+
+exports.down = async knex => {
+  await knex.raw('ALTER TABLE statement DROP CONSTRAINT involved_staff_incident_id_user_id_unique;')
+  await knex.schema.table('statement', table => {
+    table.unique(['report_id', 'user_id'])
+  })
+}

--- a/server/index.js
+++ b/server/index.js
@@ -14,7 +14,7 @@ const { authClientBuilder, systemToken } = require('./data/authClientBuilder')
 
 const createSignInService = require('./authentication/signInService')
 
-const createInvolvedStaffService = require('./services/involvedStaffService')
+const { createInvolvedStaffService } = require('./services/involvedStaffService')
 const createOffenderService = require('./services/offenderService')
 const createReportService = require('./services/reportService')
 const createStatementService = require('./services/statementService')

--- a/server/middleware/roleCheck.js
+++ b/server/middleware/roleCheck.js
@@ -1,0 +1,13 @@
+const httpError = require('http-errors')
+
+const check = userCheck => (req, res, next) => {
+  if (userCheck(res.locals.user)) {
+    return next()
+  }
+  throw httpError(401, 'Not authorised to access this resource')
+}
+
+module.exports = {
+  coordinatorOnly: check(user => user.isCoordinator),
+  reviewerOrCoordinatorOnly: check(user => user.isCoordinator || user.isReviewer),
+}

--- a/server/middleware/roleCheck.test.js
+++ b/server/middleware/roleCheck.test.js
@@ -1,0 +1,62 @@
+const roleCheck = require('./roleCheck')
+
+describe('roleCheck', () => {
+  let req
+  const next = jest.fn()
+
+  const createRes = flag => ({
+    locals: {
+      user: {
+        ...flag,
+      },
+    },
+  })
+
+  describe('coordinatorOnly', () => {
+    test('will reject no specific role access', () => {
+      const res = createRes({})
+
+      expect(() => roleCheck.coordinatorOnly(req, res, next)).toThrow(Error('Not authorised to access this resource'))
+    })
+
+    test('will reject reviewer access', () => {
+      const res = createRes({ isReviewer: true })
+
+      expect(() => roleCheck.coordinatorOnly(req, res, next)).toThrow(Error('Not authorised to access this resource'))
+    })
+
+    test('will accept coordinator access', () => {
+      const res = createRes({ isCoordinator: true })
+
+      roleCheck.coordinatorOnly(req, res, next)
+
+      expect(next).toBeCalled()
+    })
+  })
+
+  describe('reviewerOrCoordinatorOnly', () => {
+    test('will reject no specific role access', () => {
+      const res = createRes({})
+
+      expect(() => roleCheck.reviewerOrCoordinatorOnly(req, res, next)).toThrow(
+        Error('Not authorised to access this resource')
+      )
+    })
+
+    test('will reject reviewer access', () => {
+      const res = createRes({ isReviewer: true })
+
+      roleCheck.reviewerOrCoordinatorOnly(req, res, next)
+
+      expect(next).toBeCalled()
+    })
+
+    test('will accept coordinator access', () => {
+      const res = createRes({ isCoordinator: true })
+
+      roleCheck.reviewerOrCoordinatorOnly(req, res, next)
+
+      expect(next).toBeCalled()
+    })
+  })
+})

--- a/server/routes/coordinator.test.js
+++ b/server/routes/coordinator.test.js
@@ -37,17 +37,51 @@ describe('coordinator', () => {
     jest.resetAllMocks()
   })
 
-  describe('add involved staff', () => {
+  describe('view add involved staff', () => {
     it('should resolve for coordinator', async () => {
       userSupplier.mockReturnValue(coordinatorUser)
 
       await request(app)
-        .get('/report/1/involved-staff/sally')
+        .get('/coordinator/report/1/add-staff')
         .expect(200)
-        .expect('Content-Type', 'application/json; charset=utf-8')
+        .expect('Content-Type', 'text/html; charset=utf-8')
         .expect(res => {
-          expect(res.body).toEqual({ result: 'ok' })
+          expect(res.text).toContain('Add another member of staff')
         })
+    })
+
+    it('should not resolve for reviewer', async () => {
+      userSupplier.mockReturnValue(reviewerUser)
+
+      await request(app)
+        .get('/coordinator/report/1/add-staff')
+        .expect(401)
+        .expect(res => {
+          expect(res.text).toContain('Not authorised to access this resource')
+        })
+    })
+
+    it('should not resolve for user', async () => {
+      userSupplier.mockReturnValue(user)
+
+      await request(app)
+        .get('/coordinator/report/1/add-staff')
+        .expect(401)
+        .expect(res => {
+          expect(res.text).toContain('Not authorised to access this resource')
+        })
+    })
+  })
+
+  describe('submit add involved staff', () => {
+    it('should resolve for coordinator', async () => {
+      userSupplier.mockReturnValue(coordinatorUser)
+      involvedStaffService.addInvolvedStaff.mockResolvedValue('success')
+      await request(app)
+        .post('/coordinator/report/1/add-staff')
+        .send({ username: 'sally' })
+        .expect(302)
+        .expect('Location', '/coordinator/report/1/add-staff/result/success')
 
       expect(involvedStaffService.addInvolvedStaff).toBeCalledWith('user1-system-token', '1', 'sally')
     })
@@ -56,7 +90,7 @@ describe('coordinator', () => {
       userSupplier.mockReturnValue(reviewerUser)
 
       await request(app)
-        .get('/report/1/involved-staff/sally')
+        .post('/coordinator/report/1/add-staff')
         .expect(401)
         .expect(res => {
           expect(res.text).toContain('Not authorised to access this resource')
@@ -69,13 +103,46 @@ describe('coordinator', () => {
       userSupplier.mockReturnValue(user)
 
       await request(app)
-        .get('/report/1/involved-staff/sally')
+        .post('/coordinator/report/1/add-staff')
         .expect(401)
         .expect(res => {
           expect(res.text).toContain('Not authorised to access this resource')
         })
 
       expect(involvedStaffService.addInvolvedStaff).not.toBeCalled()
+    })
+  })
+
+  describe('view add involved staff results', () => {
+    it('should resolve for coordinator', async () => {
+      userSupplier.mockReturnValue(coordinatorUser)
+      involvedStaffService.addInvolvedStaff.mockResolvedValue('success')
+      await request(app)
+        .get('/coordinator/report/1/add-staff/result/success')
+        .expect(302)
+        .expect('Location', '/1/view-report')
+    })
+
+    it('should not resolve for reviewer', async () => {
+      userSupplier.mockReturnValue(reviewerUser)
+
+      await request(app)
+        .get('/coordinator/report/1/add-staff/result/success')
+        .expect(401)
+        .expect(res => {
+          expect(res.text).toContain('Not authorised to access this resource')
+        })
+    })
+
+    it('should not resolve for user', async () => {
+      userSupplier.mockReturnValue(user)
+
+      await request(app)
+        .get('/coordinator/report/1/add-staff/result/success')
+        .expect(401)
+        .expect(res => {
+          expect(res.text).toContain('Not authorised to access this resource')
+        })
     })
   })
 

--- a/server/routes/incidents.js
+++ b/server/routes/incidents.js
@@ -63,10 +63,6 @@ module.exports = function CreateReportRoutes({
     },
 
     viewAllIncidents: async (req, res) => {
-      if (!res.locals.user.isReviewer) {
-        return res.redirect('/')
-      }
-
       const { awaiting, completed } = await reviewService.getReports(res.locals.user.activeCaseLoadId)
 
       const namesByOffenderNumber = await getOffenderNames(await systemToken(res.locals.user.username), [
@@ -122,10 +118,6 @@ module.exports = function CreateReportRoutes({
     reviewReport: async (req, res) => {
       const { reportId } = req.params
 
-      if (!res.locals.user.isReviewer) {
-        return res.redirect('/')
-      }
-
       const report = await reviewService.getReport(reportId)
 
       const data = await buildReportData(report, res)
@@ -134,10 +126,6 @@ module.exports = function CreateReportRoutes({
     },
 
     reviewStatements: async (req, res) => {
-      if (!res.locals.user.isReviewer) {
-        return res.redirect('/')
-      }
-
       const { reportId } = req.params
 
       const report = await reviewService.getReport(reportId)
@@ -155,10 +143,6 @@ module.exports = function CreateReportRoutes({
     },
 
     reviewStatement: async (req, res) => {
-      if (!res.locals.user.isReviewer) {
-        return res.redirect('/')
-      }
-
       const { statementId } = req.params
 
       const statement = await reviewService.getStatement(statementId)

--- a/server/routes/incidents.test.js
+++ b/server/routes/incidents.test.js
@@ -67,12 +67,12 @@ describe('GET /all-incidents', () => {
       })
   })
 
-  it('should redirect if not reviewer', () => {
+  it('should not allow if not reviewer', () => {
     userSupplier.mockReturnValue(user)
     return request(app)
       .get('/all-incidents')
-      .expect(302)
-      .expect('Location', '/')
+      .expect(401)
+      .expect(res => expect(res.text).toContain('Not authorised to access this resource'))
   })
 })
 
@@ -133,14 +133,14 @@ describe('GET /view-statements', () => {
       })
   })
 
-  it('should redirect if not reviewer', () => {
+  it('should not allow if not reviewer', () => {
     userSupplier.mockReturnValue(user)
     reviewService.getReport.mockReturnValue({ id: 1, form: { incidentDetails: {} } })
     reviewService.getStatements.mockReturnValue([])
     return request(app)
       .get('/1/view-statements')
-      .expect(302)
-      .expect('Location', '/')
+      .expect(401)
+      .expect(res => expect(res.text).toContain('Not authorised to access this resource'))
   })
 
   it('should error if report doesnt exist', () => {

--- a/server/services/involvedStaffService.js
+++ b/server/services/involvedStaffService.js
@@ -2,159 +2,180 @@ const moment = require('moment')
 const logger = require('../../log.js')
 const { ReportStatus } = require('../config/types')
 
-/**
- * @param {object} args
- * @param {any} args.incidentClient
- * @param {import('../types/uof').UserService} args.userService
- * @param {any} args.statementsClient
- * @param {any} args.db
- */
-module.exports = function createReportService({ incidentClient, statementsClient, userService, db }) {
-  const getDraftInvolvedStaff = reportId => incidentClient.getDraftInvolvedStaff(reportId)
+const AddStaffResult = {
+  SUCCESS: 'success',
+  SUCCESS_UNVERIFIED: 'unverified',
+  MISSING: 'missing',
+  ALREADY_EXISTS: 'already-exists',
+}
 
-  const removeMissingDraftInvolvedStaff = async (userId, bookingId) => {
-    const { id, form = {} } = await incidentClient.getCurrentDraftReport(userId, bookingId)
+module.exports = {
+  AddStaffResult,
+  /**
+   * @param {object} args
+   * @param {any} args.incidentClient
+   * @param {import('../types/uof').UserService} args.userService
+   * @param {any} args.statementsClient
+   * @param {any} args.db
+   */
+  createInvolvedStaffService: ({ incidentClient, statementsClient, userService, db }) => {
+    const getDraftInvolvedStaff = reportId => incidentClient.getDraftInvolvedStaff(reportId)
 
-    const { incidentDetails = {} } = form
-    const { involvedStaff = [] } = incidentDetails
-    const updatedInvolvedStaff = involvedStaff.filter(staff => !staff.missing)
+    const removeMissingDraftInvolvedStaff = async (userId, bookingId) => {
+      const { id, form = {} } = await incidentClient.getCurrentDraftReport(userId, bookingId)
 
-    const updatedFormObject = {
-      ...form,
-      incidentDetails: { ...incidentDetails, involvedStaff: updatedInvolvedStaff },
-    }
-    await incidentClient.updateDraftReport(id, null, updatedFormObject)
-  }
+      const { incidentDetails = {} } = form
+      const { involvedStaff = [] } = incidentDetails
+      const updatedInvolvedStaff = involvedStaff.filter(staff => !staff.missing)
 
-  const getInvolvedStaff = reportId => incidentClient.getInvolvedStaff(reportId)
-
-  const loadInvolvedStaff = async (reportId, statementId) => {
-    const involvedStaff = await incidentClient.getInvolvedStaff(reportId)
-    const found = involvedStaff.find(staff => staff.statementId === statementId)
-    if (!found) {
-      throw new Error(`Staff with id: ${statementId}, does not exist on report: '${reportId}'`)
-    }
-    return found
-  }
-
-  async function lookup(token, usernames) {
-    return userService.getUsers(token, usernames)
-  }
-
-  const loadUser = async (token, username) => {
-    const results = await userService.getUsers(token, [username])
-
-    if (!results || results[0].missing) {
-      throw new Error(`Could not retrieve user details for missing user: '${username}'`)
-    }
-    const [user] = results
-    logger.info('Found user:', user)
-    return user
-  }
-
-  const getStaffRequiringStatements = async (currentUser, addedStaff) => {
-    const userAlreadyAdded = addedStaff.find(user => currentUser.username === user.username)
-    if (userAlreadyAdded) {
-      return addedStaff
-    }
-    // Current user hasn't added themselves, so add them to the list.
-    const foundUser = await loadUser(currentUser.token, currentUser.username)
-
-    return [...addedStaff, foundUser]
-  }
-
-  const save = async (reportId, reportSubmittedDate, overdueDate, currentUser, client) => {
-    const involvedStaff = await getDraftInvolvedStaff(reportId)
-
-    const staffToCreateStatmentsFor = await getStaffRequiringStatements(currentUser, involvedStaff)
-
-    const staff = staffToCreateStatmentsFor.map(user => ({
-      staffId: user.staffId,
-      userId: user.username,
-      name: user.name,
-      email: user.email,
-    }))
-
-    const firstReminderDate = moment(reportSubmittedDate).add(1, 'day')
-    const userIdsToStatementIds = await statementsClient.createStatements({
-      reportId,
-      firstReminder: firstReminderDate.toDate(),
-      overdueDate: overdueDate.toDate(),
-      staff,
-      client,
-    })
-    return staff.map(staffMember => ({ ...staffMember, statementId: userIdsToStatementIds[staffMember.userId] }))
-  }
-
-  const addInvolvedStaff = async (token, reportId, username) => {
-    logger.info(`Adding involved staff with username: ${username} to report: '${reportId}'`)
-    const foundUser = await loadUser(token, username)
-    logger.info(`found staff: '${foundUser}'`)
-
-    const report = await incidentClient.getReportForReviewer(reportId)
-    if (!report) {
-      throw new Error(`Report: '${reportId}' does not exist`)
+      const updatedFormObject = {
+        ...form,
+        incidentDetails: { ...incidentDetails, involvedStaff: updatedInvolvedStaff },
+      }
+      await incidentClient.updateDraftReport(id, null, updatedFormObject)
     }
 
-    if (await statementsClient.isStatementPresentForUser(reportId, username)) {
-      throw new Error(`Staff member already exists: '${username}' on report: '${reportId}'`)
+    const getInvolvedStaff = reportId => incidentClient.getInvolvedStaff(reportId)
+
+    const loadInvolvedStaff = async (reportId, statementId) => {
+      const involvedStaff = await incidentClient.getInvolvedStaff(reportId)
+      const found = involvedStaff.find(staff => staff.statementId === statementId)
+      if (!found) {
+        throw new Error(`Staff with id: ${statementId}, does not exist on report: '${reportId}'`)
+      }
+      return found
     }
 
-    await db.inTransaction(async client => {
-      await statementsClient.createStatements({
+    const loadInvolvedStaffByUsername = async (reportId, username) => {
+      const involvedStaff = await incidentClient.getInvolvedStaff(reportId)
+      const found = involvedStaff.find(staff => staff.userId === username)
+      if (!found) {
+        throw new Error(`Staff with username: ${username}, does not exist on report: '${reportId}'`)
+      }
+      return found
+    }
+
+    async function lookup(token, usernames) {
+      return userService.getUsers(token, usernames)
+    }
+
+    const getStaffRequiringStatements = async (currentUser, addedStaff) => {
+      const userAlreadyAdded = addedStaff.find(user => currentUser.username === user.username)
+      if (userAlreadyAdded) {
+        return addedStaff
+      }
+      // Current user hasn't added themselves, so add them to the list.
+      const [foundUser] = await userService.getUsers(currentUser.token, [currentUser.username])
+
+      if (!foundUser || foundUser.missing) {
+        throw new Error(`Could not retrieve user details for current user: '${currentUser.username}'`)
+      }
+
+      logger.info('Found user:', foundUser)
+      return [...addedStaff, foundUser]
+    }
+
+    const save = async (reportId, reportSubmittedDate, overdueDate, currentUser, client) => {
+      const involvedStaff = await getDraftInvolvedStaff(reportId)
+
+      const staffToCreateStatmentsFor = await getStaffRequiringStatements(currentUser, involvedStaff)
+
+      const staff = staffToCreateStatmentsFor.map(user => ({
+        staffId: user.staffId,
+        userId: user.username,
+        name: user.name,
+        email: user.email,
+      }))
+
+      const firstReminderDate = moment(reportSubmittedDate).add(1, 'day')
+      const userIdsToStatementIds = await statementsClient.createStatements({
         reportId,
-        firstReminder: null,
-        overdueDate: moment(report.submittedDate)
-          .add(3, 'day')
-          .toDate(),
-        staff: [
-          {
-            staffId: foundUser.staffId,
-            userId: foundUser.username,
-            name: foundUser.name,
-            email: foundUser.email,
-          },
-        ],
+        firstReminder: firstReminderDate.toDate(),
+        overdueDate: overdueDate.toDate(),
+        staff,
         client,
       })
+      return staff.map(staffMember => ({ ...staffMember, statementId: userIdsToStatementIds[staffMember.userId] }))
+    }
 
-      if (report.status === ReportStatus.COMPLETE.value) {
-        logger.info(`There are now pending statements on : ${reportId}, moving from 'COMPLETE' to 'SUBMITTED'`)
-        await incidentClient.changeStatus(reportId, ReportStatus.COMPLETE, ReportStatus.SUBMITTED, client)
+    const addInvolvedStaff = async (token, reportId, username) => {
+      logger.info(`Adding involved staff with username: ${username} to report: '${reportId}'`)
+
+      const [foundUser] = await userService.getUsers(token, [username])
+
+      if (!foundUser || foundUser.missing) {
+        return AddStaffResult.MISSING
       }
-    })
-  }
 
-  const removeInvolvedStaff = async (reportId, statementId) => {
-    logger.info(`Removing statement: ${statementId} from report: ${reportId}`)
+      logger.info(`found staff: '${foundUser}'`)
 
-    await db.inTransaction(async client => {
-      const pendingStatementBeforeDeletion = await statementsClient.getNumberOfPendingStatements(reportId, client)
+      const report = await incidentClient.getReportForReviewer(reportId)
+      if (!report) {
+        throw new Error(`Report: '${reportId}' does not exist`)
+      }
 
-      await statementsClient.deleteStatement({
-        statementId,
-        client,
-      })
+      if (await statementsClient.isStatementPresentForUser(reportId, username)) {
+        return AddStaffResult.ALREADY_EXISTS
+      }
 
-      if (pendingStatementBeforeDeletion !== 0) {
-        const pendingStatementCount = await statementsClient.getNumberOfPendingStatements(reportId, client)
+      return db.inTransaction(async client => {
+        await statementsClient.createStatements({
+          reportId,
+          firstReminder: null,
+          overdueDate: moment(report.submittedDate)
+            .add(3, 'day')
+            .toDate(),
+          staff: [
+            {
+              staffId: foundUser.staffId,
+              userId: foundUser.username,
+              name: foundUser.name,
+              email: foundUser.email,
+            },
+          ],
+          client,
+        })
 
-        if (pendingStatementCount === 0) {
-          logger.info(`All statements complete on : ${reportId}, marking as complete`)
-          await incidentClient.changeStatus(reportId, ReportStatus.SUBMITTED, ReportStatus.COMPLETE, client)
+        if (report.status === ReportStatus.COMPLETE.value) {
+          logger.info(`There are now pending statements on : ${reportId}, moving from 'COMPLETE' to 'SUBMITTED'`)
+          await incidentClient.changeStatus(reportId, ReportStatus.COMPLETE, ReportStatus.SUBMITTED, client)
         }
-      }
-    })
-  }
+        return foundUser.verified ? AddStaffResult.SUCCESS : AddStaffResult.SUCCESS_UNVERIFIED
+      })
+    }
 
-  return {
-    getInvolvedStaff,
-    loadInvolvedStaff,
-    removeMissingDraftInvolvedStaff,
-    getDraftInvolvedStaff,
-    addInvolvedStaff,
-    removeInvolvedStaff,
-    save,
-    lookup,
-  }
+    const removeInvolvedStaff = async (reportId, statementId) => {
+      logger.info(`Removing statement: ${statementId} from report: ${reportId}`)
+
+      await db.inTransaction(async client => {
+        const pendingStatementBeforeDeletion = await statementsClient.getNumberOfPendingStatements(reportId, client)
+
+        await statementsClient.deleteStatement({
+          statementId,
+          client,
+        })
+
+        if (pendingStatementBeforeDeletion !== 0) {
+          const pendingStatementCount = await statementsClient.getNumberOfPendingStatements(reportId, client)
+
+          if (pendingStatementCount === 0) {
+            logger.info(`All statements complete on : ${reportId}, marking as complete`)
+            await incidentClient.changeStatus(reportId, ReportStatus.SUBMITTED, ReportStatus.COMPLETE, client)
+          }
+        }
+      })
+    }
+
+    return {
+      getInvolvedStaff,
+      loadInvolvedStaff,
+      loadInvolvedStaffByUsername,
+      removeMissingDraftInvolvedStaff,
+      getDraftInvolvedStaff,
+      addInvolvedStaff,
+      removeInvolvedStaff,
+      save,
+      lookup,
+    }
+  },
 }

--- a/server/views/pages/check-your-answers.html
+++ b/server/views/pages/check-your-answers.html
@@ -13,7 +13,7 @@
   <div class="govuk-grid-column-three-quarters govuk-!-margin-bottom-9 ">
     <h1 class="govuk-heading-xl"> {{pageTitle}} </h1>
     {{
-      reportDetail.detail(data, bookingId, user)
+      reportDetail.detail(data, bookingId, null, user)
     }}
   </div>
 

--- a/server/views/pages/coordinator/add-involved-staff/add-involved-staff.html
+++ b/server/views/pages/coordinator/add-involved-staff/add-involved-staff.html
@@ -1,0 +1,57 @@
+{% extends "../../../partials/layout.html" %} 
+{% from "govuk/components/button/macro.njk" import govukButton %} 
+{% from "govuk/components/input/macro.njk" import govukInput %} 
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+
+{% set pageTitle = 'Add another member of staff' %}
+
+{% block content %}
+<div class="govuk-grid-row govuk-body">
+    {% if errors.length > 0 %}
+        {{
+        govukErrorSummary({
+            titleText: 'There is a problem',
+            errorList: errors,
+            attributes: { 'data-qa-errors': true }
+        })
+        }}
+    {% endif %}
+    <div class="govuk-grid-column-three-quarters govuk-!-margin-bottom-9">
+        <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>  
+        <div class="govuk-grid-row govuk-!-margin-top-9">
+            <div class="govuk-grid-column-full">
+                <form method="post">
+                    <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+                    <div class="add-another-staff-member">
+                        <div class="govuk-grid-row">
+                            <div class="govuk-grid-column-one-third">
+                            {{
+                                govukInput({
+                                    label: {
+                                    html: 'Username'
+                                    },
+                                    id: 'username',
+                                    name: 'username',
+                                    value: value,
+                                    errorMessage: errors | findError('usernam')
+                                })
+                            }}
+                            </div>
+                        </div>
+                        {{
+                        govukButton({
+                            text: 'Save and continue',
+                            name: 'continue',
+                            classes: 'govuk-button  govuk-!-margin-top-5',
+                            attributes: { 'data-qa': 'continue' }
+                            })
+                        }}
+                    </div>
+                    <a href="/{{ data.incidentId }}/view-report" draggable="false" class="govuk-link">Cancel</a>   
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+{% endblock %}

--- a/server/views/pages/coordinator/add-involved-staff/already-exists.html
+++ b/server/views/pages/coordinator/add-involved-staff/already-exists.html
@@ -1,0 +1,30 @@
+{% extends "../../../partials/layout.html" %} 
+{% from "govuk/components/button/macro.njk" import govukButton %} 
+
+
+{% set pageTitle = name + ' has already been added to the report' %}
+
+
+{% block content %}
+<div class="govuk-grid-row govuk-body">
+  <div class="govuk-grid-column-three-quarters govuk-!-margin-bottom-4">
+    <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
+    <p>
+        {{name}} will not be added to the report again. Their username is {{username}}. 
+    </p>
+  </div>
+  <div class="govuk-grid-column-three-quarters">
+    <div>
+        {{
+          govukButton({
+            text: 'Continue',
+            classes: 'govuk-button',
+            href: '/' + reportId + '/view-report',
+            attributes: { 'data-qa': 'continue', 'data-submit': true }
+          })
+        }}
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/server/views/pages/coordinator/add-involved-staff/missing.html
+++ b/server/views/pages/coordinator/add-involved-staff/missing.html
@@ -1,0 +1,32 @@
+{% extends "../../../partials/layout.html" %} 
+{% from "govuk/components/button/macro.njk" import govukButton %} 
+
+
+{% set pageTitle = 'The username does not exist' %}
+
+
+{% block content %}
+<div class="govuk-grid-row govuk-body">
+  <div class="govuk-grid-column-three-quarters govuk-!-margin-bottom-4">
+    <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
+    <p>
+        The username {{ username }} does not exist.
+    </p>
+    <p>You should check the username of the person you want to add and try again.
+</div>
+  <div class="govuk-grid-column-three-quarters">
+
+    <div>
+        {{
+          govukButton({
+            text: 'Continue',
+            classes: 'govuk-button',
+            href: '/coordinator/report/' + reportId + '/add-staff',
+            attributes: { 'data-qa': 'continue', 'data-submit': true }
+          })
+        }}
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/server/views/pages/coordinator/add-involved-staff/unverified.html
+++ b/server/views/pages/coordinator/add-involved-staff/unverified.html
@@ -1,0 +1,34 @@
+{% extends "../../../partials/layout.html" %} 
+{% from "govuk/components/button/macro.njk" import govukButton %} 
+
+
+{% set pageTitle = name + ' has not verified their email address' %}
+
+
+{% block content %}
+<div class="govuk-grid-row govuk-body">
+  <div class="govuk-grid-column-three-quarters govuk-!-margin-bottom-4">
+    <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
+    <p>
+        {{ name }} will not be able to complete their use of force statement until they have verified their email address. 
+    </p>
+    <p>
+        You should tell {{name}} to verify their email address as soon as possible. They can do this when they sign in to complete their statement.
+    </p>
+</div>
+  <div class="govuk-grid-column-three-quarters">
+
+    <div>
+        {{
+          govukButton({
+            text: 'Continue',
+            classes: 'govuk-button',
+            href: '/' + reportId + '/view-report',
+            attributes: { 'data-qa': 'continue', 'data-submit': true }
+          })
+        }}
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/server/views/pages/reportDetailMacro.njk
+++ b/server/views/pages/reportDetailMacro.njk
@@ -88,7 +88,7 @@
       {%for item in data.incidentDetails.staffInvolved %}
           {{item.name}} - {{item.username}}
           {%- if user.isCoordinator and item.statementId -%}      
-            <a data-qa="delete-statement-{{item.username}}" href="{{'/coordinator/report/' + item.reportId + '/statement/' + item.statementId + '/confirm-delete'}}" class="govuk-link float-right">
+            <a data-qa="delete-staff-{{item.username}}" href="{{'/coordinator/report/' + item.reportId + '/statement/' + item.statementId + '/confirm-delete'}}" class="govuk-link float-right">
               Delete <span class="govuk-visually-hidden">{{item.name}}</span></a>
           {%- endif -%}  
         {% if not loop.last %}<br/>{% endif %}
@@ -96,7 +96,7 @@
 
       {%- if user.isCoordinator -%}
         <br/>
-        <a data-qa="add-involved-staff" href="{{'/coordinator/report/' + incidentId + '/add-staff'}}" class="govuk-link">
+        <a data-qa="add-staff" href="{{'/coordinator/report/' + incidentId + '/add-staff'}}" class="govuk-link">
             Add another member of staff</a>
       {%- endif -%}
     </dd>

--- a/server/views/pages/reportDetailMacro.njk
+++ b/server/views/pages/reportDetailMacro.njk
@@ -44,7 +44,7 @@
   </div>
 {% endmacro %}
 
-{% macro detail(data, bookingId, user) %}
+{% macro detail(data, bookingId, incidentId, user) %}
     {{
       pagesMacros.sectionHeading({
         id: 'incidentDetails', 
@@ -89,10 +89,16 @@
           {{item.name}} - {{item.username}}
           {%- if user.isCoordinator and item.statementId -%}      
             <a data-qa="delete-statement-{{item.username}}" href="{{'/coordinator/report/' + item.reportId + '/statement/' + item.statementId + '/confirm-delete'}}" class="govuk-link float-right">
-             Delete <span class="govuk-visually-hidden">{{item.name}}</span></a>
+              Delete <span class="govuk-visually-hidden">{{item.name}}</span></a>
           {%- endif -%}  
         {% if not loop.last %}<br/>{% endif %}
       {% endfor %} 
+
+      {%- if user.isCoordinator -%}
+        <br/>
+        <a data-qa="add-involved-staff" href="{{'/coordinator/report/' + incidentId + '/add-staff'}}" class="govuk-link">
+            Add another member of staff</a>
+      {%- endif -%}
     </dd>
     {% endcall %}
     {{

--- a/server/views/pages/reviewer/view-report.html
+++ b/server/views/pages/reviewer/view-report.html
@@ -19,7 +19,7 @@
     </div>
 
     {{
-      reportDetail.detail(data, null, user)
+      reportDetail.detail(data, null, data.incidentId, user)
     }}
 
     {{

--- a/server/views/pages/your-report.html
+++ b/server/views/pages/your-report.html
@@ -19,7 +19,7 @@
     </div>
 
     {{
-      reportDetail.detail(data, null, user)
+      reportDetail.detail(data, null, data.incidentId, user)
     }}
 
     {{


### PR DESCRIPTION
If a new staff member is added to a completed report it will mark the report as incomplete.

Staff are added via the report details screen:
<kbd>![Screenshot 2020-03-12 at 16 02 31](https://user-images.githubusercontent.com/1517745/76541070-ec367100-647a-11ea-8312-90ebb2b182f4.png)</kbd>

One a user has been added they will be presented the "view report" screen.

There are 3 different error cases that are handled and present an interrupt screen with an appropriate message:
1.) The user does not exist: will lead the user back to 'add another user' screen to try again
2.) The user is already on the report: will lead the user back to "view report"
3.) The user is unverified: this adds the user to the report and will redirect to 'view report'

Also needed to fix a unique index on statements which ensured a user can appear on a report once. It now will allow users to have more than one statement on a report - as long as only a single report is not deleted.