### PR TITLE
DCS-545 Fixing link location for reviewers/coordinators

### DIFF
--- a/server/routes/statements.js
+++ b/server/routes/statements.js
@@ -82,7 +82,7 @@ module.exports = function CreateReportRoutes({ statementService, offenderService
 
       const isValid = isNilOrEmpty(errors)
 
-      // Always persist to prevent loss of work and avoiding issues with storing large content in cookie session state
+      // Always persist to prevent loss of work
       await statementService.save(req.user.username, reportId, statement)
 
       if (saveAndContinue && !isValid) {
@@ -90,7 +90,7 @@ module.exports = function CreateReportRoutes({ statementService, offenderService
         return res.redirect(`/${reportId}/write-your-statement`)
       }
 
-      const location = saveAndContinue ? `/${reportId}/check-your-statement` : `/`
+      const location = saveAndContinue ? `/${reportId}/check-your-statement` : `/your-statements`
 
       return res.redirect(location)
     },

--- a/server/routes/statements.test.js
+++ b/server/routes/statements.test.js
@@ -56,7 +56,7 @@ describe('POST /:reportId/write-your-statement', () => {
       .post('/-1/write-your-statement')
       .send('submitType=save-and-return')
       .expect(302)
-      .expect('Location', '/'))
+      .expect('Location', '/your-statements'))
 
   it('save and continue with invalid data will redirect to same page', () =>
     request(app)


### PR DESCRIPTION
 Should always open 'your statements' tab, this currently opens `/` which means that reviewers and coordinators get sent to `All incidents` instead. 

<kbd>
<img width="793" alt="Screenshot 2020-06-22 at 09 31 42" src="https://user-images.githubusercontent.com/1517745/85266156-5d6ac480-b46b-11ea-9dd8-5c1a25c439f8.png">
</kbd>

This was fixed for 'review your statement" but not explicitly covered by a ticket and should be consistent