### PR TITLE
DCS-437: layout changes to view-statement

### DIFF
--- a/server/views/pages/reviewer/view-statement.html
+++ b/server/views/pages/reviewer/view-statement.html
@@ -17,14 +17,16 @@
  
   {{ statementDetail.detail(data) }}
 
-  {{
-    govukButton({
-      text: 'Continue',
-      name: 'continue',
-      href: '/' + data.reportId + '/view-statements',
-      classes: 'govuk-button  govuk-!-margin-top-5',
-      attributes: { 'data-qa': 'continue' }
-    })
-  }}
+  <p class="govuk-!-margin-top-5">
+    <a
+      href="/{{ data.reportId }}/view-statements"
+      draggable="false"
+      class="govuk-link"
+      data-qa="continue"
+    >
+      Return to incident overview
+    </a>
+  </p>
+
 </div>
 {% endblock %}

--- a/server/views/pages/statement/check-your-statement.html
+++ b/server/views/pages/statement/check-your-statement.html
@@ -12,7 +12,11 @@
 
 {% block content %}
 <div class="govuk-body">
-  <h1 class="govuk-heading-xl mainHeading">{{ pageTitle }} </h1>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl mainHeading">{{ pageTitle }} </h1>
+    </div>
+  </div>
 
   {{ statementDetail.detail(data) }}
   

--- a/server/views/pages/statementDetailMacro.njk
+++ b/server/views/pages/statementDetailMacro.njk
@@ -1,68 +1,78 @@
-
 {% macro detail(data) %}
-  <div class="govuk-grid-row govuk-body">
-    <div class="govuk-grid-column-full ">
-      <p class="govuk-!-margin-bottom-1">
-        <span class="govuk-label--s">Prisoner:&nbsp;</span>
-        <span data-qa="offender-name"> {{ data.displayName }} </span>
-        <br>
-        <span class="govuk-label--s">Date and time of incident:&nbsp;</span>
-        <span data-qa="date-and-time">
-          {{ data.incidentDate | formatDate('D MMMM YYYY - HH:mm')  }}
-        </span>
-        <br>
-        <span class="govuk-label--s">When did you last attend control and restraint basic refresher
-          training?:&nbsp;</span>
-        <span data-qa="last-training"> {{ data.lastTrainingMonth }} {{ data.lastTrainingYear }} </span>
-        <br>
-        <span class="govuk-label--s">What year did you join the prison service?:&nbsp;</span>
-        <span data-qa="job-start-year">
-          {{ data.jobStartYear }}
-        </span>
-      </p>
-    </div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-third ">
+    <p class="govuk-!-margin-bottom-0 govuk-label--s">Prisoner</p>
+    <p class="govuk-!-margin-top-0" data-qa="offender-name"> {{ data.displayName }} </p>
   </div>
-  
-  <hr class="govuk-!-margin-top-2" />
-  
-  <div class="govuk-grid-row govuk-!-margin-top-4">
-    <div class="govuk-grid-column-one-half">
-      <p class="govuk-!-margin-bottom-0 govuk-label--s">Statement</p>
-    </div>
-    {% if data.submittedDate %}
-    <div class="govuk-grid-column-one-half ">
-      <p>
-        <span class="govuk-label--s">Submitted:</span> {{ data.submittedDate | formatDate('D MMMM YYYY - HH:mm') }}
-      </p>
-    </div>
+  <div class="govuk-grid-column-one-third">
+    <p class="govuk-!-margin-bottom-0 govuk-label--s">Last control and restraint training</p>
+    <p class="govuk-!-margin-top-0" data-qa="last-training"> {{ data.lastTrainingMonth }} {{ data.lastTrainingYear }}
+    </p>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-third">
+    <p class="govuk-!-margin-bottom-0 govuk-label--s">Date and time of incident</p>
+    <p class="govuk-!-margin-top-0" data-qa="date-and-time">
+      {{ data.incidentDate | formatDate('D MMMM YYYY - HH:mm')  }}
+    </p>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <p class="govuk-!-margin-bottom-0 govuk-label--s">Year joined the prison service</p>
+    <p class="govuk-!-margin-top-0" data-qa="job-start-year">
+      {{ data.jobStartYear }}
+    </p>
+  </div>
+</div>
+
+<div class="govuk-grid-column-two-thirds govuk-!-padding-0">
+  <hr class="govuk-!-margin-top-4" />
+</div>
+
+<div class="govuk-grid-row govuk-!-margin-top-4">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-!-margin-bottom-0 govuk-label--s">
+      Statement submitted
+    </p>
+    <p class="govuk-!-margin-top-0">
+      {% if data.submittedDate %}
+      {{ data.submittedDate | formatDate('D MMMM YYYY - HH:mm') }}
+    </p>
     {% endif %}
   </div>
-  
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <p class="govuk-!-margin-bottom-1 govuk-label--xs statement" data-qa="statement">{{ data.statement }}</p>
-    </div>
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-!-margin-bottom-1 govuk-label--xs statement" data-qa="statement">{{ data.statement }}</p>
   </div>
-  <hr />
 
-  {% for comment in data.additionalComments %}
-  <div class="govuk-grid-row govuk-!-margin-top-4">
-    <div class="govuk-grid-column-one-half">
-      <p class="govuk-!-margin-bottom-0 govuk-label--s">Additional comment</p>
-    </div>
-    <div class="govuk-grid-column-one-half ">
-      <p>
-        <span class="govuk-label--s">Submitted:</span> {{ comment.dateSubmitted | formatDate('D MMMM YYYY - HH:mm') }}
-      </p>
-    </div>
+  <div class="govuk-grid-column-two-thirds">
+    <hr class="govuk-!-margin-top-6" />
+  </div>
+</div>
+
+
+
+{% for comment in data.additionalComments %}
+<div class="govuk-grid-row govuk-!-margin-top-4">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-!-margin-bottom-0 govuk-label--s">Additional comment</p>
+  </div>
+
+  <div class="govuk-grid-column-one-half ">
+    <p> <span class="govuk-label--s">Submitted:</span> {{ comment.dateSubmitted | formatDate('D MMMM YYYY - HH:mm') }}</p>
+  </div>
   </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <p class="govuk-!-margin-bottom-1 govuk-!-margin-top-0 govuk-label--xs statement" data-loop={{loop.index}}
-        data-qa="viewAdditionalComment">{{comment.additionalComment}}</p>
-    </div>
+        data-qa="viewAdditionalComment">{{comment.additionalComment}}
+      </p>
   </div>
-  <hr />
-  {% endfor %}
+  <div class="govuk-grid-column-two-thirds">
+    <hr class="govuk-!-margin-top-6" />
+  </div>
+</div>
+
+{% endfor %}
 
 {% endmacro %}

--- a/server/views/pages/statementDetailMacro.njk
+++ b/server/views/pages/statementDetailMacro.njk
@@ -1,40 +1,36 @@
 {% macro detail(data) %}
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-third ">
-    <p class="govuk-!-margin-bottom-0 govuk-label--s">Prisoner</p>
-    <p class="govuk-!-margin-top-0" data-qa="offender-name"> {{ data.displayName }} </p>
+  <div class="govuk-grid-column-two-thirds  govuk-!-padding-left-0">
+    <div class="govuk-grid-column-one-half">
+      <p class="govuk-!-margin-bottom-0 govuk-label--s">Prisoner</p>
+      <p class="govuk-!-margin-top-0" data-qa="offender-name"> {{ data.displayName }} </p>
+    </div>
+    <div class="govuk-grid-column-one-half">
+      <p class="govuk-!-margin-bottom-0 govuk-label--s">Last control and restraint training</p>
+      <p class="govuk-!-margin-top-0" data-qa="last-training"> {{ data.lastTrainingMonth }} {{ data.lastTrainingYear }}
+      </p>
+    </div>
   </div>
-  <div class="govuk-grid-column-one-third">
-    <p class="govuk-!-margin-bottom-0 govuk-label--s">Last control and restraint training</p>
-    <p class="govuk-!-margin-top-0" data-qa="last-training"> {{ data.lastTrainingMonth }} {{ data.lastTrainingYear }}
-    </p>
+  <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
+    <div class="govuk-grid-column-one-half govuk-!-padding-bottom-3">
+      <p class="govuk-!-margin-bottom-0 govuk-label--s">Date and time of incident</p>
+      <p class="govuk-!-margin-top-0" data-qa="date-and-time">
+        {{ data.incidentDate | formatDate('D MMMM YYYY - HH:mm')  }}
+      </p>
+    </div>
+    <div class="govuk-grid-column-one-half  govuk-!-padding-bottom-3">
+      <p class="govuk-!-margin-bottom-0 govuk-label--s">Year joined the prison service</p>
+      <p class="govuk-!-margin-top-0" data-qa="job-start-year">
+        {{ data.jobStartYear }}
+      </p>
+    </div>
+    <hr class="govuk-!-margin-left-3" />
   </div>
-</div>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-third">
-    <p class="govuk-!-margin-bottom-0 govuk-label--s">Date and time of incident</p>
-    <p class="govuk-!-margin-top-0" data-qa="date-and-time">
-      {{ data.incidentDate | formatDate('D MMMM YYYY - HH:mm')  }}
-    </p>
-  </div>
-  <div class="govuk-grid-column-one-third">
-    <p class="govuk-!-margin-bottom-0 govuk-label--s">Year joined the prison service</p>
-    <p class="govuk-!-margin-top-0" data-qa="job-start-year">
-      {{ data.jobStartYear }}
-    </p>
-  </div>
-</div>
-
-<div class="govuk-grid-column-two-thirds govuk-!-padding-0">
-  <hr class="govuk-!-margin-top-4" />
 </div>
 
 <div class="govuk-grid-row govuk-!-margin-top-4">
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-!-margin-bottom-0 govuk-label--s">
-      Statement submitted
-    </p>
+    <p class="govuk-!-margin-bottom-0 govuk-label--s">Statement submitted</p>
     <p class="govuk-!-margin-top-0">
       {% if data.submittedDate %}
       {{ data.submittedDate | formatDate('D MMMM YYYY - HH:mm') }}
@@ -43,36 +39,22 @@
   </div>
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-!-margin-bottom-1 govuk-label--xs statement" data-qa="statement">{{ data.statement }}</p>
-  </div>
-
-  <div class="govuk-grid-column-two-thirds">
     <hr class="govuk-!-margin-top-6" />
   </div>
 </div>
-
 
 
 {% for comment in data.additionalComments %}
-<div class="govuk-grid-row govuk-!-margin-top-4">
-  <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-!-margin-bottom-0 govuk-label--s">Additional comment</p>
-  </div>
-
-  <div class="govuk-grid-column-one-half ">
-    <p> <span class="govuk-label--s">Submitted:</span> {{ comment.dateSubmitted | formatDate('D MMMM YYYY - HH:mm') }}</p>
-  </div>
-  </div>
-  <div class="govuk-grid-row">
+  <div class="govuk-grid-row govuk-!-margin-top-4">
     <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-!-margin-bottom-0 govuk-label--s">Additional comment submitted</p>
+      <p class="govuk-!-margin-top-0"> {{ comment.dateSubmitted | formatDate('D MMMM YYYY - HH:mm') }} </p>
       <p class="govuk-!-margin-bottom-1 govuk-!-margin-top-0 govuk-label--xs statement" data-loop={{loop.index}}
         data-qa="viewAdditionalComment">{{comment.additionalComment}}
       </p>
+      <hr>
+    </div>
   </div>
-  <div class="govuk-grid-column-two-thirds">
-    <hr class="govuk-!-margin-top-6" />
-  </div>
-</div>
-
 {% endfor %}
 
 {% endmacro %}


### PR DESCRIPTION
screen shots of pages impacted
1. check-your-statement
<bkr>
<img width="118" alt="check-your-statement" src="https://user-images.githubusercontent.com/50441412/87062530-10297980-c205-11ea-9685-fa79841d39d2.png">

</bkr>

2. your-statement
<bkr>
<img width="105" alt="your-statement" src="https://user-images.githubusercontent.com/50441412/87062535-128bd380-c205-11ea-9d3e-0f9d49ef6001.png">
</bkr>

3. your-statement with added comments
<bkr>
<img width="105" alt="your-statement" src=https://user-images.githubusercontent.com/50441412/87062680-4961e980-c205-11ea-9aa9-0dd83a59fc22.png>
</bkr>

4. view statement. As see by coordinator 
<bkr>
<img width="105" alt="view-statement" src=https://user-images.githubusercontent.com/50441412/87062725-57176f00-c205-11ea-8b5b-d9d3a94bb9e0.png>

</bkr>