### PR TITLE
DCS-403 Removing missing user check

### DIFF
--- a/server/config/forms/incidentDetailsForm.js
+++ b/server/config/forms/incidentDetailsForm.js
@@ -70,6 +70,7 @@ const optionalInvolvedStaff = joi
           .uppercase()
           .alter(optionalForPartialValidation),
       })
+      .unknown(true)
       .id('username')
   )
   .ruleset.unique(caseInsensitiveComparator('username'))

--- a/server/config/forms/incidentDetailsForm.js
+++ b/server/config/forms/incidentDetailsForm.js
@@ -1,6 +1,6 @@
-const { joi, asMeta, validations, usernamePattern, namePattern, caseInsensitiveComparator } = require('./validations')
+const { joi, validations, usernamePattern, namePattern, caseInsensitiveComparator } = require('./validations')
 const { EXTRACTED } = require('../fieldType')
-const { toDate, removeEmptyObjects, toBoolean } = require('./sanitisers')
+const { toDate, removeEmptyObjects } = require('./sanitisers')
 const { buildValidationSpec } = require('../../services/validation')
 const {
   ValidationError,
@@ -12,10 +12,7 @@ const {
 
 const {
   optionalForPartialValidation,
-  requiredNumber,
   requiredIntegerMsg,
-  requiredString,
-  optionalString,
   requiredPatternMsg,
   requiredBooleanMsg,
   arrayOfObjects,
@@ -99,20 +96,8 @@ const transientSchema = joi.object({
     .message("Witness '{#value.name}' has already been added - remove this witness"),
 })
 
-const persistentSchema = transientSchema.fork('involvedStaff.username', schema =>
-  schema.append({
-    name: requiredString,
-    email: optionalString,
-    staffId: requiredNumber,
-    missing: joi.boolean().valid(false).meta(asMeta(toBoolean)),
-    verified: joi.boolean().meta(asMeta(toBoolean)),
-  })
-)
 module.exports = {
   optionalInvolvedStaff: transientSchema.extract('involvedStaff'),
-  optionalInvolvedStaffWhenPersisted: persistentSchema.extract('involvedStaff'),
-
   complete: buildValidationSpec(transientSchema),
-  persistent: buildValidationSpec(persistentSchema),
   partial: buildValidationSpec(transientSchema.tailor('partial')),
 }

--- a/server/config/forms/incidentDetailsValidation.test.js
+++ b/server/config/forms/incidentDetailsValidation.test.js
@@ -828,10 +828,11 @@ describe("'complete' validation", () => {
       expect(isValid(optionalInvolvedStaff, [{ username: 'Bob' }])).toEqual(true)
       expect(isValid(optionalInvolvedStaff, [{ username: 'VQO24O' }])).toEqual(true)
       expect(isValid(optionalInvolvedStaff, [])).toEqual(true)
+      expect(isValid(optionalInvolvedStaff, [{ username: 'Bob', staffId: 1234 }])).toEqual(true)
     })
 
     test('invalid (optionalInvolvedStaff)', () => {
-      expect(isValid(optionalInvolvedStaff, [{ username: 'Bob', age: 29 }])).toEqual(false)
+      expect(isValid(optionalInvolvedStaff, [{ username: 1 }])).toEqual(false)
       expect(isValid(optionalInvolvedStaff, true)).toEqual(false)
       expect(isValid(optionalInvolvedStaff, [{ username: '' }])).toEqual(false)
       expect(isValid(optionalInvolvedStaff, [{ bob: 'Bob' }])).toEqual(false)

--- a/server/config/forms/incidentDetailsValidation.test.js
+++ b/server/config/forms/incidentDetailsValidation.test.js
@@ -1,11 +1,5 @@
 const moment = require('moment')
-const {
-  complete,
-  partial,
-  persistent,
-  optionalInvolvedStaff,
-  optionalInvolvedStaffWhenPersisted,
-} = require('./incidentDetailsForm')
+const { complete, partial, optionalInvolvedStaff } = require('./incidentDetailsForm')
 const { processInput } = require('../../services/validation')
 const { isValid } = require('../../services/validation/fieldValidation')
 
@@ -842,25 +836,8 @@ describe("'complete' validation", () => {
       expect(isValid(optionalInvolvedStaff, [{ username: '' }])).toEqual(false)
       expect(isValid(optionalInvolvedStaff, [{ bob: 'Bob' }])).toEqual(false)
     })
-
-    test('Check valid (optionalInvolvedStaffWhenPersisted)', () => {
-      expect(
-        isValid(optionalInvolvedStaffWhenPersisted, [
-          { username: 'VQO24O', name: 'Bob', email: 'a@bcom', staffId: 123 },
-        ])
-      ).toEqual(true)
-      expect(isValid(optionalInvolvedStaffWhenPersisted, [])).toEqual(true)
-    })
-
-    test('invalid (optionalInvolvedStaffWhenPersisted)', () => {
-      expect(isValid(optionalInvolvedStaffWhenPersisted, [{ username: 'Bob', age: 29 }])).toEqual(false)
-      expect(isValid(optionalInvolvedStaffWhenPersisted, true)).toEqual(false)
-      expect(isValid(optionalInvolvedStaffWhenPersisted, [{ username: '' }])).toEqual(false)
-      expect(isValid(optionalInvolvedStaffWhenPersisted, [{ bob: 'Bob' }])).toEqual(false)
-    })
   })
 })
-
 describe("'partial' validation", () => {
   const check = buildCheck(partial)
   describe('Incident details page - overall', () => {
@@ -945,78 +922,6 @@ describe("'partial' validation", () => {
 
       expect(errors).toEqual([])
       expect(formResponse).toEqual({})
-    })
-  })
-})
-
-describe("'persistent' validation", () => {
-  const check = buildCheck(persistent)
-
-  beforeEach(() => {
-    validInput = {
-      incidentDate: {
-        date: '15/01/2019',
-        time: { hour: '12', minute: '45' },
-      },
-      locationId: -1,
-      plannedUseOfForce: 'true',
-      involvedStaff: [
-        {
-          name: 'Licence Batchloader',
-          missing: 'false',
-          staffId: 6,
-          username: 'NOMIS_BATCHLOAD',
-          verified: 'true',
-        },
-      ],
-      witnesses: [{ name: 'User bob' }, { name: '' }],
-    }
-  })
-
-  describe('Incident details page - persistent', () => {
-    it('Should return no validation error messages if no invalid data', () => {
-      const { errors } = check(validInput)
-
-      expect(errors).toEqual([])
-    })
-
-    it('unverified users are valid', () => {
-      const { errors } = check({
-        ...validInput,
-        involvedStaff: [
-          {
-            name: 'Licence Batchloader',
-            missing: 'false',
-            staffId: 6,
-            username: 'NOMIS_BATCHLOAD',
-            verified: 'false',
-          },
-        ],
-      })
-
-      expect(errors).toEqual([])
-    })
-
-    it('missing users are invalid', () => {
-      const { errors } = check({
-        ...validInput,
-        involvedStaff: [
-          {
-            name: 'Licence Batchloader',
-            missing: 'true',
-            staffId: 6,
-            username: 'NOMIS_BATCHLOAD',
-            verified: 'false',
-          },
-        ],
-      })
-
-      expect(errors).toEqual([
-        {
-          href: '#involvedStaff[0][missing]',
-          text: '"involvedStaff[0].missing" must be [false]',
-        },
-      ])
     })
   })
 })

--- a/server/config/incident.js
+++ b/server/config/incident.js
@@ -16,12 +16,6 @@ module.exports = {
     relocationAndInjuries: relocationAndInjuriesForm.complete,
     evidence: evidenceForm.complete,
   },
-  persistent: {
-    incidentDetails: incidentDetails.persistent,
-    useOfForceDetails: useOfForceDetailsForm.complete,
-    relocationAndInjuries: relocationAndInjuriesForm.complete,
-    evidence: evidenceForm.complete,
-  },
   partial: {
     incidentDetails: incidentDetails.partial,
     useOfForceDetails: useOfForceDetailsForm.partial,

--- a/server/index.js
+++ b/server/index.js
@@ -42,13 +42,7 @@ const eventPublisher = require('./services/eventPublisher')(buildAppInsightsClie
 
 const heatmapBuilder = createHeatmapBuilder(elite2ClientBuilder)
 const userService = new UserService(elite2ClientBuilder, authClientBuilder)
-const involvedStaffService = new InvolvedStaffService(
-  incidentClient,
-  statementsClient,
-  userService,
-  db.inTransaction,
-  db.query
-)
+const involvedStaffService = new InvolvedStaffService(incidentClient, statementsClient, userService, db.inTransaction)
 const notificationService = notificationServiceFactory(eventPublisher)
 const offenderService = new OffenderService(elite2ClientBuilder)
 const reportService = new ReportService(incidentClient, offenderService, systemToken)

--- a/server/index.js
+++ b/server/index.js
@@ -3,7 +3,7 @@ import PrisonerSearchClient from './data/prisonerSearchClient'
 import IncidentClient from './data/incidentClient'
 import StatementsClient from './data/statementsClient'
 import OffenderService from './services/offenderService'
-import createReportingService from './services/reportingService'
+import ReportingService from './services/reportingService'
 import PrisonSearchService from './services/prisonerSearchService'
 
 import ReportService from './services/report/reportService'
@@ -66,7 +66,7 @@ const reviewService = new ReviewService(
   offenderService,
   systemToken
 )
-const reportingService = createReportingService(reportingClient, offenderService, heatmapBuilder)
+const reportingService = new ReportingService(reportingClient, offenderService, heatmapBuilder)
 const prisonerSearchService = new PrisonSearchService(PrisonerSearchClient, elite2ClientBuilder, systemToken)
 const locationService = new LocationService(elite2ClientBuilder)
 const reportDetailBuilder = new ReportDetailBuilder(involvedStaffService, locationService, offenderService, systemToken)

--- a/server/routes/checkYourAnswers.js
+++ b/server/routes/checkYourAnswers.js
@@ -37,6 +37,9 @@ module.exports = function CheckAnswerRoutes({
         form.incidentDetails.locationId
       )
 
+      // TODO remove once all missing users are removed and add to list pattern has been implemented
+      await involvedStaffService.removeMissingDraftInvolvedStaff(res.locals.user.username, id)
+
       const draftInvolvedStaff = await involvedStaffService.getDraftInvolvedStaff(id)
 
       const involvedStaff = [

--- a/server/routes/checkYourAnswers.test.js
+++ b/server/routes/checkYourAnswers.test.js
@@ -14,6 +14,7 @@ const offenderService = {
 
 const involvedStaffService = {
   getDraftInvolvedStaff: () => [],
+  removeMissingDraftInvolvedStaff: jest.fn(),
 }
 
 const locationService = {
@@ -25,7 +26,7 @@ let app
 
 beforeEach(() => {
   app = appWithAllRoutes({ draftReportService, offenderService, involvedStaffService, locationService })
-  draftReportService.getCurrentDraft.mockResolvedValue({ form: { incidentDetails: {} } })
+  draftReportService.getCurrentDraft.mockResolvedValue({ id: 1, form: { incidentDetails: {} } })
 
   offenderService.getOffenderDetails.mockResolvedValue({})
   locationService.getLocation.mockResolvedValue({})
@@ -43,6 +44,7 @@ describe('GET /check-your-answers', () => {
       .expect(res => {
         expect(res.text).toContain('Check your answers')
         expect(offenderService.getOffenderDetails).toHaveBeenCalledWith('user1-system-token', -35)
+        expect(involvedStaffService.removeMissingDraftInvolvedStaff).toBeCalledWith('user1', 1)
       })
   })
 

--- a/server/routes/createReport.ts
+++ b/server/routes/createReport.ts
@@ -109,4 +109,3 @@ export default class CreateReport {
     return res.redirect(`/report/${bookingId}/check-your-answers`)
   }
 }
-

--- a/server/routes/createReport.ts
+++ b/server/routes/createReport.ts
@@ -109,3 +109,4 @@ export default class CreateReport {
     return res.redirect(`/report/${bookingId}/check-your-answers`)
   }
 }
+

--- a/server/routes/incidentDetails.ts
+++ b/server/routes/incidentDetails.ts
@@ -1,5 +1,5 @@
 import moment from 'moment'
-import { RequestHandler } from 'express'
+import { Request, RequestHandler } from 'express'
 import { isNilOrEmpty, firstItem } from '../utils/utils'
 import types from '../config/types'
 import { processInput, mergeIntoPayload } from '../services/validation'

--- a/server/routes/incidentDetails.ts
+++ b/server/routes/incidentDetails.ts
@@ -68,7 +68,7 @@ export default class IncidentDetailsRoutes {
     return verifiedInvolvedStaff
   }
 
-  private getSubmitRedirectLocation = (req, payloadFields, form, bookingId, editMode, submitType) => {
+  private getSubmitRedirectLocation = (req, payloadFields, bookingId, editMode, submitType) => {
     if (submitType === SubmitType.SAVE_AND_CHANGE_PRISON) {
       return editMode ? `/report/${bookingId}/edit-change-prison` : `/report/${bookingId}/change-prison`
     }
@@ -189,7 +189,7 @@ export default class IncidentDetailsRoutes {
       })
     }
 
-    const location = this.getSubmitRedirectLocation(req, formPayload, formName, bookingId, editMode, submitType)
+    const location = this.getSubmitRedirectLocation(req, formPayload, bookingId, editMode, submitType)
     return res.redirect(location)
   }
 

--- a/server/services/involvedStaffService.ts
+++ b/server/services/involvedStaffService.ts
@@ -3,7 +3,7 @@ import logger from '../../log'
 import { ReportStatus } from '../config/types'
 import IncidentClient from '../data/incidentClient'
 import StatementsClient from '../data/statementsClient'
-import { User, GetUsersResults } from '../types/uof'
+import { GetUsersResults, LoggedInUser } from '../types/uof'
 import { InTransaction, QueryPerformer } from '../data/dataAccess/db'
 import UserService from './userService'
 
@@ -66,7 +66,7 @@ export class InvolvedStaffService {
     return this.userService.getUsers(token, usernames)
   }
 
-  private getStaffRequiringStatements = async (currentUser: User, addedStaff) => {
+  private getStaffRequiringStatements = async (currentUser: LoggedInUser, addedStaff) => {
     const userAlreadyAdded = addedStaff.find(user => currentUser.username === user.username)
     if (userAlreadyAdded) {
       return addedStaff
@@ -86,7 +86,7 @@ export class InvolvedStaffService {
     reportId: number,
     reportSubmittedDate: Moment,
     overdueDate: Moment,
-    currentUser: User,
+    currentUser: LoggedInUser,
     client: QueryPerformer
   ) {
     const involvedStaff = await this.getDraftInvolvedStaff(reportId)

--- a/server/services/involvedStaffService.ts
+++ b/server/services/involvedStaffService.ts
@@ -19,8 +19,7 @@ export class InvolvedStaffService {
     private readonly incidentClient: IncidentClient,
     private readonly statementsClient: StatementsClient,
     private readonly userService: UserService,
-    private readonly inTransaction: InTransaction,
-    private readonly queryPerformer: QueryPerformer
+    private readonly inTransaction: InTransaction
   ) {}
 
   public getInvolvedStaff(reportId: number): Promise<any[]> {
@@ -31,7 +30,7 @@ export class InvolvedStaffService {
     return this.incidentClient.getDraftInvolvedStaff(reportId)
   }
 
-  public removeMissingDraftInvolvedStaff = async (userId: string, bookingId: number) => {
+  public async removeMissingDraftInvolvedStaff(userId: string, bookingId: number) {
     const { id, form = {} } = await this.incidentClient.getCurrentDraftReport(userId, bookingId)
 
     const { incidentDetails = {} } = form
@@ -45,7 +44,7 @@ export class InvolvedStaffService {
     await this.incidentClient.updateDraftReport(id, null, updatedFormObject)
   }
 
-  public loadInvolvedStaff = async (reportId: number, statementId: number) => {
+  public async loadInvolvedStaff(reportId: number, statementId: number) {
     const involvedStaff = await this.incidentClient.getInvolvedStaff(reportId)
     const found = involvedStaff.find(staff => staff.statementId === statementId)
     if (!found) {
@@ -54,7 +53,7 @@ export class InvolvedStaffService {
     return found
   }
 
-  public loadInvolvedStaffByUsername = async (reportId: number, username: string) => {
+  public async loadInvolvedStaffByUsername(reportId: number, username: string) {
     const involvedStaff = await this.incidentClient.getInvolvedStaff(reportId)
     const found = involvedStaff.find(staff => staff.userId === username)
     if (!found) {
@@ -67,7 +66,7 @@ export class InvolvedStaffService {
     return this.userService.getUsers(token, usernames)
   }
 
-  private getStaffRequiringStatements = async (currentUser, addedStaff) => {
+  private getStaffRequiringStatements = async (currentUser: User, addedStaff) => {
     const userAlreadyAdded = addedStaff.find(user => currentUser.username === user.username)
     if (userAlreadyAdded) {
       return addedStaff
@@ -112,7 +111,7 @@ export class InvolvedStaffService {
     return staff.map(staffMember => ({ ...staffMember, statementId: userIdsToStatementIds[staffMember.userId] }))
   }
 
-  addInvolvedStaff = async (token, reportId, username) => {
+  public async addInvolvedStaff(token: string, reportId: number, username: string): Promise<AddStaffResult> {
     logger.info(`Adding involved staff with username: ${username} to report: '${reportId}'`)
 
     const [foundUser] = await this.userService.getUsers(token, [username])
@@ -156,7 +155,7 @@ export class InvolvedStaffService {
     })
   }
 
-  public removeInvolvedStaff = async (reportId, statementId) => {
+  public removeInvolvedStaff = async (reportId: number, statementId: number): Promise<void> => {
     logger.info(`Removing statement: ${statementId} from report: ${reportId}`)
 
     await this.inTransaction(async client => {

--- a/server/services/report/draftReportService.ts
+++ b/server/services/report/draftReportService.ts
@@ -1,7 +1,7 @@
 import moment from 'moment'
 import type IncidentClient from '../../data/incidentClient'
 import type SubmitDraftReportService from './submitDraftReportService'
-import type { User } from '../../types/uof'
+import type { LoggedInUser, User } from '../../types/uof'
 import { check as getReportStatus } from './reportStatusChecker'
 import UpdateDraftReportService, { UpdateParams } from './updateDraftReportService'
 import { DraftReport, NoDraftReport } from '../../data/incidentClientTypes'
@@ -36,7 +36,7 @@ export default class DraftReportService {
   }
 
   public submit(
-    currentUser: User,
+    currentUser: LoggedInUser,
     bookingId: number,
     now: () => moment.Moment = () => moment()
   ): Promise<number | false> {

--- a/server/services/report/reportStatusChecker.js
+++ b/server/services/report/reportStatusChecker.js
@@ -1,4 +1,4 @@
-const { persistent } = require('../../config/incident')
+const { full } = require('../../config/incident')
 const { isValid } = require('../validation')
 
 const SectionStatus = Object.freeze({
@@ -18,8 +18,8 @@ const getStatus = (validationSpec, sectionValues) => {
 module.exports = {
   SectionStatus,
   check: report => {
-    const result = Object.keys(persistent).reduce(
-      (previous, key) => ({ ...previous, [key]: getStatus(persistent[key], report[key]) }),
+    const result = Object.keys(full).reduce(
+      (previous, key) => ({ ...previous, [key]: getStatus(full[key], report[key]) }),
       {}
     )
 

--- a/server/services/report/reportStatusChecker.test.js
+++ b/server/services/report/reportStatusChecker.test.js
@@ -9,10 +9,6 @@ describe('statusCheck', () => {
       },
       witnesses: [{ name: 'BOB BARRY' }, { name: 'JAMES JOHN' }],
       locationId: -25,
-      involvedStaff: [
-        { name: 'Itag User', email: 'itag_user@digital.justice.gov.uk', staffId: 1, username: 'ITAG_USER' },
-        { name: 'Licence Case Admin', email: 'ca_user@digital.justice.gov.uk', staffId: 3, username: 'CA_USER' },
-      ],
       plannedUseOfForce: true,
     },
     useOfForceDetails: {
@@ -109,28 +105,6 @@ describe('statusCheck', () => {
       complete: false,
       incidentDetails: SectionStatus.COMPLETE,
       useOfForceDetails: SectionStatus.INCOMPLETE,
-      relocationAndInjuries: SectionStatus.COMPLETE,
-      evidence: SectionStatus.COMPLETE,
-    })
-  })
-
-  test('invalid incident details', async () => {
-    const invalidReport = {
-      ...validReport,
-      incidentDetails: {
-        witnesses: [{ name: 'BOB BARRY' }, { name: 'JAMES JOHN' }],
-        locationId: -25,
-        involvedStaff: [{ username: 'ITAG_USER' }, { username: 'CA_USER' }],
-        plannedUseOfForce: true,
-      },
-    }
-
-    const output = check(invalidReport)
-
-    expect(output).toEqual({
-      complete: false,
-      incidentDetails: SectionStatus.INCOMPLETE,
-      useOfForceDetails: SectionStatus.COMPLETE,
       relocationAndInjuries: SectionStatus.COMPLETE,
       evidence: SectionStatus.COMPLETE,
     })

--- a/server/services/report/submitDraftReportService.test.ts
+++ b/server/services/report/submitDraftReportService.test.ts
@@ -2,7 +2,7 @@ import moment from 'moment'
 import IncidentClient from '../../data/incidentClient'
 import SubmitDraftReportService from './submitDraftReportService'
 import { InvolvedStaffService } from '../involvedStaffService'
-import { User } from '../../types/uof'
+import { LoggedInUser, User } from '../../types/uof'
 
 jest.mock('../../data/incidentClient')
 jest.mock('../offenderService')
@@ -11,7 +11,6 @@ jest.mock('../involvedStaffService')
 const incidentClient = new IncidentClient(jest.fn as any, jest.fn() as any) as jest.Mocked<IncidentClient>
 
 const involvedStaffService = new InvolvedStaffService(
-  jest.fn as any,
   jest.fn as any,
   jest.fn as any,
   jest.fn as any,
@@ -29,7 +28,7 @@ const elite2Client = {
   getOffenderDetails: jest.fn(),
 }
 
-const currentUser = { username: 'user1', displayName: 'Bob Smith' } as User
+const currentUser = { username: 'user1', displayName: 'Bob Smith' } as LoggedInUser
 
 let service: SubmitDraftReportService
 let elite2ClientBuilder

--- a/server/services/report/submitDraftReportService.ts
+++ b/server/services/report/submitDraftReportService.ts
@@ -4,7 +4,7 @@ import type IncidentClient from '../../data/incidentClient'
 import logger from '../../../log'
 import { InTransaction } from '../../data/dataAccess/db'
 import { InvolvedStaffService } from '../involvedStaffService'
-import { User } from '../../types/uof'
+import { LoggedInUser } from '../../types/uof'
 
 export default class SubmitDraftReportService {
   constructor(
@@ -34,7 +34,7 @@ export default class SubmitDraftReportService {
   }
 
   public async submit(
-    currentUser: User,
+    currentUser: LoggedInUser,
     bookingId: number,
     now: () => Moment = () => moment()
   ): Promise<number | false> {

--- a/server/services/report/updateDraftReportService.ts
+++ b/server/services/report/updateDraftReportService.ts
@@ -1,5 +1,5 @@
 import type IncidentClient from '../../data/incidentClient'
-import type { SystemToken } from '../../types/uof'
+import type { SystemToken, User } from '../../types/uof'
 
 import logger from '../../../log'
 import { isNilOrEmpty } from '../../utils/utils'
@@ -23,7 +23,7 @@ export default class UpdateDraftReportService {
       : this.startNewReport(bookingId, currentUser, incidentDateValue, formObject)
   }
 
-  private async updateReport(formId: number, bookingId: number, currentUser, incidentDateValue, formValue) {
+  private async updateReport(formId: number, bookingId: number, currentUser: User, incidentDateValue, formValue) {
     const { username: userId } = currentUser
     if (incidentDateValue || formValue) {
       logger.info(`Updated report with id: ${formId} for user: ${userId} on booking: ${bookingId}`)

--- a/server/services/reportDetailBuilder.test.ts
+++ b/server/services/reportDetailBuilder.test.ts
@@ -12,7 +12,6 @@ const involvedStaffService = new InvolvedStaffService(
   jest.fn() as any,
   jest.fn() as any,
   jest.fn() as any,
-  jest.fn() as any,
   jest.fn() as any
 ) as jest.Mocked<InvolvedStaffService>
 

--- a/server/services/reportingService.test.ts
+++ b/server/services/reportingService.test.ts
@@ -1,8 +1,8 @@
 import moment from 'moment'
-import serviceCreator from './reportingService'
 import { ReportStatus } from '../config/types'
 import OffenderService from './offenderService'
 import { PrisonerDetail } from '../data/elite2ClientBuilderTypes'
+import ReportingService from './reportingService'
 
 jest.mock('./offenderService')
 
@@ -24,7 +24,7 @@ const heatmapBuilder = {
 let service
 
 beforeEach(() => {
-  service = serviceCreator(reportingClient, offenderService, heatmapBuilder)
+  service = new ReportingService(reportingClient, offenderService, heatmapBuilder)
 })
 
 afterEach(() => {

--- a/server/services/reportingService.ts
+++ b/server/services/reportingService.ts
@@ -43,145 +43,168 @@ const getIncidentCountsByOffenderNumber = async (
   }, {})
 }
 
-export default function createReportingService(
-  reportingClient: ReportingClient,
-  offenderService: OffenderService,
-  heatmapBuilder: HeatmapBuilder
-) {
-  const aggregateIncidentsUsing = (aggregator: Aggregator) => async (token, agencyId, month, year) => {
-    const range = dateRange(month, year)
-    logger.info(`${aggregator.title} for agency: ${agencyId}, between '${formatRange(range)}'`)
-    const incidentCountsByOffenderNumber = await getIncidentCountsByOffenderNumber(reportingClient, agencyId, range)
+export default class ReportingService {
+  constructor(
+    private readonly reportingClient: ReportingClient,
+    private readonly offenderService: OffenderService,
+    private readonly heatmapBuilder: HeatmapBuilder
+  ) {}
 
-    const prisonersDetails = await offenderService.getPrisonersDetails(
-      token,
-      Object.keys(incidentCountsByOffenderNumber)
-    )
+  private async aggregateIncidentsUsing(aggregator: Aggregator) {
+    return async (token, agencyId, month, year) => {
+      const range = dateRange(month, year)
+      logger.info(`${aggregator.title} for agency: ${agencyId}, between '${formatRange(range)}'`)
+      const incidentCountsByOffenderNumber = await getIncidentCountsByOffenderNumber(
+        this.reportingClient,
+        agencyId,
+        range
+      )
 
-    const answer = aggregator.aggregate(incidentCountsByOffenderNumber, prisonersDetails)
+      const prisonersDetails = await this.offenderService.getPrisonersDetails(
+        token,
+        Object.keys(incidentCountsByOffenderNumber)
+      )
 
-    return toCsv(aggregator.csvRendererConfiguration, [answer])
+      const answer = aggregator.aggregate(incidentCountsByOffenderNumber, prisonersDetails)
+
+      return toCsv(aggregator.csvRendererConfiguration, [answer])
+    }
   }
 
-  return {
-    getMostOftenInvolvedStaff: async (agencyId, month, year) => {
-      const range = dateRange(month, year)
-      logger.info(`Retrieve most involved staff for agency: ${agencyId}, between '${formatRange(range)}'`)
-      const results = await reportingClient.getMostOftenInvolvedStaff(agencyId, range)
+  public async getMostOftenInvolvedStaff(agencyId, month, year) {
+    const range = dateRange(month, year)
+    logger.info(`Retrieve most involved staff for agency: ${agencyId}, between '${formatRange(range)}'`)
+    const results = await this.reportingClient.getMostOftenInvolvedStaff(agencyId, range)
 
-      return toCsv(
-        [
-          { key: 'name', header: 'Staff member name' },
-          { key: 'count', header: 'Count' },
-        ],
-        results
-      )
-    },
+    return toCsv(
+      [
+        { key: 'name', header: 'Staff member name' },
+        { key: 'count', header: 'Count' },
+      ],
+      results
+    )
+  }
 
-    getMostOftenInvolvedPrisoners: async (token, agencyId, month, year) => {
-      const range = dateRange(month, year)
-      logger.info(`Retrieve most involved prisoner for agency: ${agencyId}, between '${formatRange(range)}'`)
-      const results = await reportingClient.getMostOftenInvolvedPrisoners(agencyId, range)
+  public async getMostOftenInvolvedPrisoners(token, agencyId, month, year): Promise<string> {
+    const range = dateRange(month, year)
+    logger.info(`Retrieve most involved prisoner for agency: ${agencyId}, between '${formatRange(range)}'`)
+    const results = await this.reportingClient.getMostOftenInvolvedPrisoners(agencyId, range)
 
-      const offenderNos = results.map(result => result.offenderNo)
-      const nosToNames = await offenderService.getOffenderNames(token, offenderNos)
+    const offenderNos = results.map(result => result.offenderNo)
+    const nosToNames = await this.offenderService.getOffenderNames(token, offenderNos)
 
-      const rows = results.map(({ offenderNo, count }) => ({ name: nosToNames[offenderNo], count }))
+    const rows = results.map(({ offenderNo, count }) => ({ name: nosToNames[offenderNo], count }))
 
-      return toCsv(
-        [
-          { key: 'name', header: 'Prisoner name' },
-          { key: 'count', header: 'Count' },
-        ],
-        rows
-      )
-    },
+    return toCsv(
+      [
+        { key: 'name', header: 'Prisoner name' },
+        { key: 'count', header: 'Count' },
+      ],
+      rows
+    )
+  }
 
-    getIncidentsOverview: async (agencyId, month, year) => {
-      const range = dateRange(month, year)
-      logger.info(`Retrieve incident overview for agency: ${agencyId}, between '${formatRange(range)}'`)
+  public async getIncidentsOverview(agencyId, month, year) {
+    const range = dateRange(month, year)
+    logger.info(`Retrieve incident overview for agency: ${agencyId}, between '${formatRange(range)}'`)
 
-      const [completeResults] = await reportingClient.getIncidentsOverview(agencyId, range, [
-        ReportStatus.SUBMITTED,
-        ReportStatus.COMPLETE,
-      ])
-      const [inprogressResults] = await reportingClient.getIncidentsOverview(agencyId, range, [
-        ReportStatus.IN_PROGRESS,
-      ])
+    const [completeResults] = await this.reportingClient.getIncidentsOverview(agencyId, range, [
+      ReportStatus.SUBMITTED,
+      ReportStatus.COMPLETE,
+    ])
+    const [inprogressResults] = await this.reportingClient.getIncidentsOverview(agencyId, range, [
+      ReportStatus.IN_PROGRESS,
+    ])
 
-      const results = [
-        { ...completeResults, type: 'Complete' },
-        { ...inprogressResults, type: 'In progress' },
-      ]
+    const results = [
+      { ...completeResults, type: 'Complete' },
+      { ...inprogressResults, type: 'In progress' },
+    ]
 
-      return toCsv(
-        [
-          { key: 'type', header: 'Type' },
-          { key: 'total', header: 'Total' },
-          { key: 'planned', header: 'Planned incidents' },
-          { key: 'unplanned', header: 'Unplanned incidents' },
-          { key: 'handcuffsApplied', header: 'Handcuffs applied' },
-          { key: 'batonDrawn', header: 'Baton drawn' },
-          { key: 'batonUsed', header: 'Baton used' },
-          { key: 'pavaDrawn', header: 'Pava drawn' },
-          { key: 'pavaUsed', header: 'Pava used' },
-          { key: 'personalProtectionTechniques', header: 'Personal protection techniques' },
-          { key: 'cctvRecording', header: 'CCTV recording' },
-          { key: 'bodyWornCamera', header: 'Body worn camera recording' },
-          { key: 'bodyWornCameraUnknown', header: 'Body worn camera recording unknown' },
-        ],
-        results
-      )
-    },
+    return toCsv(
+      [
+        { key: 'type', header: 'Type' },
+        { key: 'total', header: 'Total' },
+        { key: 'planned', header: 'Planned incidents' },
+        { key: 'unplanned', header: 'Unplanned incidents' },
+        { key: 'handcuffsApplied', header: 'Handcuffs applied' },
+        { key: 'batonDrawn', header: 'Baton drawn' },
+        { key: 'batonUsed', header: 'Baton used' },
+        { key: 'pavaDrawn', header: 'Pava drawn' },
+        { key: 'pavaUsed', header: 'Pava used' },
+        { key: 'personalProtectionTechniques', header: 'Personal protection techniques' },
+        { key: 'cctvRecording', header: 'CCTV recording' },
+        { key: 'bodyWornCamera', header: 'Body worn camera recording' },
+        { key: 'bodyWornCameraUnknown', header: 'Body worn camera recording unknown' },
+      ],
+      results
+    )
+  }
 
-    getIncidentHeatmap: async (token, agencyId, month, year) => {
-      const range = dateRange(month, year)
-      logger.info(`Retrieve heatmap for agency: ${agencyId}, between '${formatRange(range)}'`)
+  public async getIncidentHeatmap(token, agencyId, month, year) {
+    const range = dateRange(month, year)
+    logger.info(`Retrieve heatmap for agency: ${agencyId}, between '${formatRange(range)}'`)
 
-      const results = await reportingClient.getIncidentLocationsAndTimes(agencyId, range)
+    const results = await this.reportingClient.getIncidentLocationsAndTimes(agencyId, range)
 
-      const heatmap = await heatmapBuilder.build(token, agencyId, results)
+    const heatmap = await this.heatmapBuilder.build(token, agencyId, results)
 
-      return toCsv(
-        [
-          { key: 'location', header: 'Location' },
-          { key: 'six', header: '06:00' },
-          { key: 'seven', header: '07:00' },
-          { key: 'eight', header: '08:00' },
-          { key: 'nine', header: '09:00' },
-          { key: 'ten', header: '10:00' },
-          { key: 'eleven', header: '11:00' },
-          { key: 'twelve', header: '12:00' },
-          { key: 'onePm', header: '13:00' },
-          { key: 'twoPm', header: '14:00' },
-          { key: 'threePm', header: '15:00' },
-          { key: 'fourPm', header: '16:00' },
-          { key: 'fivePm', header: '17:00' },
-          { key: 'sixPm', header: '18:00' },
-          { key: 'sevenPm', header: '19:00' },
-          { key: 'afterEight', header: '20:00+' },
-        ],
-        heatmap
-      )
-    },
+    return toCsv(
+      [
+        { key: 'location', header: 'Location' },
+        { key: 'six', header: '06:00' },
+        { key: 'seven', header: '07:00' },
+        { key: 'eight', header: '08:00' },
+        { key: 'nine', header: '09:00' },
+        { key: 'ten', header: '10:00' },
+        { key: 'eleven', header: '11:00' },
+        { key: 'twelve', header: '12:00' },
+        { key: 'onePm', header: '13:00' },
+        { key: 'twoPm', header: '14:00' },
+        { key: 'threePm', header: '15:00' },
+        { key: 'fourPm', header: '16:00' },
+        { key: 'fivePm', header: '17:00' },
+        { key: 'sixPm', header: '18:00' },
+        { key: 'sevenPm', header: '19:00' },
+        { key: 'afterEight', header: '20:00+' },
+      ],
+      heatmap
+    )
+  }
 
-    getIncidentsByReligiousGroup: aggregateIncidentsUsing(religiousGroupAggregator),
-    getIncidentsByEthnicGroup: aggregateIncidentsUsing(ethnicGroupAggregator),
+  public async getIncidentsByReligiousGroup(
+    token: string,
+    agencyId: string,
+    month: number,
+    year: number
+  ): Promise<string> {
+    const report = await this.aggregateIncidentsUsing(religiousGroupAggregator)
+    return report(token, agencyId, month, year)
+  }
 
-    getIncidentsByAgeGroup: async (token: string, agencyId: string, month: number, year: number): Promise<string> => {
-      const range = dateRange(month, year)
-      logger.info(`Retrieve incidents by age group for agency: ${agencyId}, between '${formatRange(range)}'`)
+  public async getIncidentsByEthnicGroup(
+    token: string,
+    agencyId: string,
+    month: number,
+    year: number
+  ): Promise<string> {
+    const report = await this.aggregateIncidentsUsing(ethnicGroupAggregator)
+    return report(token, agencyId, month, year)
+  }
 
-      const incidents = await reportingClient.getIncidentsForAgencyAndDateRange(agencyId, range)
+  public async getIncidentsByAgeGroup(token: string, agencyId: string, month: number, year: number): Promise<string> {
+    const range = dateRange(month, year)
+    logger.info(`Retrieve incidents by age group for agency: ${agencyId}, between '${formatRange(range)}'`)
 
-      const offenderNumbers = Array.from(
-        incidents.reduce((offenderNos, { offenderNo }) => offenderNos.add(offenderNo), new Set<string>())
-      )
+    const incidents = await this.reportingClient.getIncidentsForAgencyAndDateRange(agencyId, range)
 
-      const prisonersDetails = await offenderService.getPrisonersDetails(token, offenderNumbers)
+    const offenderNumbers = Array.from(
+      incidents.reduce((offenderNos, { offenderNo }) => offenderNos.add(offenderNo), new Set<string>())
+    )
 
-      const incidentsByAgeGroup = aggregateIncidentsByAgeGroup(incidents, prisonersDetails)
-      return toCsv(ageGroupCsvRendererConfig, [incidentsByAgeGroup])
-    },
+    const prisonersDetails = await this.offenderService.getPrisonersDetails(token, offenderNumbers)
+
+    const incidentsByAgeGroup = aggregateIncidentsByAgeGroup(incidents, prisonersDetails)
+    return toCsv(ageGroupCsvRendererConfig, [incidentsByAgeGroup])
   }
 }

--- a/server/types/uof.d.ts
+++ b/server/types/uof.d.ts
@@ -22,6 +22,7 @@ export type User = {
   lastName: string
   activeCaseLoad: CaseLoad
   displayName: string
+  token: string
 }
 
 export type GetUsersResults = {

--- a/server/types/uof.d.ts
+++ b/server/types/uof.d.ts
@@ -22,7 +22,6 @@ export type User = {
   lastName: string
   activeCaseLoad: CaseLoad
   displayName: string
-  token: string
 }
 
 export type GetUsersResults = {
@@ -47,4 +46,18 @@ export interface ReportingClient {
     agencyId: AgencyId,
     range: DateRange
   ) => Promise<Array<OffenderNoWithIncidentDate>>
+}
+
+export type LoggedInUser = {
+  username: string
+  token: string
+  refreshToken: string
+  refreshTime: any
+  firstName: string
+  lastName: string
+  userId: string
+  displayName: string
+  isReviewer: boolean
+  isCoordinator: boolean
+  activeCaseLoadId: string
 }


### PR DESCRIPTION
Previously we would prevent a user from submitting a report if they
had listed users in the report that didn't exist in nomis.

This was to handle an edge case where the user failed to resolve
a missing user after being prompted.

Going forward there will be no way to add a missing staff member so
this check will not be necessary. Implementing this change now
to ease moving to new flow. 

In the meanwhile we will automatically remove missing users for the user
(which should be fine as the user will have had to navigate away after being presented a warning message)