### PR TITLE
DCS-618: timeInput macro refactored

### DIFF
--- a/assets/sass/local.sass
+++ b/assets/sass/local.sass
@@ -295,6 +295,9 @@ dt.summary-list__key__wider
 .date-picker-container span
     width: 850px
 
+.date-picker-input-wide
+    width: 110%
+
 .ui-datepicker table
   background: govuk-colour("white") !important
 

--- a/server/views/formPages/incident/incidentDetails.html
+++ b/server/views/formPages/incident/incidentDetails.html
@@ -15,7 +15,7 @@
 {% block formItems %}
 <div class="govuk-body">
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds"> 
+    <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl mainHeading">{{ pageTitle }}</h1>
       <div class="govuk-!-margin-bottom-6">
         <p class="govuk-!-margin-bottom-1">
@@ -24,7 +24,10 @@
         </p>
       </div>
 
-      <!-- new date start -->
+      {% set isDateError = errors | isErrorPresent(['incidentDate[date]'])  %}
+      {% set isHourError = errors | isErrorPresent(['incidentDate[time][hour]', 'incidentDate[time]'])  %}
+      {% set isMinuteError = errors | isErrorPresent(['incidentDate[time][minute]', 'incidentDate[time]'])  %}
+
       <h3>When did the incident happen?</h3>
       <div>
         {{ datePicker({
@@ -32,46 +35,23 @@
           label: 'Date',
           name: 'incidentDate[date]',
           date: data.incidentDate.date,
-          classes: 'text-align-center',
+          classes: 'text-align-center ' + ('date-picker-input-wide' if isDateError ) ,
           attributes: {'disable-future-dates': 'true', 'date-format': 'dd/mm/yy'},
           errorMessage: errors | findErrors(['incidentDate[date]'])
-          }) 
+          })
         }}
       </div>
 
-        {% set isHourError = errors | isErrorPresent(['incidentDate[time][hour]', 'incidentDate[time]'])  %}
-        {% set isMinuteError = errors | isErrorPresent(['incidentDate[time][minute]', 'incidentDate[time]'])  %}
-        
         {{ timeInput({
-          id: "incidentDate[time]",
-          fieldset: {
-            legend: {
-              text: "Time",
-              isPageHeading: false
-            }
-          }, 
           errorMessage: errors | concatErrors(["incidentDate[time][hour]", "incidentDate[time][minute]", "incidentDate[time]"]),
-          items: [
-              {
-              label: 'Hours',
+          hour:  {
               value: data.incidentDate.hour,
-              name: "incidentDate[time][hour]",
-              classes: "text-align-center govuk-input--width-2 " + ('govuk-input--error' if isHourError),
-              attributes: { 'data-qa': 'incident-date-hour' },
-              id: "incidentDate[time][hour]"
+              classes: ('govuk-input--error' if isHourError)
             },
-              {
-              label: 'Minutes',
+          minutes:  {
               value: data.incidentDate.minute,
-              name: "incidentDate[time][minute]",
-              classes: "text-align-center govuk-input--width-2 " + ('govuk-input--error' if isMinuteError), 
-              attributes: { 'data-qa': 'incident-date-minute' },
-              id: "incidentDate[time][minute]"
+              classes: ('govuk-input--error' if isMinuteError)
               }
-          ],
-          hint: {
-            text: "Use the 24 hour clock. For example, 09 08 or 17 32"
-          }
         }) }}
         <hr>
     </div>
@@ -82,12 +62,12 @@
       <span class="govuk-label--s">Prison:&nbsp;</span>
       <span data-qa="prison" id='prison'>
         {{ data.prison.description }} &nbsp;
-        {{ 
+        {{
           submitLink({
-            label: 'Change<span class="govuk-visually-hidden"> prison </span>', 
-            qa: 'change-prison-link', 
+            label: 'Change<span class="govuk-visually-hidden"> prison </span>',
+            qa: 'change-prison-link',
             value: 'save-and-change-prison'
-          }) 
+          })
         }}
       </span>
     </div>

--- a/server/views/formPages/incident/incidentDetails.html
+++ b/server/views/formPages/incident/incidentDetails.html
@@ -8,7 +8,7 @@
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/error-message/macro.njk" import govukErrorMessage %}
 {% from "../../partials/datePicker.njk" import datePicker %}
-{% from "../timeMacro.njk"  import  timeInput %}
+{% from "../incidentTimeMacro.njk"  import incidentTime %}
 {% set pageTitle = 'Incident details' %}
 {% set showCancelEditButton = data.locationId %}
 
@@ -42,13 +42,17 @@
         }}
       </div>
 
-        {{ timeInput({
+        {{ incidentTime({
           errorMessage: errors | concatErrors(["incidentDate[time][hour]", "incidentDate[time][minute]", "incidentDate[time]"]),
           hour:  {
+              name: 'incidentDate[time][hour]',
+              id: 'incidentDate[time][hour]',
               value: data.incidentDate.hour,
               classes: ('govuk-input--error' if isHourError)
             },
           minutes:  {
+              name: 'incidentDate[time][minute]',
+              id: 'incidentDate[time][minute]',
               value: data.incidentDate.minute,
               classes: ('govuk-input--error' if isMinuteError)
               }

--- a/server/views/formPages/incidentTimeMacro.njk
+++ b/server/views/formPages/incidentTimeMacro.njk
@@ -4,7 +4,7 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
 
-{% macro timeInput(params) %}
+{% macro incidentTime(params) %}
 
 <div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error {% endif %}">
     {% call govukFieldset({
@@ -38,9 +38,9 @@
                 {{
                 govukInput({
                     label: { text: 'Hours', classes: 'govuk-date-input__label' },
-                    id: 'incidentDate[time][hour]',
+                    id: params.hour.id,
                     classes: 'govuk-date-input__input text-align-center govuk-input--width-2 ' + params.hour.classes,
-                    name: 'incidentDate[time][hour]',
+                    name: params.hour.name,
                     value: params.hour.value,
                     attributes: { 'data-qa': 'incident-date-hour' }
                 })
@@ -50,9 +50,9 @@
                 {{
                 govukInput({
                     label: { text: 'Minutes', classes: 'govuk-date-input__label' },
-                    id: 'incidentDate[time][minute]',
+                    id: params.minutes.id,
                     classes: 'govuk-date-input__input text-align-center govuk-input--width-2 ' + params.minutes.classes,
-                    name: 'incidentDate[time][minute]',
+                    name: params.minutes.name,
                     value: params.minutes.value,
                     attributes: { 'data-qa': 'incident-date-minute' }
                 })

--- a/server/views/formPages/timeMacro.njk
+++ b/server/views/formPages/timeMacro.njk
@@ -6,80 +6,61 @@
 
 {% macro timeInput(params) %}
 
-    {#- a record of other elements that we need to associate with the input using
-    aria-describedby – for example hints or error messages -#}
-    {% set describedBy = params.fieldset.describedBy if params.fieldset.describedBy else "" %}
-
-    {% set dateInputItems = params.items %}
-    
-    {#- Capture the HTML so we can optionally nest it in a fieldset -#}
-    {% set innerHtml %}
-    {% if params.hint %}
-    {% set hintId = params.id + "-hint" %}
-    {% set describedBy = describedBy + " " + hintId if describedBy else hintId %}
-    {{ govukHint({
-        id: hintId,
-        classes: params.hint.classes,
-        attributes: params.hint.attributes,
-        html: params.hint.html,
-        text: params.hint.text
-    }) | indent(2) | trim }}
-    {% endif %}
-    {% if params.errorMessage %}
-    {% set errorId = params.id + "-error" %}
-    {% set describedBy = describedBy + " " + errorId if describedBy else errorId %}
-    {{ govukErrorMessage({
-        id: errorId,
-        classes: params.errorMessage.classes,
-        attributes: params.errorMessage.attributes,
-        html: params.errorMessage.html,
-        text: params.errorMessage.text,
-        visuallyHiddenText: params.errorMessage.visuallyHiddenText
-    }) | indent(2) | trim }}
-    {% endif %}
-    <div class="govuk-date-input {%- if params.classes %} {{ params.classes }}{% endif %}"
-        {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}
-        {%- if params.id %} id="{{ params.id }}"{% endif %}>
-        {% for item in dateInputItems %}
-        <div class="govuk-date-input__item">
-        {{ govukInput({
-            label: {
-            text: item.label if item.label else item.name | capitalize,
-            classes: "govuk-date-input__label"
-            },
-            id: item.id if item.id else (params.id + "-" + item.name),
-            classes: "govuk-date-input__input " + (item.classes if item.classes),
-            name: (params.namePrefix + "-" + item.name) if params.namePrefix else item.name,
-            value: item.value,
-            type: "text",
-            inputmode: "numeric",
-            autocomplete: item.autocomplete,
-            pattern: item.pattern if item.pattern else "[0-9]*",
-            attributes: item.attributes
-        }) | indent(6) | trim }}
-        </div>
-    {% endfor %}
-    </div>
-    {% endset %}
-
-    <div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}">
-    {% if params.fieldset %}
-    {#- We override the fieldset's role to 'group' because otherwise JAWS does not
-        announce the description for a fieldset comprised of text inputs, but
-        adding the role to the fieldset always makes the output overly verbose for
-        radio buttons or checkboxes. -#}
+<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error {% endif %}">
     {% call govukFieldset({
-        describedBy: describedBy,
-        classes: params.fieldset.classes,
-        role: 'group',
-        attributes: params.fieldset.attributes,
-        legend: params.fieldset.legend
-    }) %}
-    {{ innerHtml | trim | safe }}
-    {% endcall %}
-    {% else %}
-    {{ innerHtml | trim | safe }}
+            role: 'group',
+            legend: {
+                text: "Time",
+                isPageHeading: false
+            }
+        }) 
+    %}
+
+    {{
+    govukHint({
+        id: 'incidentDate[time]-hint',
+        text: 'Use the 24 hour clock. For example, 09 08 or 17 32'
+        })
+    }}
+
+    {% if params.errorMessage %}
+        {{
+        govukErrorMessage({
+        html: params.errorMessage.html,
+        text: params.errorMessage.text
+        })
+        }}
     {% endif %}
+
+    <div class="govuk-date-input">
+        <div class="govuk-date-input__item flex-container">
+            <div class="govuk-!-margin-right-4">
+                {{
+                govukInput({
+                    label: { text: 'Hours', classes: 'govuk-date-input__label' },
+                    id: 'incidentDate[time][hour]',
+                    classes: 'govuk-date-input__input text-align-center govuk-input--width-2 ' + params.hour.classes,
+                    name: 'incidentDate[time][hour]',
+                    value: params.hour.value,
+                    attributes: { 'data-qa': 'incident-date-hour' }
+                })
+                }}
+            </div>
+            <div>
+                {{
+                govukInput({
+                    label: { text: 'Minutes', classes: 'govuk-date-input__label' },
+                    id: 'incidentDate[time][minute]',
+                    classes: 'govuk-date-input__input text-align-center govuk-input--width-2 ' + params.minutes.classes,
+                    name: 'incidentDate[time][minute]',
+                    value: params.minutes.value,
+                    attributes: { 'data-qa': 'incident-date-minute' }
+                })
+                }}
+            </div>
+        </div>
     </div>
+    {% endcall %}
+</div>
 
 {% endmacro %}


### PR DESCRIPTION
The macro has been trimmed down to remove any unused elements. The incidentsDetails.html file uses this macro so that has been updated to pass in only the dynamic content (value and error classes). All the other classes and attributes for the hour and minute has been hard coded into the macro.
Have added a new class to widen the date input field because when there is an error in the date, the red errors border covers some of the field content.
Screen shot of errors below
<bkr>
<img width="1360" alt="dcs 618" src="https://user-images.githubusercontent.com/50441412/92219801-f453f400-ee92-11ea-944e-eef3bb7d7cfc.png">
</bkr>

