### PR TITLE
DCS-614: user can print statement

### DIFF
--- a/assets/sass/local.sass
+++ b/assets/sass/local.sass
@@ -351,11 +351,10 @@ dt.summary-list__key__wider
 
 .print-link 
     display: inline-block
-    position: relative
-    top: govuk-spacing(2)
     padding: 0.5em 0.5em 0.5em govuk-spacing(7)
     background: url(/assets/images/Printer_icon.png) no-repeat govuk-spacing(1) 50%
     background-size: 1.125em 1.3125em
+    padding-top: 0
 
 .print
   display: none !important

--- a/server/views/pages/reviewer/view-statement.html
+++ b/server/views/pages/reviewer/view-statement.html
@@ -15,7 +15,7 @@
   <div class="govuk-grid-row">
     <h1 class="govuk-heading-xl mainHeading">{{ data.name}}'s statement</h1>
  
-  {{ statementDetail.detail(data) }}
+  {{ statementDetail.detail(data, false) }}
 
   <p class="govuk-!-margin-top-5">
     <a

--- a/server/views/pages/statement/add-comment-to-statement.html
+++ b/server/views/pages/statement/add-comment-to-statement.html
@@ -23,7 +23,7 @@
   {% endif %}
   <h1 class="govuk-heading-xl mainHeading">{{ pageTitle }}</h1>
 
-  {{ statementDetail.detail(data) }}
+  {{ statementDetail.detail(data, false) }}
 
   <form method="POST">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}" />

--- a/server/views/pages/statement/check-your-statement.html
+++ b/server/views/pages/statement/check-your-statement.html
@@ -18,7 +18,7 @@
     </div>
   </div>
 
-  {{ statementDetail.detail(data) }}
+  {{ statementDetail.detail(data, false) }}
   
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/pages/statement/your-statement.html
+++ b/server/views/pages/statement/your-statement.html
@@ -20,7 +20,7 @@
       <a href="javascript:window.print()" class="govuk-link print-link">  Print statement  </a>
     </div>
 
-    {{ statementDetail.detail(data) }}
+    {{ statementDetail.detail(data, true) }}
 
     {{
         govukButton({

--- a/server/views/pages/statementDetailMacro.njk
+++ b/server/views/pages/statementDetailMacro.njk
@@ -1,34 +1,25 @@
-{% macro detail(data) %}
+{% macro detail(data, fullWidthContent) %}
+
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds  govuk-!-padding-left-0">
-    <div class="govuk-grid-column-one-half">
-      <p class="govuk-!-margin-bottom-0 govuk-label--s">Prisoner</p>
-      <p class="govuk-!-margin-top-0" data-qa="offender-name"> {{ data.displayName }} </p>
-    </div>
-    <div class="govuk-grid-column-one-half">
-      <p class="govuk-!-margin-bottom-0 govuk-label--s">Last control and restraint training</p>
-      <p class="govuk-!-margin-top-0" data-qa="last-training"> {{ data.lastTrainingMonth }} {{ data.lastTrainingYear }}
-      </p>
-    </div>
-  </div>
   <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
-    <div class="govuk-grid-column-one-half govuk-!-padding-bottom-3">
-      <p class="govuk-!-margin-bottom-0 govuk-label--s">Date and time of incident</p>
-      <p class="govuk-!-margin-top-0" data-qa="date-and-time">
-        {{ data.incidentDate | formatDate('D MMMM YYYY - HH:mm')  }}
-      </p>
+    <div class="govuk-grid-column-one-half govuk-!-margin-bottom-4">
+      <p class="govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-label--s">Prisoner</p>
+      <p class="govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-label--s">Date and time of incident</p>
+      <p class="govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-label--s">Last control and restraint training</p>
+      <p class="govuk-!-margin-top-0 govuk-label--s">Year joined the prison service</p>
     </div>
-    <div class="govuk-grid-column-one-half  govuk-!-padding-bottom-3">
-      <p class="govuk-!-margin-bottom-0 govuk-label--s">Year joined the prison service</p>
-      <p class="govuk-!-margin-top-0" data-qa="job-start-year">
-        {{ data.jobStartYear }}
-      </p>
+    <div class="govuk-grid-column-one-half govuk-!-margin-bottom-4">
+      <p class="govuk-!-margin-top-0 govuk-!-margin-bottom-0" data-qa="offender-name"> {{ data.displayName }} </p>
+      <p class="govuk-!-margin-top-0 govuk-!-margin-bottom-0" data-qa="date-and-time"> {{ data.incidentDate | formatDate('D MMMM YYYY - HH:mm') }} </p>
+      <p class="govuk-!-margin-top-0 govuk-!-margin-bottom-0" data-qa="last-training"> {{ data.lastTrainingMonth }} {{ data.lastTrainingYear }} </p>
+      <p class="govuk-!-margin-top-0" data-qa="job-start-year"> {{ data.jobStartYear }} </p>
     </div>
-    <hr class="govuk-!-margin-left-3" />
+    {% if fullWidthContent != true %} <hr class="govuk-!-margin-left-3" /> {% endif %}
   </div>
 </div>
+{% if fullWidthContent %} <hr/> {% endif %}
 
-<div class="govuk-grid-row govuk-!-margin-top-4">
+<div class="govuk-grid-row govuk-!-margin-top-4 govuk-!-margin-bottom-6">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-!-margin-bottom-0 govuk-label--s">Statement submitted</p>
     <p class="govuk-!-margin-top-0">
@@ -39,9 +30,10 @@
   </div>
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-!-margin-bottom-1 govuk-label--xs statement" data-qa="statement">{{ data.statement }}</p>
-    <hr class="govuk-!-margin-top-6" />
+    {% if fullWidthContent != true %}  <hr class="govuk-!-margin-top-6" /> {% endif %}
   </div>
 </div>
+{% if fullWidthContent %} <hr/> {% endif %}
 
 
 {% for comment in data.additionalComments %}
@@ -52,9 +44,10 @@
       <p class="govuk-!-margin-bottom-1 govuk-!-margin-top-0 govuk-label--xs statement" data-loop={{loop.index}}
         data-qa="viewAdditionalComment">{{comment.additionalComment}}
       </p>
-      <hr>
+      {% if fullWidthContent != true %}  <hr> {% endif %}
     </div>
   </div>
-{% endfor %}
+  {% if fullWidthContent %} <hr/> {% endif %}
+  {% endfor %}
 
 {% endmacro %}


### PR DESCRIPTION
http://localhost:3000/{reporttId}/your-statement
The user can print the statement currently on view.
The first section of the page (Prisoner, Date of incident, LastControl etc) has been changed from
being laid in 2 x 2 to being vertically stacked. The print link has been placed on the extreme
top right of the content section. Because the print link is outside of the 2/3rds content width,
the horizontal rules have been extended to full width but just for the you-statement page.
Other pages that use the statementDetail macro still have their horizontal rules at 2/3rds width

<img>
<img width="600" alt="Screenshot 2020-09-21 at 09 30 01" src="https://user-images.githubusercontent.com/50441412/93746819-a60e5700-fbed-11ea-9b31-86ea9dc177a2.png">
</img>

<img>
<img width="600" alt="Screenshot 2020-09-21 at 09 30 15" src="https://user-images.githubusercontent.com/50441412/93746829-a9a1de00-fbed-11ea-8965-e2455afb0a17.png">
</img>