### PR TITLE
DCS-640 Remove content security policy. 

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -72,7 +72,11 @@ export default function createApp({
   // Secure code best practice - see:
   // 1. https://expressjs.com/en/advanced/best-practice-security.html,
   // 2. https://www.npmjs.com/package/helmet
-  app.use(helmet())
+  app.use(
+    helmet({
+      contentSecurityPolicy: false,
+    })
+  )
 
   const client = redis.createClient({
     port: config.redis.port,


### PR DESCRIPTION
This is a middleware that is added by default version 4.0 of helmet. This prevents running of js unless it's specifically accounted for as part of the security policy which breaks everything. 

Added a ticket to the backlog to get it working under CSP