### PR TITLE
Dcs 630 uof reviewer/coordinator can print report and its statement

### DIFF
--- a/assets/sass/local.sass
+++ b/assets/sass/local.sass
@@ -369,6 +369,9 @@ dt.summary-list__key__wider
   
   .print
     display: block !important
+  
+  .page-break-before
+    page-break-before: always
 
 @page
   size: A4

--- a/assets/sass/local.sass
+++ b/assets/sass/local.sass
@@ -238,6 +238,10 @@ i[class^="arrow-"]
 .flex-container 
   display: flex
 
+.flex-container-justified
+  display: flex
+  justify-content: space-between
+
 dt.summary-list__key__wider
   width: 80%
 

--- a/server/routes/reviewer.ts
+++ b/server/routes/reviewer.ts
@@ -81,7 +81,18 @@ export = function CreateReviewRoutes({ offenderService, reportDetailBuilder, rev
       const tab = report.status === ReportStatus.SUBMITTED.value ? '/not-completed-incidents' : '/completed-incidents'
 
       const data = { incidentId: reportId, reporterName, submittedDate, offenderDetail, statements, tab }
-      return res.render('pages/reviewer/view-statements', { data })
+
+      const reportDataForPrint = await reportDetailBuilder.build(res.locals.user.username, report)
+
+      const statementsWithNarrative = await Promise.all(
+        statements.map(statement => reviewService.getStatement(statement.id))
+      ).then(stmnts => stmnts.filter(stmnt => stmnt.statement))
+
+      return res.render('pages/reviewer/view-statements', {
+        data,
+        reportDataForPrint,
+        statements: statementsWithNarrative,
+      })
     },
 
     reviewStatement: async (req: Request, res: Response): Promise<void> => {

--- a/server/views/pages/reportDetailMacro.njk
+++ b/server/views/pages/reportDetailMacro.njk
@@ -8,7 +8,7 @@
 
 {% macro reportHeading(data, print) %}
   <div class="govuk-grid-row  {% if print %} flex-container {% endif %}">
-      <div class="govuk-grid-column-one-third govuk-!-margin-bottom-4" style="flex-basis: 25%">
+      <div class="govuk-grid-column-one-third govuk-!-margin-bottom-4" style="flex-basis: 30%">
         <p class="govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-label--s">Created by</p>
         <p class="govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-label--s">Date and time</p>
         <p class="govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-label--s">Prisoner name</p>
@@ -17,7 +17,7 @@
           <p class="govuk-!-margin-top-0 govuk-!-margin-bottom-0 govuk-label--s">Incident number</p>
         {% endif %}
       </div>
-      <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-4" style="flex-basis: 75%" >
+      <div class="govuk-grid-column-two-thirds govuk-!-margin-bottom-4" style="flex-basis: 70%" >
         <p class="govuk-!-margin-top-0 govuk-!-margin-bottom-0" data-qa="reporter-name"> {{ data.reporterName }} </p>
         <p class="govuk-!-margin-top-0 govuk-!-margin-bottom-0" data-qa="submitted-date"> {{ data.submittedDate | formatDate('D MMMM YYYY, HH:mm') }} </p>
         <p class="govuk-!-margin-top-0 govuk-!-margin-bottom-0" data-qa="prisoner-name"> {{ data.offenderDetail.displayName }}</p>

--- a/server/views/pages/reportDetailSectionsMacros.njk
+++ b/server/views/pages/reportDetailSectionsMacros.njk
@@ -1,50 +1,50 @@
 
  {% macro sectionHeading(obj) %}
-    <h2 class="govuk-heading-l govuk-!-margin-bottom-1 govuk-!-margin-top-7">
-    {{obj.title}}
-    {% if obj.url %}  
-      <span class="govuk-body govuk-!-margin-top-1 float-right">
-        <a class="govuk-link" data-qa='{{obj.id}}-link' href='{{obj.url}}' >
-          Change<span class="govuk-visually-hidden"> {{obj.title}} </span>
-        </a>
-      </span>
-    {% endif %}
-  </h2>
+ <h2 class="govuk-heading-l govuk-!-margin-bottom-1 govuk-!-margin-top-7">
+ {{obj.title}}
+ {% if obj.url %}  
+   <span class="govuk-body govuk-!-margin-top-1 float-right">
+     <a class="govuk-link" data-qa='{{obj.id}}-link' href='{{obj.url}}' >
+       Change<span class="govuk-visually-hidden"> {{obj.title}} </span>
+     </a>
+   </span>
+ {% endif %}
+</h2>
 {% endmacro %}
 
 {% macro tableRow(dataItem) %}
- <dl class="govuk-summary-list govuk-!-margin-0">  
-  <div class="govuk-summary-list__row {% if dataItem.print %} flex-container {% endif %}">
-    <dt class="govuk-summary-list__key summary-list__key__wider {% if dataItem.print %} govuk-!-margin-right-4 {% endif %}" style="flex-basis: 50%"> {{dataItem.label}} </dt>
-    <dd class="govuk-summary-list__value  {% if dataItem.print %} govuk-!-margin-right-4 {% endif %}" data-qa="{{dataItem['data-qa']}}">
-  
-      {% if dataItem.dataValue.length === 0 or dataItem.dataValue == null %}
-        &ndash;
-      {% elif dataItem.dataValue | isArray and dataItem.type === 'itemPerLine' %}
-        {%for item in dataItem.dataValue %}
-          {%for value in item %}
-            {{value}} 
-            {% if not loop.last %}<br/>{% endif %}
-          {% endfor%}
-          <br/>
-          {%if item.length > 1 and not loop.last %}
-          <br/>
-          {% endif %}
-        {% endfor %}
-      {% else %}
-      {{dataItem.dataValue}}
-      {% endif %}
-    </dd>
-    <dd class="govuk-summary-list__actions"></dd>
+<dl class="govuk-summary-list govuk-!-margin-0">  
+<div class="govuk-summary-list__row {% if dataItem.print %} flex-container {% endif %}">
+ <dt class="govuk-summary-list__key summary-list__key__wider {% if dataItem.print %} govuk-!-margin-right-4 {% endif %}" style="flex-basis: 50%"> {{dataItem.label}} </dt>
+ <dd class="govuk-summary-list__value  {% if dataItem.print %} govuk-!-margin-right-4 {% endif %}" data-qa="{{dataItem['data-qa']}}">
+
+   {% if dataItem.dataValue.length === 0 or dataItem.dataValue == null %}
+     &ndash;
+   {% elif dataItem.dataValue | isArray and dataItem.type === 'itemPerLine' %}
+     {%for item in dataItem.dataValue %}
+       {%for value in item %}
+         {{value}} 
+         {% if not loop.last %}<br/>{% endif %}
+       {% endfor%}
+       <br/>
+       {%if item.length > 1 and not loop.last %}
+       <br/>
+       {% endif %}
+     {% endfor %}
+   {% else %}
+   {{dataItem.dataValue}}
+   {% endif %}
+ </dd>
+ <dd class="govuk-summary-list__actions"></dd>
 </div>
-  </dl> 
+</dl> 
 {% endmacro %}
 
 {% macro tableRowWithContent(dataItem) %}
- <dl class="govuk-summary-list govuk-!-margin-0">  
-  <div class="govuk-summary-list__row {% if dataItem.print %} flex-container {% endif %}">
-    <dt class="govuk-summary-list__key summary-list__key__wider  {% if dataItem.print %} govuk-!-margin-right-4 {% endif %}" style="flex-basis: 50%"> {{dataItem.label}} </dt>
-      {{ caller() }}
-  </div>
+<dl class="govuk-summary-list govuk-!-margin-0">  
+<div class="govuk-summary-list__row {% if dataItem.print %} flex-container {% endif %}">
+ <dt class="govuk-summary-list__key summary-list__key__wider  {% if dataItem.print %} govuk-!-margin-right-4 {% endif %}" style="flex-basis: 50%"> {{dataItem.label}} </dt>
+   {{ caller() }}
+</div>
 </dl> 
 {% endmacro%}

--- a/server/views/pages/reviewer/view-statements.html
+++ b/server/views/pages/reviewer/view-statements.html
@@ -76,8 +76,29 @@
       </a>
     </div>
   </div>
+
   <div class="print"> 
-   content to be printed
+    <!-- header -->
+    <h1>Use of force incident number {{ data.incidentId }}</h1>
+    <p>{{ reportDetail.reportHeading(data, true) }}</p>
+
+    <!-- report body  -->
+    <p>  {{ reportDetail.detail(reportDataForPrint, null, report.incidentId, user, true) }}</p>
+  
+    <!-- statement narrative and additional comments --> 
+    <div class="page-break-before">
+      {% for statement in statements %}
+        <h1 class="govuk-heading-l">{{ statement.name }}'s statement</h1>
+        <p> <span class="govuk-label--s"> Submitted </span> {{statement.submittedDate | formatDate('D MMMM YYYY - HH:mm')}}</p> 
+        {{ statement.statement }} 
+        <br>
+        {% for additionalComments in statement.additionalComments %}
+          {{ additionalComments.additionalComment}}
+          <br>
+        {% endfor %}
+      <hr>
+      {% endfor %}
+    </div> 
   </div>
 </div>
 {% endblock %}

--- a/server/views/pages/reviewer/view-statements.html
+++ b/server/views/pages/reviewer/view-statements.html
@@ -8,29 +8,31 @@
 {% block content %}
 <div class="govuk-body">
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters">
+    <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
+
+        <p class="govuk-!-padding-bottom-0">
+          <a
+            href="/{{ data.incidentId }}/view-report"
+            draggable="false"
+            class="govuk-link"
+            data-qa="report-link"
+          >
+            View report details
+          </a>
+        </p>
+
       {{ reportDetail.reportHeading(data) }}
     </div>
   </div>
   <div class="govuk-grid-row govuk-!-margin-top-3">
     <div class="govuk-grid-column-full">    
-      <p class="govuk-!-padding-bottom-2">
-        <a
-          href="/{{ data.incidentId }}/view-report"
-          draggable="false"
-          class="govuk-link"
-          data-qa="report-link"
-        >
-          View report details
-        </a>
-      </p>
 
       <table class="govuk-table govuk-!-width-two-thirds" data-qa="statements">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
-            <th class="govuk-table__header" scope="col">Officer</th>
-            <th class="govuk-table__header" scope="col">Statement</th>
+            <th class="govuk-table__header" scope="col">Staff member involved</th>
+            <th class="govuk-table__header" scope="col"></th>
           </tr>
         </thead>
 

--- a/server/views/pages/reviewer/view-statements.html
+++ b/server/views/pages/reviewer/view-statements.html
@@ -7,28 +7,27 @@
 
 {% block content %}
 <div class="govuk-body">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
+  <div class="govuk-grid-row no-print">     
+    <div class="govuk-grid-column-full"> 
       <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
-
-        <p class="govuk-!-padding-bottom-0">
-          <a
-            href="/{{ data.incidentId }}/view-report"
-            draggable="false"
-            class="govuk-link"
-            data-qa="report-link"
-          >
-            View report details
-          </a>
-        </p>
-
-      {{ reportDetail.reportHeading(data) }}
+      <p class="govuk-!-padding-bottom-0">
+        <a href="/{{ data.incidentId }}/view-report" draggable="false" class="govuk-link" data-qa="report-link">
+          View report details
+        </a>
+      </p>
+  
+      <div class="flex-container-justified">
+        <div  style="flex-basis: 60%" >
+          {{ reportDetail.reportHeading(data) }}
+        </div>
+    
+        <div class="float-right">
+          <a href="javascript:window.print()" class="govuk-link print-link">  Print report and statements  </a>
+        </div>
+      </div> 
     </div>
-  </div>
-  <div class="govuk-grid-row govuk-!-margin-top-3">
-    <div class="govuk-grid-column-full">    
-
-      <table class="govuk-table govuk-!-width-two-thirds" data-qa="statements">
+    <div class="govuk-grid-column-two-thirds"> 
+      <table class="govuk-table" data-qa="statements">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th class="govuk-table__header" scope="col">Staff member involved</th>
@@ -76,6 +75,9 @@
         Return to use of force incidents
       </a>
     </div>
+  </div>
+  <div class="print"> 
+   content to be printed
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
Corrodinator/Reviewer can print both the report and statements (plus added comments ) in one go from the 
/view-statements page

Screen shot 1: page before any changes (from T3)
screen shot 2 : page after code change
screen shot 3, 4 and 5 show the print preview (top, middle and bottom)

<img width="400" alt="630 screen before new code" src="https://user-images.githubusercontent.com/50441412/94128213-c3435f80-fe51-11ea-8df0-7b28b6be9a80.png">

<img width="400" alt="630 screen after new code" src="https://user-images.githubusercontent.com/50441412/94128240-ccccc780-fe51-11ea-90a2-cf07017c3a84.png">

<img width="400" alt="630 print top" src="https://user-images.githubusercontent.com/50441412/94128255-d1917b80-fe51-11ea-8894-c28d0c3e1696.png">

<img width="400" alt="630 print middle" src="https://user-images.githubusercontent.com/50441412/94128263-d3f3d580-fe51-11ea-8c24-6dc1ada69b86.png">

<img width="400" alt="630 print statements" src="https://user-images.githubusercontent.com/50441412/94128268-d6eec600-fe51-11ea-8904-7811ff6a0fc7.png">

