### PR TITLE
DCS-483 

### DIFF
--- a/helm_deploy/secrets-example.yaml
+++ b/helm_deploy/secrets-example.yaml
@@ -7,4 +7,5 @@ secrets:
   SYSTEM_CLIENT_SECRET: somesecretvalue
   NOTIFY_API_KEY: somesecretvalue
   TAG_MANAGER_KEY: somesecretvalue
+  TAG_MANAGER_ENVIRONMENT:
   SESSION_SECRET: somesecretvalue

--- a/helm_deploy/use-of-force/templates/_envs.tpl
+++ b/helm_deploy/use-of-force/templates/_envs.tpl
@@ -73,6 +73,12 @@ env:
         name: {{ template "app.name" . }}
         key: TAG_MANAGER_KEY
 
+  - name: TAG_MANAGER_ENVIRONMENT
+    valueFrom:
+      secretKeyRef:
+        name: {{ template "app.name" . }}
+        key: TAG_MANAGER_ENVIRONMENT
+
   - name: SESSION_SECRET
     valueFrom:
       secretKeyRef:

--- a/helm_deploy/use-of-force/templates/secrets.yaml
+++ b/helm_deploy/use-of-force/templates/secrets.yaml
@@ -11,4 +11,5 @@ data:
   SYSTEM_CLIENT_SECRET: {{ .Values.secrets.SYSTEM_CLIENT_SECRET | b64enc | quote }}
   NOTIFY_API_KEY: {{ .Values.secrets.NOTIFY_API_KEY | b64enc | quote }}
   TAG_MANAGER_KEY: {{ .Values.secrets.TAG_MANAGER_KEY | b64enc | quote }}
+  TAG_MANAGER_ENVIRONMENT: {{ .Values.secrets.TAG_MANAGER_ENVIRONMENT | default "" | b64enc | quote }}
   SESSION_SECRET: {{ .Values.secrets.SESSION_SECRET | b64enc | quote }}

--- a/server/config.js
+++ b/server/config.js
@@ -97,5 +97,8 @@ module.exports = {
     exitUrl: get('EXIT_LOCATION_URL', '/', requiredInProduction),
   },
   https: production,
-  tagManagerKey: get('TAG_MANAGER_KEY', null),
+  googleTagManager: {
+    key: get('TAG_MANAGER_KEY', null),
+    environment: get('TAG_MANAGER_ENVIRONMENT', ''), // The additional GTM snippet string that configures a non-prod environment
+  },
 }

--- a/server/utils/nunjucksSetup.js
+++ b/server/utils/nunjucksSetup.js
@@ -1,6 +1,7 @@
 const nunjucks = require('nunjucks')
 const moment = require('moment')
-const { tagManagerKey } = require('../config')
+const nodeCrypto = require('crypto')
+const { key: tagManagerKey, environment: tagManagerEnvironment } = require('../config').googleTagManager
 
 module.exports = (app, path) => {
   const njkEnv = nunjucks.configure([path.join(__dirname, '../../server/views'), 'node_modules/govuk-frontend/'], {
@@ -9,6 +10,7 @@ module.exports = (app, path) => {
   })
 
   njkEnv.addGlobal('googleTagManagerContainerId', tagManagerKey)
+  njkEnv.addGlobal('googleTagManagerEnvironment', tagManagerEnvironment)
 
   njkEnv.addFilter('findError', (array, formFieldId) => {
     const item = array.find(error => error.href === `#${formFieldId}`)
@@ -74,4 +76,13 @@ module.exports = (app, path) => {
     }
     return value ? 'Yes' : 'No'
   })
+
+  njkEnv.addFilter('MD5', value =>
+    value
+      ? nodeCrypto
+          .createHash('md5')
+          .update(value)
+          .digest('hex')
+      : value
+  )
 }

--- a/server/views/tagManager/bodyContent.html
+++ b/server/views/tagManager/bodyContent.html
@@ -1,6 +1,6 @@
 {% if googleTagManagerContainerId %}
 <!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{googleTagManagerContainerId}}"
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ googleTagManagerContainerId }}{{ googleTagManagerEnvironment }}"
                   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
 {% endif %}

--- a/server/views/tagManager/headContent.html
+++ b/server/views/tagManager/headContent.html
@@ -1,10 +1,10 @@
 {% if googleTagManagerContainerId %}
-<script>dataLayer=[{ 'activeCaseloadId':'{{user.activeCaseLoadId}}' }];</script>
+<script>dataLayer=[{'activeCaseloadId':'{{ user.activeCaseLoadId }}','userId':'{{ user.username | MD5 | upper }}'}];</script>
 <!-- Google Tag Manager -->
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
   j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl+'{{ googleTagManagerEnvironment }}';f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','{{googleTagManagerContainerId}}');</script>
 <!-- End Google Tag Manager -->
 {% endif %}


### PR DESCRIPTION
Tag 'submit a report' 

Introduce support for Google Tag Manager environments. This allows us to use one GTM container with multiple environments (live, preprod and dev).  Changes to GTM configuration are versioned and can be published to different environments.  This is much easier to do than manually copying configuration changes from one container to another and will eliminate transcription errors.

From the app point of view supporting environments consists of adding more parameters to the GTM snippets that are added to each page.  All environments and deployments will use the same container id (TAG_MANAGER_KEY) while the preprod and dev environments will include extra configuration parameters.  These parameters are injected as an opaque string from AWS secrets. The new secret key and environment variable name is TAG_MANAGER_ENVIRONMENT.  In prod this value will be the empty string. 

Add the MD5 hash of the current username to the GTM dataLayer variable. This value will not be sent by GTM to Google Analytics unless a new dimension is set up in GA and a new variable set up in GTM.  Neither of these things exist at present.  

The work to actually send a 'submit a report' hit to GTM is all done in the GTM UI.