### PR TITLE
DCS-200 Adding new incident overview report

### DIFF
--- a/server/services/reportingService.test.js
+++ b/server/services/reportingService.test.js
@@ -4,6 +4,7 @@ const serviceCreator = require('./reportingService')
 const reportingClient = {
   getMostOftenInvolvedStaff: jest.fn(),
   getMostOftenInvolvedPrisoners: jest.fn(),
+  getIncidentsOverview: jest.fn(),
 }
 
 const offenderService = {
@@ -40,7 +41,7 @@ Bella,10
 Charlotte,5
 `)
 
-    expect(reportingClient.getMostOftenInvolvedStaff).toBeCalledWith('LEI', startDate, endDate)
+    expect(reportingClient.getMostOftenInvolvedStaff).toBeCalledWith('LEI', [startDate, endDate])
   })
 
   it('getMostOftenInvolvedPrisoners', async () => {
@@ -68,7 +69,39 @@ Bella,10
 Charlotte,5
 `)
 
-    expect(reportingClient.getMostOftenInvolvedPrisoners).toBeCalledWith('LEI', startDate, endDate)
+    expect(reportingClient.getMostOftenInvolvedPrisoners).toBeCalledWith('LEI', [startDate, endDate])
     expect(offenderService.getOffenderNames).toBeCalledWith('token-1', ['AAAA', 'BBBB', 'CCCC'])
+  })
+
+  it('getIncidentsOverview', async () => {
+    reportingClient.getIncidentsOverview.mockReturnValue([
+      {
+        total: 'total-1',
+        planned: 'planned-1',
+        unplanned: 'unplanned-1',
+        handcuffsApplied: 'handcuffsApplied-1',
+        batonDrawn: 'batonDrawn-1',
+        batonUsed: 'batonUsed-1',
+        pavaDrawn: 'pavaDrawn-1',
+        pavaUsed: 'pavaUsed-1',
+        personalProtectionTechniques: 'personalProtectionTechniques-1',
+        cctvRecording: 'cctvRecording-1',
+        bodyWornCamera: 'bodyWornCamera-1',
+        bodyWornCameraUnknown: 'bodyWornCameraUnknown-1',
+      },
+    ])
+
+    const date = moment({ years: 2019, months: 1 })
+    const startDate = moment(date).startOf('month')
+    const endDate = moment(date).endOf('month')
+
+    const result = await service.getIncidentsOverview('LEI', 2, 2019)
+
+    expect(result)
+      .toEqual(`Total,Planned incidents,Unplanned incidents,Handcuffs applied,Baton drawn,Baton used,Pava drawn,Pava used,Personal protection techniques,CCTV recording,Body worn camera recording,Body worn camera recording unknown
+total-1,planned-1,unplanned-1,handcuffsApplied-1,batonDrawn-1,batonUsed-1,pavaDrawn-1,pavaUsed-1,personalProtectionTechniques-1,cctvRecording-1,bodyWornCamera-1,bodyWornCameraUnknown-1
+`)
+
+    expect(reportingClient.getIncidentsOverview).toBeCalledWith('LEI', [startDate, endDate])
   })
 })


### PR DESCRIPTION
This returns summary information for all submitted Incidents that were submitted within a
specific month.

Waiting to here back whether we want to key by incident date instead but there are some
disadvantages that way based on getting incomplete reports at the end of the month.

Also moving to use new role based middleware rather than having custom authorisation within
the routes