### PR TITLE
DCS-572 Adding pagination for completed incidents

### DIFF
--- a/integration-tests/integration/createIncident/form-submit.spec.js
+++ b/integration-tests/integration/createIncident/form-submit.spec.js
@@ -64,7 +64,7 @@ context('Submit the incident report', () => {
       .then(reportId => cy.task('getPayload', reportId).then(payload => expect(payload).to.deep.equal(expectedPayload)))
   })
 
-  it('After submitting, can not resubmit, go on to view all incidents', () => {
+  it('After submitting, can not resubmit', () => {
     cy.login()
 
     cy.task('seedReport', {

--- a/integration-tests/pages/reviewer/completedIncidentsPage.js
+++ b/integration-tests/pages/reviewer/completedIncidentsPage.js
@@ -1,5 +1,6 @@
 import page from '../page'
 import tabs from '../sections/incidentTabs'
+import pagination from '../sections/pagination'
 
 const row = (type, i) => cy.get(`[data-qa=${type}] tbody tr`).eq(i)
 const completeCol = (i, j) => row('incidents-complete', i).find('td').eq(j)
@@ -7,6 +8,7 @@ const completeCol = (i, j) => row('incidents-complete', i).find('td').eq(j)
 const incidentsPage = () =>
   page('Use of force incidents', {
     ...tabs,
+    ...pagination,
     filter: {
       prisonerName: () => cy.get('[name="prisonerName"]'),
       prisonNumber: () => cy.get('[name="prisonNumber"]'),

--- a/server/services/reviewService.test.ts
+++ b/server/services/reviewService.test.ts
@@ -2,18 +2,16 @@
 import { OffenderService } from '../types/uof'
 
 jest.mock('../data/incidentClient')
+jest.mock('../data/statementsClient')
 
 import IncidentClient from '../data/incidentClient'
-import ReviewService, { IncidentSummary } from './reviewService'
+import StatementsClient from '../data/statementsClient'
+import ReviewService, { IncidentSummary, ReportQuery } from './reviewService'
 import { ReportSummary } from '../data/incidentClientTypes'
+import { PageResponse } from '../utils/page'
 
 let incidentClient: jest.Mocked<IncidentClient>
-
-const statementsClient = {
-  getStatementsForReviewer: jest.fn(),
-  getStatementForReviewer: jest.fn(),
-  getAdditionalComments: jest.fn(),
-}
+let statementsClient: jest.Mocked<StatementsClient>
 
 const authClient = {
   getEmail: jest.fn(),
@@ -24,6 +22,7 @@ const authClientBuilder = jest.fn().mockReturnValue(authClient)
 interface MockOS extends OffenderService {
   getOffenderNames: jest.Mock<Promise<{ [offenderNo: string]: string }>, [string, string[]]>
 }
+
 const offenderService: MockOS = {
   getOffenderDetails: undefined,
   getOffenderNames: jest.fn(),
@@ -36,6 +35,7 @@ let service: ReviewService
 describe('reviewService', () => {
   beforeEach(() => {
     incidentClient = new IncidentClient(jest.fn(), jest.fn()) as jest.Mocked<IncidentClient>
+    statementsClient = new StatementsClient(jest.fn()) as jest.Mocked<StatementsClient>
     service = new ReviewService(statementsClient, incidentClient, authClientBuilder, offenderService, username =>
       Promise.resolve(`${username}-system-token`)
     )
@@ -47,22 +47,22 @@ describe('reviewService', () => {
 
   test('getStatements', async () => {
     authClient.getEmail.mockResolvedValueOnce({ verified: false }).mockResolvedValueOnce({ verified: true })
-    statementsClient.getStatementsForReviewer.mockReturnValue([{ id: 1 }, { id: 2 }])
+    statementsClient.getStatementsForReviewer.mockResolvedValue([{ id: 1 }, { id: 2 }])
 
-    const statements = await service.getStatements('token-1', 'report-1')
+    const statements = await service.getStatements('token-1', 1)
 
     expect(statements).toEqual([
       { id: 1, isVerified: false },
       { id: 2, isVerified: true },
     ])
-    expect(statementsClient.getStatementsForReviewer).toBeCalledWith('report-1')
+    expect(statementsClient.getStatementsForReviewer).toBeCalledWith(1)
   })
 
   describe('getStatement', () => {
     test('success', async () => {
-      statementsClient.getStatementForReviewer.mockReturnValue({ id: 2 })
+      statementsClient.getStatementForReviewer.mockResolvedValue({ id: 2 })
 
-      statementsClient.getAdditionalComments.mockReturnValue([
+      statementsClient.getAdditionalComments.mockResolvedValue([
         {
           id: 1,
           statementId: 1,
@@ -71,7 +71,7 @@ describe('reviewService', () => {
         },
       ])
 
-      const output = await service.getStatement('statement-1')
+      const output = await service.getStatement(1)
 
       expect(output).toEqual({
         id: 2,
@@ -85,32 +85,32 @@ describe('reviewService', () => {
         ],
       })
 
-      expect(statementsClient.getStatementForReviewer).toBeCalledWith('statement-1')
+      expect(statementsClient.getStatementForReviewer).toBeCalledWith(1)
     })
 
     test('failed as no statement', async () => {
       statementsClient.getStatementForReviewer.mockReturnValue(null)
 
-      await expect(service.getStatement('statement-1')).rejects.toThrow("Statement: 'statement-1' does not exist")
+      await expect(service.getStatement(1)).rejects.toThrow("Statement: '1' does not exist")
     })
   })
 
   describe('getReport', () => {
     test('it should call query on db', async () => {
       incidentClient.getReportForReviewer.mockResolvedValue({ id: 2 })
-      await service.getReport('report1')
+      await service.getReport(1)
       expect(incidentClient.getReportForReviewer).toBeCalledTimes(1)
-      expect(incidentClient.getReportForReviewer).toBeCalledWith('report1')
+      expect(incidentClient.getReportForReviewer).toBeCalledWith(1)
     })
 
     test('report not present', async () => {
       incidentClient.getReportForReviewer.mockReturnValue(null)
 
-      await expect(service.getReport('report1')).rejects.toThrow("Report: 'report1' does not exist")
+      await expect(service.getReport(1)).rejects.toThrow("Report: '1' does not exist")
     })
   })
 
-  describe('getReports', () => {
+  describe('getIncompletedReports', () => {
     const reportSummary = (id: number): ReportSummary => ({
       id,
       bookingId: id + 1,
@@ -129,18 +129,83 @@ describe('reviewService', () => {
       offenderNo: `offender-${id}`,
     })
 
-    test('it should filter on prisoner name', async () => {
-      const query = { prisonerName: 'OnER-2' }
+    test('retrieve and include offender names', async () => {
+      incidentClient.getIncompleteReportsForReviewer.mockResolvedValue([reportSummary(1), reportSummary(2)])
 
-      incidentClient.getCompletedReportsForReviewer.mockResolvedValue([reportSummary(1), reportSummary(2)])
       offenderService.getOffenderNames.mockResolvedValue({
         'offender-1': 'Prisoner prisoner-1',
         'offender-2': 'Prisoner prisoner-2',
       })
 
-      const result = await service.getCompletedReports('userName', 'agency-1', query)
-      expect(result).toEqual([incidentSummary(2)])
-      expect(incidentClient.getCompletedReportsForReviewer).toBeCalledWith('agency-1', query)
+      const result = await service.getIncompleteReports('userName', 'agency-1')
+      expect(result).toEqual([incidentSummary(1), incidentSummary(2)])
+      expect(incidentClient.getIncompleteReportsForReviewer).toBeCalledWith('agency-1')
+      expect(offenderService.getOffenderNames).toBeCalledWith('userName-system-token', ['offender-1', 'offender-2'])
+    })
+  })
+
+  describe('getCompletedReports', () => {
+    const reportSummary = (id: number): ReportSummary => ({
+      id,
+      bookingId: id + 1,
+      reporterName: `reporter-${id}`,
+      offenderNo: `offender-${id}`,
+      incidentDate: new Date(id),
+    })
+
+    const incidentSummary = (id: number): IncidentSummary => ({
+      id,
+      bookingId: id + 1,
+      incidentdate: new Date(id),
+      staffMemberName: `reporter-${id}`,
+      isOverdue: false,
+      offenderName: `Prisoner prisoner-${id}`,
+      offenderNo: `offender-${id}`,
+    })
+
+    test('when not filtering on prisoner name', async () => {
+      const query: ReportQuery = { prisonNumber: 'AA1234A' }
+
+      incidentClient.getCompletedReportsForReviewer.mockResolvedValue(
+        new PageResponse({ min: 1, max: 2, page: 1, totalCount: 2, totalPages: 1 }, [
+          reportSummary(1),
+          reportSummary(2),
+        ])
+      )
+      offenderService.getOffenderNames.mockResolvedValue({
+        'offender-1': 'Prisoner prisoner-1',
+        'offender-2': 'Prisoner prisoner-2',
+      })
+
+      const result = await service.getCompletedReports('userName', 'agency-1', query, 1)
+      expect(result).toEqual(
+        new PageResponse({ min: 1, max: 2, page: 1, totalCount: 2, totalPages: 1 }, [
+          incidentSummary(1),
+          incidentSummary(2),
+        ])
+      )
+      expect(incidentClient.getCompletedReportsForReviewer).toBeCalledWith('agency-1', query, 1)
+      expect(offenderService.getOffenderNames).toBeCalledWith('userName-system-token', ['offender-1', 'offender-2'])
+    })
+
+    test('it can filter on prisoner name', async () => {
+      const query = { prisonerName: 'OnER-2' }
+
+      incidentClient.getAllCompletedReportsForReviewer.mockResolvedValue([reportSummary(1), reportSummary(2)])
+
+      offenderService.getOffenderNames.mockResolvedValue({
+        'offender-1': 'Prisoner prisoner-1',
+        'offender-2': 'Prisoner prisoner-2',
+      })
+
+      const result = await service.getCompletedReports('userName', 'agency-1', query, 1)
+      expect(result).toEqual(
+        new PageResponse(
+          { min: 1, max: 1, page: 1, totalCount: 1, totalPages: 1, nextPage: null, previousPage: null },
+          [incidentSummary(2)]
+        )
+      )
+      expect(incidentClient.getAllCompletedReportsForReviewer).toBeCalledWith('agency-1', query)
       expect(offenderService.getOffenderNames).toBeCalledWith('userName-system-token', ['offender-1', 'offender-2'])
     })
   })

--- a/server/utils/page.test.ts
+++ b/server/utils/page.test.ts
@@ -1,4 +1,4 @@
-import { offsetAndLimitForPage, metaDataForPage, buildPageResponse } from './page'
+import { offsetAndLimitForPage, metaDataForPage, buildPageResponse, toPage } from './page'
 
 describe('limitAndOffsetForPage', () => {
   it('check values', () => {
@@ -129,6 +129,126 @@ describe('buildPageResponse', () => {
         totalPages: 1,
         nextPage: null,
         previousPage: null,
+      },
+    })
+  })
+})
+
+describe('toPage', () => {
+  it('empty response', () => {
+    expect(toPage(1, [])).toEqual({
+      items: [],
+      metaData: {
+        max: 0,
+        min: 0,
+        page: 1,
+        totalCount: 0,
+        totalPages: 0,
+      },
+    })
+  })
+
+  it('less than 1 page', () => {
+    expect(toPage(1, [1, 2], 3)).toEqual({
+      items: [1, 2],
+      metaData: {
+        min: 1,
+        max: 2,
+        page: 1,
+        totalCount: 2,
+        totalPages: 1,
+        nextPage: null,
+        previousPage: null,
+      },
+    })
+  })
+
+  it('full page', () => {
+    expect(toPage(1, [1, 2, 3], 3)).toEqual({
+      items: [1, 2, 3],
+      metaData: {
+        min: 1,
+        max: 3,
+        page: 1,
+        totalCount: 3,
+        totalPages: 1,
+        nextPage: null,
+        previousPage: null,
+      },
+    })
+  })
+
+  it('more than full page', () => {
+    expect(toPage(1, [1, 2, 3, 4], 3)).toEqual({
+      items: [1, 2, 3],
+      metaData: {
+        min: 1,
+        max: 3,
+        page: 1,
+        totalCount: 4,
+        totalPages: 2,
+        nextPage: 2,
+        previousPage: null,
+      },
+    })
+  })
+
+  it('second page', () => {
+    expect(toPage(2, [1, 2, 3, 4, 5], 3)).toEqual({
+      items: [4, 5],
+      metaData: {
+        min: 4,
+        max: 5,
+        page: 2,
+        totalCount: 5,
+        totalPages: 2,
+        nextPage: null,
+        previousPage: 1,
+      },
+    })
+  })
+
+  it('middle page', () => {
+    expect(toPage(2, [1, 2, 3, 4, 5, 6, 7, 8], 3)).toEqual({
+      items: [4, 5, 6],
+      metaData: {
+        min: 4,
+        max: 6,
+        page: 2,
+        totalCount: 8,
+        totalPages: 3,
+        nextPage: 3,
+        previousPage: 1,
+      },
+    })
+  })
+
+  it('last page', () => {
+    expect(toPage(3, [1, 2, 3, 4, 5, 6, 7, 8], 3)).toEqual({
+      items: [7, 8],
+      metaData: {
+        min: 7,
+        max: 8,
+        page: 3,
+        totalCount: 8,
+        totalPages: 3,
+        nextPage: null,
+        previousPage: 2,
+      },
+    })
+  })
+
+  it('last page full', () => {
+    expect(toPage(3, [1, 2, 3, 4, 5, 6, 7, 8, 9], 3)).toEqual({
+      items: [7, 8, 9],
+      metaData: {
+        min: 7,
+        max: 9,
+        page: 3,
+        totalCount: 9,
+        totalPages: 3,
+        nextPage: null,
+        previousPage: 2,
       },
     })
   })

--- a/server/utils/page.ts
+++ b/server/utils/page.ts
@@ -24,6 +24,11 @@ export class PageResponse<T> {
   }
 }
 
+export function toPage<T>(page: number, items: T[], pageSize: number = PAGE_SIZE): PageResponse<T> {
+  const metaData = metaDataForPage(page, items.length, pageSize)
+  return new PageResponse(metaData, items.slice(metaData.min - 1, metaData.max))
+}
+
 export type OffsetAndLimit = [number, number]
 
 export function offsetAndLimitForPage(page: number, pageSize: number = PAGE_SIZE): OffsetAndLimit {

--- a/server/views/pages/completed-incidents.html
+++ b/server/views/pages/completed-incidents.html
@@ -2,11 +2,16 @@
 {% from "govuk/components/button/macro.njk" import govukButton %} 
 {% from "govuk/components/table/macro.njk" import govukTable %} 
 {% from  "../macros.njk" import overdueBadge %}    
+{% from "moj/components/pagination/macro.njk" import mojPagination %}
 
 {% block tabContent %}
 <section class="govuk-tabs__panel">
   {% include "../partials/incidentSearchPanel.html" %}
-  
+
+  {% if pageData.totalPages > 1 %}
+    {{ mojPagination( pageData | toPagination ) }}
+  {% endif %} 
+
 {% if reports.length %}
 <table class="govuk-table reviewer-incidents" data-qa="incidents-complete">
 
@@ -55,5 +60,10 @@
 {% else %}
 <p class="govuk-body" data-qa="no-incidents-complete">There are no completed incidents</p>
 {% endif %}
+
+{% if pageData.totalPages > 1 %}
+{{ mojPagination( pageData | toPagination ) }}
+{% endif %} 
+
 </section>
 {% endblock %}


### PR DESCRIPTION
As we don't store prisoner names in the service, if people search by prisoner name then we have to load up all records that match the rest of the criteria, attached the names and then filter by prisoner name and page in memory. Otherwise we would end up with odd shaped pages

If not explicitly searching by prisoner name then we fallback to just doing a normal paginated search