### PR TITLE
DCS-472 Fix issue adding unverified users

### DIFF
--- a/server/services/userService.js
+++ b/server/services/userService.js
@@ -38,7 +38,9 @@ module.exports = function createUserService(elite2ClientBuilder, authClientBuild
 
         const getEmailSafely = R.ifElse(R.test(usernamePattern), client.getEmail, emailNotExistPromise)
 
-        const requests = usernames.map((username, i) => getEmailSafely(username).then(email => ({ ...email, i })))
+        const requests = usernames.map((username, i) =>
+          getEmailSafely(username.toUpperCase()).then(email => ({ ...email, i }))
+        )
         const responses = await Promise.all(requests)
 
         const missing = responses.filter(email => !email.exists)

--- a/server/services/userService.test.js
+++ b/server/services/userService.test.js
@@ -112,8 +112,8 @@ describe('getUsers', () => {
   })
 
   it('One not verified', async () => {
-    const user1 = { username: 'Bob', email: 'an@email.com', exists: true, verified: true }
-    const user2 = { username: 'June', exists: true, verified: false }
+    const user1 = { username: 'BOB', email: 'an@email.com', exists: true, verified: true }
+    const user2 = { username: 'JUNE', exists: true, verified: false }
 
     authClient.getEmail.mockResolvedValueOnce(user1).mockResolvedValueOnce(user2)
     authClient.getUser
@@ -124,7 +124,7 @@ describe('getUsers', () => {
 
     expect(result).toEqual([
       {
-        username: 'Bob',
+        username: 'BOB',
         name: 'Bob Smith',
         staffId: 123,
         email: 'an@email.com',
@@ -132,7 +132,7 @@ describe('getUsers', () => {
         verified: true,
       },
       {
-        username: 'June',
+        username: 'JUNE',
         name: 'June Jones',
         staffId: 234,
         email: undefined,
@@ -140,6 +140,8 @@ describe('getUsers', () => {
         verified: false,
       },
     ])
+
+    expect(authClient.getEmail.mock.calls).toEqual([['BOB'], ['JUNE']])
   })
 
   it('should use the user token', async () => {


### PR DESCRIPTION
If an unverified user is added then the system was storing
the user provided version of the username.

This causes an issue where elite2 and auth use case insensitive search so
return results correctly but we then cannot load their statement as we do a case
sensitive search on statements by user id.

We'd rather store the user ids in the canonical form so upper casing here.