### PR TITLE
DCS-467 Add exit link to top of the page.

### DIFF
--- a/server/views/partials/incidentPage.html
+++ b/server/views/partials/incidentPage.html
@@ -2,7 +2,20 @@
 
 {% set pageTitle = 'Use of force incidents' %}
 
-    {% block content %}
+{% macro exitLink(qa) %}
+    <div class="govuk-grid-column-full">
+        <a href="{{ links.exitUrl }}" class="govuk-link govuk-!-font-size-19" data-qa="{{qa}}">Exit to Digital Prison Services</a>
+    </div>
+{% endmacro %}
+
+{% block beforeContent %}
+    <div class="govuk-grid-row">
+        {{ exitLink("exit-to-dps-link-top") }}
+    </div>    
+{% endblock %}
+
+{% block content %}
+
     <h1 class="govuk-heading-xl mainHeading">{{ pageTitle }}</h1>
 
     <div class="govuk-tabs">
@@ -32,9 +45,7 @@
         {% block tabContent %}
         {% endblock %}
         <div class="govuk-grid-row govuk-!-margin-top-4">
-            <div class="govuk-grid-column-full">
-                <a href="{{ links.exitUrl }}" class="govuk-link govuk-!-font-size-19" data-qa="exit-to-dps-link">Exit to Digital Prison Services</a>
-            </div>
+            {{ exitLink("exit-to-dps-link") }}
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
Adding an additional exit link to incident list pages. 

<kbd>
<img width="1186" alt="Screenshot 2020-05-01 at 15 47 44" src="https://user-images.githubusercontent.com/1517745/80814206-5c33be80-8bc3-11ea-8efe-f7fa55d13ef2.png">

</kbd>

This is possibly an interim measure as we workout how to effectively display the home page.