### PR TITLE
DCS-438, DCS-444, DCS-445

### DIFF
--- a/assets/sass/local.sass
+++ b/assets/sass/local.sass
@@ -29,7 +29,7 @@ header.govuk-header
   font-size: 26px
   flex-grow: 1
   text-decoration: none
-  padding-left: 0px
+  padding-left: 0
   @include govuk-media-query($from: mobile)
     margin-left: 58px
   @include govuk-media-query($from: desktop)
@@ -73,10 +73,10 @@ header.govuk-header
         padding: 0 10px
   @include govuk-media-query($from: desktop)
     position: inherit
-    bottom: 0px
-    padding-bottom: 0px
-    margin-right: 0px
-    margin-left: 0px
+    bottom: 0
+    padding-bottom: 0
+    margin-right: 0
+    margin-left: 0
     ul
       li
         padding: 0 30px
@@ -220,3 +220,6 @@ i[class^="arrow-"]
 
 .flex-container 
   display: flex
+
+dt.summary-list__key__wider
+  width: 80%

--- a/server/views/pages/report-sent.html
+++ b/server/views/pages/report-sent.html
@@ -24,7 +24,7 @@
 
     {{
       govukButton({
-        text: 'Exit',
+        text: 'Exit to Digital Prison Services',
         href: links.exitUrl,
         classes: 'govuk-button govuk-button--secondary govuk-!-margin-left-3 ',
         attributes: { 'data-qa': 'exit' }

--- a/server/views/pages/reportDetailSectionsMacros.njk
+++ b/server/views/pages/reportDetailSectionsMacros.njk
@@ -15,7 +15,7 @@
 {% macro tableRow(dataItem) %}
  <dl class="govuk-summary-list govuk-!-margin-0">  
   <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key"> {{dataItem.label}} </dt>
+    <dt class="govuk-summary-list__key summary-list__key__wider"> {{dataItem.label}} </dt>
     <dd class="govuk-summary-list__value" data-qa="{{dataItem['data-qa']}}">
       {% if dataItem.dataValue.length === 0 or dataItem.dataValue == null %}
         &ndash;
@@ -42,7 +42,7 @@
 {% macro tableRowWithContent(dataItem) %}
  <dl class="govuk-summary-list govuk-!-margin-0">  
   <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key"> {{dataItem.label}} </dt>
+    <dt class="govuk-summary-list__key summary-list__key__wider"> {{dataItem.label}} </dt>
       {{ caller() }}
   </div>
 </dl> 

--- a/server/views/pages/reviewer/view-statements.html
+++ b/server/views/pages/reviewer/view-statements.html
@@ -9,7 +9,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
       <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
-      {{ reportDetail.reportHeadingWithSpacing(data) }}
+      {{ reportDetail.reportHeading(data) }}
     </div>
   </div>
   <div class="govuk-grid-row govuk-!-margin-top-3">


### PR DESCRIPTION
### DCS-438 Tweaks to 'Report sent'
Report sent page: Change grey button text to 'Exit to Digital Prison Services

![report-sent tweak](https://user-images.githubusercontent.com/3247844/85139474-6295fc80-b23c-11ea-8275-b56316a45893.png)

### DCS-444 Tweaks to 'View Use of Force' page

`{/bookingId}/view-report` 
Expand the width of the label section so that, where possible, it remains on a single line

![view-report tweak](https://user-images.githubusercontent.com/3247844/85139578-86594280-b23c-11ea-9f64-ba60bc1de5f1.png)

 ### DCS-445 Use of Force incident (overview)

The playback of incident details at the top should have reduced line spacing so that it aligns with the ‘view report’ page

It matches the layout for DCS-444 (above) now.

![view-statements tweak](https://user-images.githubusercontent.com/3247844/85139865-9d983000-b23c-11ea-85cf-9115e788fd07.png)

