### PR TITLE
DCS-614 user can print off their statement

### DIFF
--- a/server/views/pages/statement/your-statement.html
+++ b/server/views/pages/statement/your-statement.html
@@ -43,22 +43,8 @@
   </div>
 
   <div class="print">
-    <h2 class="govuk-!-margin-top-0"> Use of force incident number {{data.reportId}}</h2>
-    <p class="margin-top-bottom-0"><span class="govuk-label--s">Created by:&nbsp; </span> {{data.reporterName}} </p>
-    <p class="margin-top-bottom-0"> <span class="govuk-label--s">Date and time: &nbsp;</span>{{ data.incidentDate | formatDate('D MMMM YYYY - HH:mm')  }} </p>
-    <p class="margin-top-bottom-0"><span class="govuk-label--s">Prisoner name: &nbsp;</span>{{ data.displayName }}</p>
-    <p class="govuk-!-margin-top-0"><span class="govuk-label--s">Prisoner number: &nbsp; </span> {{ data.offenderNo }}</p>
-    <hr>
-
-    <p><span class="govuk-label--s"> {{data.name}}'s statement: &nbsp; </span>
-      {{ data.submittedDate | formatDate('D MMMM YYYY - HH:mm') }}<br> {{ data.statement }}
-    </p>
-
-    {% for comment in data.additionalComments %}
-    <p><span class="govuk-label--s">Additional comment submitted: &nbsp;</span>
-      {{ comment.dateSubmitted | formatDate('D MMMM YYYY - HH:mm') }} <br> {{comment.additionalComment}}
-    </p>
-    {% endfor %}
+    <h2 class="govuk-!-margin-top-0"> Your use of force statement </h2>
+    {{ statementDetail.detail(data, true) }}
   </div>
 </div>
 

--- a/server/views/pages/statementDetailMacro.njk
+++ b/server/views/pages/statementDetailMacro.njk
@@ -31,7 +31,7 @@
   </div>
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-!-margin-bottom-0 govuk-label--xs statement" data-qa="statement">{{ data.statement }}</p>
-    {% if fullWidthContent != true %}  <hr class="govuk-!-margin-top-4" /> {% endif %}
+    {% if not fullWidthContent %}  <hr class="govuk-!-margin-top-4" /> {% endif %}
   </div>
 </div>
 {% if fullWidthContent %} <hr/> {% endif %}

--- a/server/views/pages/statementDetailMacro.njk
+++ b/server/views/pages/statementDetailMacro.njk
@@ -2,49 +2,50 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds govuk-!-padding-left-0">
-    <div class="govuk-grid-column-one-half govuk-!-margin-bottom-4">
-      <p class="govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-label--s">Prisoner</p>
-      <p class="govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-label--s">Date and time of incident</p>
-      <p class="govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-label--s">Last control and restraint training</p>
-      <p class="govuk-!-margin-top-0 govuk-label--s">Year joined the prison service</p>
+    <div class="flex-container"> 
+      <div class="govuk-grid-column-one-half govuk-!-margin-bottom-4">
+        <p class="govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-label--s">Prisoner</p>
+        <p class="govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-label--s">Date and time of incident</p>
+        <p class="govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-label--s">Last control and restraint training</p>
+        <p class="govuk-!-margin-top-0 govuk-label--s">Year joined the prison service</p>
+      </div>
+      <div class="govuk-grid-column-one-half govuk-!-margin-bottom-4">
+        <p class="govuk-!-margin-top-0 govuk-!-margin-bottom-0" data-qa="offender-name"> {{ data.displayName }} </p>
+        <p class="govuk-!-margin-top-0 govuk-!-margin-bottom-0" data-qa="date-and-time"> {{ data.incidentDate | formatDate('D MMMM YYYY - HH:mm') }} </p>
+        <p class="govuk-!-margin-top-0 govuk-!-margin-bottom-0" data-qa="last-training"> {{ data.lastTrainingMonth }} {{ data.lastTrainingYear }} </p>
+        <p class="govuk-!-margin-top-0" data-qa="job-start-year"> {{ data.jobStartYear }} </p>
+      </div>
     </div>
-    <div class="govuk-grid-column-one-half govuk-!-margin-bottom-4">
-      <p class="govuk-!-margin-top-0 govuk-!-margin-bottom-0" data-qa="offender-name"> {{ data.displayName }} </p>
-      <p class="govuk-!-margin-top-0 govuk-!-margin-bottom-0" data-qa="date-and-time"> {{ data.incidentDate | formatDate('D MMMM YYYY - HH:mm') }} </p>
-      <p class="govuk-!-margin-top-0 govuk-!-margin-bottom-0" data-qa="last-training"> {{ data.lastTrainingMonth }} {{ data.lastTrainingYear }} </p>
-      <p class="govuk-!-margin-top-0" data-qa="job-start-year"> {{ data.jobStartYear }} </p>
-    </div>
-    {% if fullWidthContent != true %} <hr class="govuk-!-margin-left-3" /> {% endif %}
+    {% if not fullWidthContent %} <hr class="govuk-!-margin-left-3" /> {% endif %}
   </div>
 </div>
 {% if fullWidthContent %} <hr/> {% endif %}
 
 <div class="govuk-grid-row govuk-!-margin-top-4 govuk-!-margin-bottom-6">
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-!-margin-bottom-0 govuk-label--s">Statement submitted</p>
-    <p class="govuk-!-margin-top-0">
+    <p class="govuk-!-margin-bottom-0 govuk-label--s">Statement submitted:
       {% if data.submittedDate %}
-      {{ data.submittedDate | formatDate('D MMMM YYYY - HH:mm') }}
+      <span class="govuk-!-margin-bottom-0 govuk-body"> {{ data.submittedDate | formatDate('D MMMM YYYY - HH:mm') }} </span>
+      {% endif %}
     </p>
-    {% endif %}
   </div>
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-!-margin-bottom-1 govuk-label--xs statement" data-qa="statement">{{ data.statement }}</p>
-    {% if fullWidthContent != true %}  <hr class="govuk-!-margin-top-6" /> {% endif %}
+    <p class="govuk-!-margin-bottom-0 govuk-label--xs statement" data-qa="statement">{{ data.statement }}</p>
+    {% if fullWidthContent != true %}  <hr class="govuk-!-margin-top-4" /> {% endif %}
   </div>
 </div>
 {% if fullWidthContent %} <hr/> {% endif %}
 
-
 {% for comment in data.additionalComments %}
   <div class="govuk-grid-row govuk-!-margin-top-4">
     <div class="govuk-grid-column-two-thirds">
-      <p class="govuk-!-margin-bottom-0 govuk-label--s">Additional comment submitted</p>
-      <p class="govuk-!-margin-top-0"> {{ comment.dateSubmitted | formatDate('D MMMM YYYY - HH:mm') }} </p>
-      <p class="govuk-!-margin-bottom-1 govuk-!-margin-top-0 govuk-label--xs statement" data-loop={{loop.index}}
+      <p class="govuk-!-margin-bottom-4 govuk-label--s">Additional comment submitted:
+        <span class="govuk-body"> {{ comment.dateSubmitted | formatDate('D MMMM YYYY - HH:mm') }} </span>
+      </p>
+      <p class="govuk-!-margin-bottom-0 govuk-!-margin-top-0 govuk-label--xs statement" data-loop={{loop.index}}
         data-qa="viewAdditionalComment">{{comment.additionalComment}}
       </p>
-      {% if fullWidthContent != true %}  <hr> {% endif %}
+      {% if not fullWidthContent %}  <hr> {% endif %}
     </div>
   </div>
   {% if fullWidthContent %} <hr/> {% endif %}


### PR DESCRIPTION
http://localhost:3000/{reportId}/your-statement
The information in the top part of the page is now in blocks rether then tight upto each other.
More consistent spacing between statement and additional comments
This ticket corrects mistakes made previously that had been pushed to main. The mistake was, the data in the header section of the print was incorrect
Have also moved code from the print section on your-statement to statementDetailMacro.detail

<img width="600" alt="614 screen" src="https://user-images.githubusercontent.com/50441412/93900591-7b0b2c80-fced-11ea-97f5-b0bc6d235fe0.png">


<img width="600" alt="614 print" src="https://user-images.githubusercontent.com/50441412/93900614-852d2b00-fced-11ea-9751-b1f2b6f6b3b5.png">

