### PR TITLE
Dcs 424 sort prisoner and other cell

### DIFF
--- a/server/services/offenderService.test.ts
+++ b/server/services/offenderService.test.ts
@@ -83,6 +83,80 @@ describe('getOffenders', () => {
       expect(elite2Client.getLocations).toBeCalledWith('WRI')
     })
 
+    it('should sort retrieved locations with top 2 primary locations at the begining', async () => {
+      elite2Client.getLocations.mockReturnValue([
+        { id: 2, userDescription: 'place 2' },
+        { id: 'o', userDescription: 'Other cell' },
+        { id: 3, userDescription: 'place 3' },
+        { id: 'p', userDescription: "Prisoner's cell" },
+        { id: 1, userDescription: 'place 1' },
+        { id: 4, userDescription: 'place 4' },
+      ])
+
+      const result = await service.getIncidentLocations(token, 'WRI')
+
+      expect(result).toEqual([
+        { id: 'p', userDescription: "Prisoner's cell" },
+        { id: 'o', userDescription: 'Other cell' },
+        { id: 1, userDescription: 'place 1' },
+        { id: 2, userDescription: 'place 2' },
+        { id: 3, userDescription: 'place 3' },
+        { id: 4, userDescription: 'place 4' },
+      ])
+    })
+
+    it('should sort retrieved locations with only 1 primary location at the begining', async () => {
+      elite2Client.getLocations.mockReturnValue([
+        { id: 2, userDescription: 'place 2' },
+        { id: 3, userDescription: 'place 3' },
+        { id: 'p', userDescription: "Prisoner's cell" },
+        { id: 1, userDescription: 'place 1' },
+        { id: 4, userDescription: 'place 4' },
+      ])
+
+      const result = await service.getIncidentLocations(token, 'WRI')
+
+      expect(result).toEqual([
+        { id: 'p', userDescription: "Prisoner's cell" },
+        { id: 1, userDescription: 'place 1' },
+        { id: 2, userDescription: 'place 2' },
+        { id: 3, userDescription: 'place 3' },
+        { id: 4, userDescription: 'place 4' },
+      ])
+    })
+
+    it('should sort retrieved locations with zero primary locations at the begining', async () => {
+      elite2Client.getLocations.mockReturnValue([
+        { id: 2, userDescription: 'place 2' },
+        { id: 3, userDescription: 'place 3' },
+        { id: 1, userDescription: 'place 1' },
+        { id: 4, userDescription: 'place 4' },
+      ])
+
+      const result = await service.getIncidentLocations(token, 'WRI')
+
+      expect(result).toEqual([
+        { id: 1, userDescription: 'place 1' },
+        { id: 2, userDescription: 'place 2' },
+        { id: 3, userDescription: 'place 3' },
+        { id: 4, userDescription: 'place 4' },
+      ])
+    })
+
+    it('should sort retrieved locations with zero other locations', async () => {
+      elite2Client.getLocations.mockReturnValue([
+        { id: 'p', userDescription: "Prisoner's cell" },
+        { id: 'o', userDescription: 'Other cell' },
+      ])
+
+      const result = await service.getIncidentLocations(token, 'WRI')
+
+      expect(result).toEqual([
+        { id: 'p', userDescription: "Prisoner's cell" },
+        { id: 'o', userDescription: 'Other cell' },
+      ])
+    })
+
     it('should use token', async () => {
       await service.getIncidentLocations(token, 'WRI')
 

--- a/server/services/offenderService.test.ts
+++ b/server/services/offenderService.test.ts
@@ -86,9 +86,9 @@ describe('getOffenders', () => {
     it('should sort retrieved locations with top 2 primary locations at the begining', async () => {
       elite2Client.getLocations.mockReturnValue([
         { id: 2, userDescription: 'place 2' },
-        { id: 'o', userDescription: 'Other cell' },
+        { id: 6, userDescription: 'Other cell' },
         { id: 3, userDescription: 'place 3' },
-        { id: 'p', userDescription: "Prisoner's cell" },
+        { id: 5, userDescription: "Prisoner's cell" },
         { id: 1, userDescription: 'place 1' },
         { id: 4, userDescription: 'place 4' },
       ])
@@ -96,8 +96,8 @@ describe('getOffenders', () => {
       const result = await service.getIncidentLocations(token, 'WRI')
 
       expect(result).toEqual([
-        { id: 'p', userDescription: "Prisoner's cell" },
-        { id: 'o', userDescription: 'Other cell' },
+        { id: 5, userDescription: "Prisoner's cell" },
+        { id: 6, userDescription: 'Other cell' },
         { id: 1, userDescription: 'place 1' },
         { id: 2, userDescription: 'place 2' },
         { id: 3, userDescription: 'place 3' },
@@ -109,7 +109,7 @@ describe('getOffenders', () => {
       elite2Client.getLocations.mockReturnValue([
         { id: 2, userDescription: 'place 2' },
         { id: 3, userDescription: 'place 3' },
-        { id: 'p', userDescription: "Prisoner's cell" },
+        { id: 5, userDescription: "Prisoner's cell" },
         { id: 1, userDescription: 'place 1' },
         { id: 4, userDescription: 'place 4' },
       ])
@@ -117,7 +117,7 @@ describe('getOffenders', () => {
       const result = await service.getIncidentLocations(token, 'WRI')
 
       expect(result).toEqual([
-        { id: 'p', userDescription: "Prisoner's cell" },
+        { id: 5, userDescription: "Prisoner's cell" },
         { id: 1, userDescription: 'place 1' },
         { id: 2, userDescription: 'place 2' },
         { id: 3, userDescription: 'place 3' },
@@ -145,15 +145,15 @@ describe('getOffenders', () => {
 
     it('should sort retrieved locations with zero other locations', async () => {
       elite2Client.getLocations.mockReturnValue([
-        { id: 'p', userDescription: "Prisoner's cell" },
-        { id: 'o', userDescription: 'Other cell' },
+        { id: 6, userDescription: 'Other cell' },
+        { id: 5, userDescription: "Prisoner's cell" },
       ])
 
       const result = await service.getIncidentLocations(token, 'WRI')
 
       expect(result).toEqual([
-        { id: 'p', userDescription: "Prisoner's cell" },
-        { id: 'o', userDescription: 'Other cell' },
+        { id: 5, userDescription: "Prisoner's cell" },
+        { id: 6, userDescription: 'Other cell' },
       ])
     })
 

--- a/server/services/offenderService.ts
+++ b/server/services/offenderService.ts
@@ -2,6 +2,16 @@ import logger from '../../log'
 import { isNilOrEmpty, properCaseName } from '../utils/utils'
 import { AgencyId, OffenderService, PrisonerDetail, PrisonLocation } from '../types/uof'
 
+const compare = (a, b): number => {
+  let comparison = 0
+  if (a.userDescription.toUpperCase() > b.userDescription.toUpperCase()) {
+    comparison = 1
+  } else if (a.userDescription.toUpperCase() < b.userDescription.toUpperCase()) {
+    comparison = -1
+  }
+  return comparison
+}
+
 export default function createOffenderService(elite2ClientBuilder): OffenderService {
   const getOffenderDetails = async (token, bookingId): Promise<object> => {
     try {
@@ -70,9 +80,25 @@ export default function createOffenderService(elite2ClientBuilder): OffenderServ
 
   const getIncidentLocations = async (token: string, agencyId: AgencyId): Promise<PrisonLocation[]> => {
     try {
-      const elite2Client = elite2ClientBuilder(token)
+      const incidentLocations = elite2ClientBuilder(token).getLocations(agencyId)
 
-      return elite2Client.getLocations(agencyId)
+      const primaryLocations = incidentLocations.filter(
+        loc =>
+          loc.userDescription.toUpperCase() === "PRISONER'S CELL" || loc.userDescription.toUpperCase() === 'OTHER CELL'
+      )
+      const remainingLocations = incidentLocations
+        .filter(
+          loc =>
+            loc.userDescription.toUpperCase() !== "PRISONER'S CELL" &&
+            loc.userDescription.toUpperCase() !== 'OTHER CELL'
+        )
+        .sort(compare)
+
+      if (primaryLocations.length === 2 && primaryLocations[0].userDescription.toUpperCase() !== "PRISONER'S CELL") {
+        primaryLocations.reverse()
+      }
+
+      return [...primaryLocations, ...remainingLocations]
     } catch (error) {
       logger.error(error, 'Error during getIncidentLocations')
       throw error

--- a/server/services/offenderService.ts
+++ b/server/services/offenderService.ts
@@ -80,7 +80,8 @@ export default function createOffenderService(elite2ClientBuilder): OffenderServ
 
   const getIncidentLocations = async (token: string, agencyId: AgencyId): Promise<PrisonLocation[]> => {
     try {
-      const incidentLocations = elite2ClientBuilder(token).getLocations(agencyId)
+      const elite2Client = elite2ClientBuilder(token)
+      const incidentLocations = await elite2Client.getLocations(agencyId)
 
       const primaryLocations = incidentLocations.filter(
         loc =>


### PR DESCRIPTION
The UOF report incident-details page has a select input for Incident location.
This PR is to ensure that should there be any locations called Prisoner's Cell or Other cell, they are at the top of the select options.
Any subsequent options will be in alpha order 