### PR TITLE
DCS-439: layout changes

### DIFF
--- a/assets/sass/local.sass
+++ b/assets/sass/local.sass
@@ -217,3 +217,6 @@ i[class^="arrow-"]
 .tab-link
   font-size: 1.1875rem
   line-height: 2.31579
+
+.flex-container 
+  display: flex

--- a/server/views/pages/statement/write-your-statement.html
+++ b/server/views/pages/statement/write-your-statement.html
@@ -30,12 +30,9 @@
         <p class="govuk-!-margin-bottom-1">
           <span class="govuk-label--s">Prisoner:&nbsp;</span>
           <span data-qa="offender-name"> {{ data.displayName }} </span>
-        </p>
-        <p class="govuk-!-margin-bottom-1">
+          <br>
           <span class="govuk-label--s">Date and time of incident:&nbsp;</span>
-          <span data-qa="date-and-time">
-            {{ data.incidentDate | formatDate('D MMMM YYYY - HH:mm')  }}
-          </span>
+          <span data-qa="date-and-time"> {{ data.incidentDate | formatDate('D MMMM YYYY - HH:mm')  }} </span>
         </p>
       </div>
     </div>
@@ -49,32 +46,31 @@
         %}
 
         <div class="govuk-grid-row govuk-grid-column-one-half govuk-!-padding-0">
-          <div class="govuk-grid-column-one-quarter">
+          <div class="govuk-grid-column-one-half flex-container">
             {{
-            govukSelect({
-              id: 'lastTrainingMonth',
-              name: 'lastTrainingMonth',
-              label: {
-                text: 'Month'
-              },
-              errorMessage: errors | findError('lastTrainingMonth'),
-              items: data.months | toSelect('value', 'label', data.lastTrainingMonth)
-            })
-          }}
-          </div>
-          <div class="govuk-grid-column-one-quarter">
-            {{
-            govukInput({
-              id: 'lastTrainingYear',
-              name: 'lastTrainingYear',
-              value: data.lastTrainingYear,
-              classes: 'govuk-input--width-4',
-              label: {
-                text: 'Year'
-              },
-              errorMessage: errors | findError('lastTrainingYear')
+              govukSelect({
+                id: 'lastTrainingMonth',
+                name: 'lastTrainingMonth',
+                label: {
+                  text: 'Month'
+                },
+                errorMessage: errors | findError('lastTrainingMonth'),
+                items: data.months | toSelect('value', 'label', data.lastTrainingMonth)
               })
             }}
+            {{
+              govukInput({
+                id: 'lastTrainingYear',
+                name: 'lastTrainingYear',
+                value: data.lastTrainingYear,
+                classes: 'govuk-!-margin-left-5 govuk-input--width-4',
+                label: {
+                  text: 'Year',
+                  classes: 'govuk-!-margin-left-5'
+                },
+                errorMessage: errors | findError('lastTrainingYear')
+                })
+              }}
           </div>
         </div>
         {% endcall %}


### PR DESCRIPTION
Removed gap between Prisoner and date of Incident two elements.
Select for month made bigger so it can fit months that have longest spelling. 