### PR TITLE
DCS-568: changed the style of the overdue tab, changed the delete_inc…

### DIFF
--- a/assets/sass/local.sass
+++ b/assets/sass/local.sass
@@ -156,15 +156,15 @@ header.govuk-header
   .prisoner, .reporter
     width: 15% !important
   .prisonNo
-    width: 12% !important
+    width: 14% !important
   .date
     width: 13% !important
   .report
-    width: 10% !important
+    width: 12% !important
   .delete
-    width: 10% !important  
+    width: 14% !important  
   .overdue
-    width: 10% !important
+    width: 7% !important
 
 .report-use-of-force-label  
   @include govuk-media-query($from: tablet)
@@ -323,3 +323,9 @@ dt.summary-list__key__wider
 
 .govuk-radios__conditional legend
   padding-top: 15px
+  
+.vertical-align-middle
+  vertical-align: middle !important
+
+.text-align-right
+  text-align: right

--- a/server/views/macros.njk
+++ b/server/views/macros.njk
@@ -4,3 +4,9 @@
         {{props.label | safe }}
     </a>
 {% endmacro %}
+
+
+{% macro overdueBadge(props) %}
+<span data-qa="{{props.qa}}" class="moj-badge moj-badge--red">{{props.text}}</span>
+{% endmacro %}
+

--- a/server/views/pages/all-incidents.html
+++ b/server/views/pages/all-incidents.html
@@ -1,6 +1,7 @@
 {% extends "../partials/incidentPage.html" %} 
 {% from "govuk/components/button/macro.njk" import govukButton %} 
 {% from "govuk/components/table/macro.njk" import govukTable %} 
+{% from  "../macros.njk" import overdueBadge %}    
 
 {% block tabContent %}
 <section class="govuk-tabs__panel">
@@ -33,7 +34,7 @@
           <td class="govuk-table__cell govuk-!-padding-top-3">{{report.offenderName}}</td>
           <td class="govuk-table__cell govuk-!-padding-top-3">{{report.offenderNo}}</td>
           <td class="govuk-table__cell govuk-!-padding-top-3">{{report.staffMemberName}}</td>
-          <td class="govuk-table__cell govuk-!-padding-top-3">
+          <td class="govuk-table__cell vertical-align-middle">
             <a
               href="/{{ report.id }}/view-statements"
               draggable="false"
@@ -43,21 +44,18 @@
             </a>
           </td>
           {% if user.isCoordinator %}
-          <td class="govuk-table__cell">
-              {{
-                govukButton({
-                  text: 'Delete',
-                  name: 'delete',
-                  href: '/coordinator/report/' + report.id + '/confirm-delete',
-                  classes: 'govuk-button govuk-button--secondary',
-                  attributes: { 'data-qa': 'continue' }
-                })
-              }}
+          <td class="govuk-table__cell vertical-align-middle">
+              <a href="/coordinator/report/{{ report.id }}/confirm-delete" class="govuk-link" data-qa='delete' name='delete'> Delete incident </a>
           </td>
           {% endif %}  
-          <td class="govuk-table__cell">
+          <td class="govuk-table__cell vertical-align-middle text-align-right">
             {% if report.isOverdue %}
-              <span data-qa="overdue" class="govuk-tag moj-tag--red govuk-!-margin-top-1">OVERDUE</span>
+              {{ 
+                overdueBadge({
+                  text: 'OVERDUE', 
+                  qa: 'overdue' 
+                }) 
+              }}
             {% endif %}
           </td>
       </tr>  

--- a/server/views/pages/reviewer/view-statements.html
+++ b/server/views/pages/reviewer/view-statements.html
@@ -1,6 +1,7 @@
 {% extends "../../partials/layout.html" %} 
 {% from "govuk/components/button/macro.njk" import govukButton %} 
 {% from "govuk/components/table/macro.njk" import govukTable %}
+{% from  "../../macros.njk" import overdueBadge %}    
 {% import "../reportDetailMacro.njk" as reportDetail %} 
 {% set pageTitle = 'Use of force incident' %}
 
@@ -50,7 +51,12 @@
                     <span data-qa="unverified" class="govuk-tag moj-tag--black govuk-!-margin-right-3">EMAIL NOT VERIFIED</span>
                   {% endif %}
                   {% if statement.isOverdue %}
-                    <span data-qa="overdue" class="govuk-tag moj-tag--red">OVERDUE</span>
+                    {{ 
+                      overdueBadge({
+                        text: 'OVERDUE', 
+                        qa: 'overdue' 
+                      }) 
+                    }}                  
                   {% endif %}
                 {% endif %}
               </td>


### PR DESCRIPTION
…ident from button to link

The overdue tab has been changed from a solid red to a border red as per 
https://moj-design-system.herokuapp.com/components/badge

The 'delete incident' button has been changed to a link.

Re-spaced the contents of the table row to ensure the 'view incident' and 'delete incident' links are horizontal rather than stacked. 
The affected screens now look like this 
<bkr>
<img width="400" alt="all-incidents 1xoverdue" src="https://user-images.githubusercontent.com/50441412/87690662-a3bcf600-c781-11ea-907e-09fe7e467ac2.png">
</bkr>

<bkr>
<img width="400" alt="all-incidents 2xoverdue " src="https://user-images.githubusercontent.com/50441412/87690700-af102180-c781-11ea-8c0f-abf77b5d2636.png">
</bkr>

<bkr>
<img width="400" alt="view-statements" src="https://user-images.githubusercontent.com/50441412/87690777-c51de200-c781-11ea-954c-0852d6df0970.png">
</bkr>