### PR TITLE
DCS-196: Run Jest tests 'in band' to reduce memory use on CircleCI.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "clean": "rm -rf dist/* .port.tmp *.log build/* uploads/* test-results.xml",
     "lint": "eslint . --cache --max-warnings 0",
     "typecheck": "tsc",
-    "test": "jest",
+    "test": "jest --runInBand",
     "int-test": "DB_NAME=use-of-force-int DB_PORT=5432 cypress run",
     "int-test-ui": "DB_NAME=use-of-force-int DB_PORT=5432 cypress open",
     "migrate": "knex migrate:latest",


### PR DESCRIPTION
Increases run time from 14 seconds to 19 on my laptop.  Seems to take rather longer on CircleCI - but not as long as the integration tests (surprise), so it doesn't really matter.