### PR TITLE
DCS-583: User was previously able to input 23:59 minutes in current d…

### DIFF
--- a/server/config/forms/incidentDateValidation.ts
+++ b/server/config/forms/incidentDateValidation.ts
@@ -9,6 +9,7 @@ export enum ValidationError {
   isNot2Digits = 'isNot2Digits',
   isFuture = 'isFuture',
   invalid = 'invalid',
+  isNotPositiveNumber = 'isNotPositiveNumber',
 }
 
 export function dateValidation(date: string, helpers: joi.CustomHelpers) {
@@ -29,7 +30,7 @@ export function dateValidation(date: string, helpers: joi.CustomHelpers) {
 export function timeValidation(time: string, helpers: joi.CustomHelpers) {
   const fullDate = helpers.state.ancestors[0].value
 
-  if (fullDate && moment(fullDate).isBetween(moment.now(), moment().endOf('day'), 'minutes')) {
+  if (fullDate && moment(fullDate).isBetween(moment.now(), moment().endOf('day'), 'seconds')) {
     return helpers.error(ValidationError.isFuture)
   }
 
@@ -45,6 +46,10 @@ export function minuteValidation(minute: string, helpers: joi.CustomHelpers) {
 
   if (parsedMinutes === null) {
     return helpers.error(ValidationError.isNotNumber)
+  }
+
+  if (parsedMinutes < 0) {
+    return helpers.error(ValidationError.isNotPositiveNumber)
   }
 
   if (parsedMinutes >= 60) {
@@ -66,6 +71,10 @@ export function hourValidation(hour: string, helpers: joi.CustomHelpers) {
 
   if (parsedHours === null) {
     return helpers.error(ValidationError.isNotNumber)
+  }
+
+  if (parsedHours < 0) {
+    return helpers.error(ValidationError.isNotPositiveNumber)
   }
 
   if (parsedHours >= 24) {

--- a/server/config/forms/incidentDetailsForm.js
+++ b/server/config/forms/incidentDetailsForm.js
@@ -41,7 +41,7 @@ const requiredIncidentDate = joi
             [ValidationError.isNotNumber]: 'Enter hours using numbers only',
             [ValidationError.isTooLarge]: 'Enter an hour which is 23 or less',
             [ValidationError.isNot2Digits]: 'Enter the hours using 2 digits',
-            [ValidationError.isNotPositiveNumber]: 'Enter the hours using positive values only',
+            [ValidationError.isNotPositiveNumber]: 'Enter an hour which is 00 or more',
           }),
 
         minute: joi
@@ -52,7 +52,7 @@ const requiredIncidentDate = joi
             [ValidationError.isNotNumber]: 'Enter minutes using numbers only',
             [ValidationError.isTooLarge]: 'Enter the minutes using 59 or less',
             [ValidationError.isNot2Digits]: 'Enter the minutes using 2 digits',
-            [ValidationError.isNotPositiveNumber]: 'Enter the minutes using positive values only',
+            [ValidationError.isNotPositiveNumber]: 'Enter the minutes using 00 or more',
           }),
       })
       .custom(timeValidation)

--- a/server/config/forms/incidentDetailsForm.js
+++ b/server/config/forms/incidentDetailsForm.js
@@ -41,6 +41,7 @@ const requiredIncidentDate = joi
             [ValidationError.isNotNumber]: 'Enter hours using numbers only',
             [ValidationError.isTooLarge]: 'Enter an hour which is 23 or less',
             [ValidationError.isNot2Digits]: 'Enter the hours using 2 digits',
+            [ValidationError.isNotPositiveNumber]: 'Enter the hours using positive values only',
           }),
 
         minute: joi
@@ -51,6 +52,7 @@ const requiredIncidentDate = joi
             [ValidationError.isNotNumber]: 'Enter minutes using numbers only',
             [ValidationError.isTooLarge]: 'Enter the minutes using 59 or less',
             [ValidationError.isNot2Digits]: 'Enter the minutes using 2 digits',
+            [ValidationError.isNotPositiveNumber]: 'Enter the minutes using positive values only',
           }),
       })
       .custom(timeValidation)

--- a/server/config/forms/incidentDetailsValidation.test.js
+++ b/server/config/forms/incidentDetailsValidation.test.js
@@ -512,7 +512,7 @@ describe("'complete' validation", () => {
         expect(errors).toEqual([
           {
             href: '#incidentDate[time][hour]',
-            text: 'Enter the hours using positive values only',
+            text: 'Enter an hour which is 00 or more',
           },
         ])
 
@@ -674,7 +674,7 @@ describe("'complete' validation", () => {
         expect(errors).toEqual([
           {
             href: '#incidentDate[time][minute]',
-            text: 'Enter the minutes using positive values only',
+            text: 'Enter the minutes using 00 or more',
           },
         ])
 

--- a/server/config/forms/incidentDetailsValidation.test.js
+++ b/server/config/forms/incidentDetailsValidation.test.js
@@ -499,6 +499,37 @@ describe("'complete' validation", () => {
           witnesses: [{ name: 'User bob' }],
         })
       })
+      it('hours are a negative number', () => {
+        const input = {
+          ...validInput,
+          incidentDate: {
+            date: '15/01/2019',
+            time: { hour: '-11', minute: '45' },
+          },
+        }
+        const { errors, formResponse, extractedFields } = check(input)
+
+        expect(errors).toEqual([
+          {
+            href: '#incidentDate[time][hour]',
+            text: 'Enter the hours using positive values only',
+          },
+        ])
+
+        expect(extractedFields).toEqual({
+          incidentDate: {
+            date: '15/01/2019',
+            value: null,
+            time: { hour: '-11', minute: '45' },
+          },
+        })
+        expect(formResponse).toEqual({
+          locationId: -1,
+          plannedUseOfForce: true,
+          involvedStaff: [{ username: 'ITAG_USER' }],
+          witnesses: [{ name: 'User bob' }],
+        })
+      })
     })
 
     describe('minutes', () => {
@@ -620,6 +651,38 @@ describe("'complete' validation", () => {
             date: '15/01/2019',
             value: moment('2019-01-15T12:04:00.000Z').toDate(),
             time: { hour: '12', minute: '4' },
+          },
+        })
+        expect(formResponse).toEqual({
+          locationId: -1,
+          plannedUseOfForce: true,
+          involvedStaff: [{ username: 'ITAG_USER' }],
+          witnesses: [{ name: 'User bob' }],
+        })
+      })
+
+      it('minutes are a negative number', () => {
+        const input = {
+          ...validInput,
+          incidentDate: {
+            date: '15/01/2019',
+            time: { hour: '12', minute: '-04' },
+          },
+        }
+        const { errors, formResponse, extractedFields } = check(input)
+
+        expect(errors).toEqual([
+          {
+            href: '#incidentDate[time][minute]',
+            text: 'Enter the minutes using positive values only',
+          },
+        ])
+
+        expect(extractedFields).toEqual({
+          incidentDate: {
+            date: '15/01/2019',
+            value: null,
+            time: { hour: '12', minute: '-04' },
           },
         })
         expect(formResponse).toEqual({

--- a/server/config/forms/incidentDetailsValidation.test.js
+++ b/server/config/forms/incidentDetailsValidation.test.js
@@ -729,6 +729,40 @@ describe("'complete' validation", () => {
         })
       })
     })
+
+    it('time is last minute of current day', () => {
+      const endOfToday = moment({ hour: 23, minute: 59, seconds: 0, milliseconds: 0 })
+
+      const input = {
+        ...validInput,
+        incidentDate: {
+          date: endOfToday.format('DD/MM/YYYY'),
+          time: { hour: endOfToday.format('HH'), minute: endOfToday.format('mm') },
+        },
+      }
+      const { errors, formResponse, extractedFields } = check(input)
+
+      expect(errors).toEqual([
+        {
+          href: '#incidentDate[time]',
+          text: 'Enter a time which is not in the future',
+        },
+      ])
+
+      expect(extractedFields).toEqual({
+        incidentDate: {
+          date: endOfToday.format('DD/MM/YYYY'),
+          value: endOfToday.toDate(),
+          time: { hour: endOfToday.format('HH'), minute: endOfToday.format('mm') },
+        },
+      })
+      expect(formResponse).toEqual({
+        locationId: -1,
+        plannedUseOfForce: true,
+        involvedStaff: [{ username: 'ITAG_USER' }],
+        witnesses: [{ name: 'User bob' }],
+      })
+    })
   })
 
   describe('check optional staff role', () => {

--- a/server/config/forms/incidentDetailsValidation.test.js
+++ b/server/config/forms/incidentDetailsValidation.test.js
@@ -436,6 +436,38 @@ describe("'complete' validation", () => {
         })
       })
 
+      it('hour contains number and non-number', () => {
+        const input = {
+          ...validInput,
+          incidentDate: {
+            date: '15/01/2019',
+            time: { hour: '1a', minute: '45' },
+          },
+        }
+        const { errors, formResponse, extractedFields } = check(input)
+
+        expect(errors).toEqual([
+          {
+            href: '#incidentDate[time][hour]',
+            text: 'Enter hours using numbers only',
+          },
+        ])
+
+        expect(extractedFields).toEqual({
+          incidentDate: {
+            date: '15/01/2019',
+            value: null,
+            time: { hour: '1a', minute: '45' },
+          },
+        })
+        expect(formResponse).toEqual({
+          locationId: -1,
+          plannedUseOfForce: true,
+          involvedStaff: [{ username: 'ITAG_USER' }],
+          witnesses: [{ name: 'User bob' }],
+        })
+      })
+
       it('hours is too large', () => {
         const input = {
           ...validInput,
@@ -587,6 +619,38 @@ describe("'complete' validation", () => {
             date: '15/01/2019',
             value: null,
             time: { hour: '12', minute: 'aa' },
+          },
+        })
+        expect(formResponse).toEqual({
+          locationId: -1,
+          plannedUseOfForce: true,
+          involvedStaff: [{ username: 'ITAG_USER' }],
+          witnesses: [{ name: 'User bob' }],
+        })
+      })
+
+      it('minutes contains number and non-number', () => {
+        const input = {
+          ...validInput,
+          incidentDate: {
+            date: '15/01/2019',
+            time: { hour: '03', minute: '4y' },
+          },
+        }
+        const { errors, formResponse, extractedFields } = check(input)
+
+        expect(errors).toEqual([
+          {
+            href: '#incidentDate[time][minute]',
+            text: 'Enter minutes using numbers only',
+          },
+        ])
+
+        expect(extractedFields).toEqual({
+          incidentDate: {
+            date: '15/01/2019',
+            value: null,
+            time: { hour: '03', minute: '4y' },
           },
         })
         expect(formResponse).toEqual({

--- a/server/config/forms/sanitisers.js
+++ b/server/config/forms/sanitisers.js
@@ -1,4 +1,4 @@
-const toDate = require('../../utils/dateSanitiser')
+const { toInteger, toDate } = require('../../utils/dateSanitiser')
 const { isNilOrEmpty } = require('../../utils/utils')
 
 const isBlankObject = o => (isNilOrEmpty(o) ? true : Object.values(o).every(isNilOrEmpty))
@@ -23,10 +23,7 @@ module.exports = {
 
   trimmedString: val => (val ? val.trim() : null),
 
-  toInteger: val => {
-    const number = parseInt(val, 10)
-    return Number.isNaN(number) ? null : number
-  },
+  toInteger,
 
   toSmallInt: val => {
     const number = parseInt(val, 10)

--- a/server/routes/createReport.test.js
+++ b/server/routes/createReport.test.js
@@ -1,7 +1,7 @@
 const request = require('supertest')
 const { appWithAllRoutes, user } = require('./testutils/appSetup')
 const types = require('../config/types')
-const incidentDateSanitiser = require('../utils/dateSanitiser')
+const { toDate } = require('../utils/dateSanitiser')
 
 const reportService = {
   getCurrentDraft: jest.fn(),
@@ -114,7 +114,7 @@ describe('POST save and continue /section/form', () => {
           currentUser: user,
           bookingId: 1,
           formId: undefined,
-          incidentDate: incidentDateSanitiser({ date: '21/01/2019', time: { hour: '12', minute: '45' } }),
+          incidentDate: toDate({ date: '21/01/2019', time: { hour: '12', minute: '45' } }),
           formObject: {
             incidentDetails: {
               locationId: -1,
@@ -168,7 +168,7 @@ describe('POST save and return to tasklist', () => {
           currentUser: user,
           bookingId: 1,
           formId: undefined,
-          incidentDate: incidentDateSanitiser({ date: '21/01/2019', time: { hour: '12', minute: '45' } }),
+          incidentDate: toDate({ date: '21/01/2019', time: { hour: '12', minute: '45' } }),
           formObject: {
             incidentDetails: {
               locationId: -1,
@@ -205,7 +205,7 @@ describe('POST save and return to tasklist', () => {
           currentUser: user,
           bookingId: 1,
           formId: undefined,
-          incidentDate: incidentDateSanitiser({ date: '21/01/2019', time: { hour: '12', minute: '45' } }),
+          incidentDate: toDate({ date: '21/01/2019', time: { hour: '12', minute: '45' } }),
           formObject: {
             incidentDetails: {
               locationId: -1,
@@ -240,7 +240,7 @@ describe('POST save and return to tasklist', () => {
           currentUser: user,
           bookingId: 1,
           formId: undefined,
-          incidentDate: incidentDateSanitiser({ date: '21/01/2019', time: { hour: '12', minute: '45' } }),
+          incidentDate: toDate({ date: '21/01/2019', time: { hour: '12', minute: '45' } }),
           formObject: {
             incidentDetails: {
               involvedStaff: [{ username: 'USER_BOB' }],
@@ -290,7 +290,7 @@ describe('POST save and return to check-your-answers', () => {
           currentUser: user,
           bookingId: 1,
           formId: undefined,
-          incidentDate: incidentDateSanitiser({ date: '21/01/2019', time: { hour: '12', minute: '45' } }),
+          incidentDate: toDate({ date: '21/01/2019', time: { hour: '12', minute: '45' } }),
           formObject: {
             incidentDetails: {
               locationId: -1,

--- a/server/utils/dateSanitiser.test.js
+++ b/server/utils/dateSanitiser.test.js
@@ -1,7 +1,7 @@
 const moment = require('moment')
-const sanitiser = require('./dateSanitiser')
+const { toDate: sanitiser } = require('./dateSanitiser')
 
-describe('sanitiser', () => {
+describe('toDate', () => {
   const check = date => expect(sanitiser(date))
   const toDate = val => moment(val).toDate()
 
@@ -115,6 +115,13 @@ describe('sanitiser', () => {
         value: null,
       }))
 
+    test('hour is not a number', () =>
+      check({ date: '21/01/2019', time: { hour: '0x', minute: '45' } }).toEqual({
+        date: '21/01/2019',
+        time: { hour: '0x', minute: '45' },
+        value: null,
+      }))
+
     test('minutes greater than 59', () =>
       check({ date: '21/01/2019', time: { hour: '12', minute: '60' } }).toEqual({
         date: '21/01/2019',
@@ -126,6 +133,13 @@ describe('sanitiser', () => {
       check({ date: '21/01/2019', time: { hour: '12', minute: '-10' } }).toEqual({
         date: '21/01/2019',
         time: { hour: '12', minute: '-10' },
+        value: null,
+      }))
+
+    test('minute is not a number', () =>
+      check({ date: '21/01/2019', time: { hour: '01', minute: '4y' } }).toEqual({
+        date: '21/01/2019',
+        time: { hour: '01', minute: '4y' },
         value: null,
       }))
   })

--- a/server/utils/dateSanitiser.test.js
+++ b/server/utils/dateSanitiser.test.js
@@ -100,6 +100,34 @@ describe('sanitiser', () => {
         time: { hour: '0', minute: '0' },
         value: toDate('2019-01-21T00:00:00.000Z'),
       }))
+
+    test('hour is greater then 23', () =>
+      check({ date: '21/01/2019', time: { hour: '24', minute: '0' } }).toEqual({
+        date: '21/01/2019',
+        time: { hour: '24', minute: '0' },
+        value: null,
+      }))
+
+    test('hour is less then 0', () =>
+      check({ date: '21/01/2019', time: { hour: '-1', minute: '0' } }).toEqual({
+        date: '21/01/2019',
+        time: { hour: '-1', minute: '0' },
+        value: null,
+      }))
+
+    test('minutes greater than 24', () =>
+      check({ date: '21/01/2019', time: { hour: '24', minute: '0' } }).toEqual({
+        date: '21/01/2019',
+        time: { hour: '24', minute: '0' },
+        value: null,
+      }))
+
+    test('minutes less than 0', () =>
+      check({ date: '21/01/2019', time: { hour: '12', minute: '-10' } }).toEqual({
+        date: '21/01/2019',
+        time: { hour: '12', minute: '-10' },
+        value: null,
+      }))
   })
   test('date is zero', () =>
     check({ date: '00/01/2019', time: { hour: '01', minute: '02' } }).toEqual({

--- a/server/utils/dateSanitiser.test.js
+++ b/server/utils/dateSanitiser.test.js
@@ -115,10 +115,10 @@ describe('sanitiser', () => {
         value: null,
       }))
 
-    test('minutes greater than 24', () =>
-      check({ date: '21/01/2019', time: { hour: '24', minute: '0' } }).toEqual({
+    test('minutes greater than 59', () =>
+      check({ date: '21/01/2019', time: { hour: '12', minute: '60' } }).toEqual({
         date: '21/01/2019',
-        time: { hour: '24', minute: '0' },
+        time: { hour: '12', minute: '60' },
         value: null,
       }))
 

--- a/server/utils/dateSanitiser.ts
+++ b/server/utils/dateSanitiser.ts
@@ -3,7 +3,7 @@ import moment from 'moment'
 const validOrNull = val => (Number.isNaN(val) ? null : val)
 
 export const toInteger = (val?: string): number | null => {
-  return /[0-9]$/.test(val) ? validOrNull(parseInt(val, 10)) : null
+  return /^-*[0-9]*$/.test(val) ? validOrNull(parseInt(val, 10)) : null
 }
 
 const toDateTime = (date: moment.Moment, hours?: number, minutes?: number): moment.Moment | null => {

--- a/server/utils/dateSanitiser.ts
+++ b/server/utils/dateSanitiser.ts
@@ -2,9 +2,8 @@ import moment from 'moment'
 
 const validOrNull = val => (Number.isNaN(val) ? null : val)
 
-const toInteger = (val?: string): number | null => {
-  const number = parseInt(val, 10)
-  return validOrNull(number)
+export const toInteger = (val?: string): number | null => {
+  return /[0-9]$/.test(val) ? validOrNull(parseInt(val, 10)) : null
 }
 
 const toDateTime = (date: moment.Moment, hours?: number, minutes?: number): moment.Moment | null => {
@@ -27,7 +26,7 @@ type DateParameter = {
   }
 }
 
-export = function ({ date: dateVal = '', time: { hour = '', minute = '' } }: DateParameter) {
+export const toDate = ({ date: dateVal = '', time: { hour = '', minute = '' } }: DateParameter) => {
   const parsedDate = moment(dateVal.trim(), 'DD/MM/YYYY', true)
   const parsedHours = toInteger(hour)
   const parsedMinutes = toInteger(minute)

--- a/server/utils/dateSanitiser.ts
+++ b/server/utils/dateSanitiser.ts
@@ -8,8 +8,8 @@ const toInteger = (val?: string): number | null => {
 }
 
 const toDateTime = (date: moment.Moment, hours?: number, minutes?: number): moment.Moment | null => {
-  const validHours = hours != null && hours < 24
-  const validMinutes = minutes != null && minutes < 60
+  const validHours = hours != null && hours >= 0 && hours < 24
+  const validMinutes = minutes != null && minutes >= 0 && minutes < 60
 
   if (!date.isValid() || !validHours || !validMinutes) {
     return null


### PR DESCRIPTION
…ay without it failing future time validation.

This was because the timeValidation() function was working with minutes rather than seconds.
Function changed to use seconds.
The user could also previously enter negative numbers for hour and minutes. Validation added in minuteValidation() and hourValidation() to identify values less than zero.
dateSanitiser stoDateTime() updated to invalidate negative numbers