### PR TITLE
DCS-640 Tidying up application creation

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,8 +8,7 @@ initialiseAppInsights()
 
 const knex = require('knex')
 const knexfile = require('./knexfile')
-/** @type {any} */
-const app = require('./server/index')
+const app = require('./server/index').default
 const log = require('./log')
 
 const selectSql = message => {

--- a/server/data/reportingClient.test.ts
+++ b/server/data/reportingClient.test.ts
@@ -1,39 +1,37 @@
-/* eslint-disable import/first */
-import moment = require('moment')
+import moment from 'moment'
 import { ReportStatus } from '../config/types'
-import * as reportingClient from './reportingClient'
+import ReportingClient from './reportingClient'
 
-jest.mock('./dataAccess/db')
-// eslint-disable-next-line import/first
-import * as original from './dataAccess/db'
-
-const db: any = original
+let reportingClient: ReportingClient
+const query = jest.fn()
 
 beforeEach(() => {
-  db.query.mockResolvedValue({ rows: [] })
-})
-
-afterEach(() => {
   jest.resetAllMocks()
+  reportingClient = new ReportingClient(query)
+  query.mockResolvedValue({ rows: [] })
 })
 
 describe('reportingClient', () => {
   describe('getMostOftenInvolvedStaff', () => {
-    test('it should pass om the correct sql', () => {
+    test('it should pass on the correct sql', () => {
       const agencyId = 'LEI'
       const startDate = moment()
       const endDate = moment().add(1, 'month')
 
       reportingClient.getMostOftenInvolvedStaff(agencyId, [startDate, endDate])
 
-      expect(db.query).toBeCalledWith({
-        text: `select s.name, count(*) 
-          from statement s
-          join report r on r.id = s.report_id
-          where r.agency_id = $1
-          and   r.incident_date >= $2
-          and   r.incident_date <= $3
-          and   s.deleted is null
+      expect(query).toBeCalledWith({
+        text: `
+          select 
+            s.name, count(*) 
+          from 
+            statement s
+            join report r on r.id = s.report_id
+          where 
+            r.agency_id = $1
+            and   r.incident_date >= $2
+            and   r.incident_date <= $3
+            and   s.deleted is null
           group by s.user_id, s.name
           order by 2 desc
           limit 10`,
@@ -43,29 +41,33 @@ describe('reportingClient', () => {
   })
 
   describe('getMostOftenInvolvedPrisoners', () => {
-    test('it should pass om the correct sql', () => {
+    test('it should pass on the correct sql', () => {
       const agencyId = 'LEI'
       const startDate = moment()
       const endDate = moment().add(1, 'month')
 
       reportingClient.getMostOftenInvolvedPrisoners(agencyId, [startDate, endDate])
 
-      expect(db.query).toBeCalledWith({
-        text: `select r.offender_no "offenderNo", count(*)
-          from v_report r
-          where r.agency_id = $1
-          and   r.incident_date >= $2
-          and   r.incident_date <= $3
-          group by offender_no
-          order by 2 desc
-          limit 10`,
+      expect(query).toBeCalledWith({
+        text: `
+            select 
+              r.offender_no "offenderNo", count(*)
+            from 
+              v_report r
+            where 
+              r.agency_id = $1
+              and   r.incident_date >= $2
+              and   r.incident_date <= $3
+            group by offender_no
+            order by 2 desc
+            limit 10`,
         values: [agencyId, startDate.toDate(), endDate.toDate()],
       })
     })
   })
 
   describe('getIncidentsOverview', () => {
-    test('it should pass om the correct sql', () => {
+    test('it should pass on the correct sql', () => {
       const agencyId = 'LEI'
       const startDate = moment('2012-01-02 01:03')
       const endDate = moment(startDate).add(1, 'month')
@@ -76,102 +78,102 @@ describe('reportingClient', () => {
         [ReportStatus.IN_PROGRESS, ReportStatus.COMPLETE]
       )
 
-      expect(db.query).toBeCalledWith({
+      expect(query).toBeCalledWith({
         text: `
-      select
-        count(*) "total",
-        count(*) filter (where (incidentDetails ->> 'plannedUseOfForce')::boolean = true) "planned",
-        count(*) filter (where (incidentDetails ->> 'plannedUseOfForce')::boolean = false) "unplanned",
-        count(*) filter (where (useOfForceDetails ->> 'handcuffsApplied')::boolean = true) "handcuffsApplied",
-        count(*) filter (where (useOfForceDetails ->> 'batonDrawn')::boolean = true) "batonDrawn",
-        count(*) filter (where (useOfForceDetails ->> 'batonUsed')::boolean = true) "batonUsed",
-        count(*) filter (where (useOfForceDetails ->> 'pavaDrawn')::boolean = true) "pavaDrawn",
-        count(*) filter (where (useOfForceDetails ->> 'pavaUsed')::boolean = true) "pavaUsed",
-        count(*) filter (where (useOfForceDetails ->> 'personalProtectionTechniques')::boolean = true) "personalProtectionTechniques",
-        count(*) filter (where evidence ->> 'cctvRecording' = 'YES') "cctvRecording",
-        count(*) filter (where evidence ->> 'bodyWornCamera' = 'YES') "bodyWornCamera",
-        count(*) filter (where evidence ->> 'bodyWornCamera' = 'NOT_KNOWN') "bodyWornCameraUnknown"
-      from
-        (
-        select
-          form_response  -> 'incidentDetails'   incidentDetails,
-          form_response  -> 'useOfForceDetails' useOfForceDetails,
-          form_response  -> 'evidence'          evidence
-        from
-          v_report
-        where
-          status in ('IN_PROGRESS','COMPLETE')
-          and agency_id = 'LEI'
-          and incident_date between '2012-01-02 01:03:00.000+00' and '2012-02-02 01:03:00.000+00') incidents`,
+          select
+            count(*) "total",
+            count(*) filter (where (incidentDetails ->> 'plannedUseOfForce')::boolean = true) "planned",
+            count(*) filter (where (incidentDetails ->> 'plannedUseOfForce')::boolean = false) "unplanned",
+            count(*) filter (where (useOfForceDetails ->> 'handcuffsApplied')::boolean = true) "handcuffsApplied",
+            count(*) filter (where (useOfForceDetails ->> 'batonDrawn')::boolean = true) "batonDrawn",
+            count(*) filter (where (useOfForceDetails ->> 'batonUsed')::boolean = true) "batonUsed",
+            count(*) filter (where (useOfForceDetails ->> 'pavaDrawn')::boolean = true) "pavaDrawn",
+            count(*) filter (where (useOfForceDetails ->> 'pavaUsed')::boolean = true) "pavaUsed",
+            count(*) filter (where (useOfForceDetails ->> 'personalProtectionTechniques')::boolean = true) "personalProtectionTechniques",
+            count(*) filter (where evidence ->> 'cctvRecording' = 'YES') "cctvRecording",
+            count(*) filter (where evidence ->> 'bodyWornCamera' = 'YES') "bodyWornCamera",
+            count(*) filter (where evidence ->> 'bodyWornCamera' = 'NOT_KNOWN') "bodyWornCameraUnknown"
+          from
+            (
+            select
+              form_response  -> 'incidentDetails'   incidentDetails,
+              form_response  -> 'useOfForceDetails' useOfForceDetails,
+              form_response  -> 'evidence'          evidence
+            from
+              v_report
+            where
+              status in ('IN_PROGRESS','COMPLETE')
+              and agency_id = 'LEI'
+              and incident_date between '2012-01-02 01:03:00.000+00' and '2012-02-02 01:03:00.000+00') incidents`,
       })
     })
   })
 
   describe('getIncidentLocationsAndTimes', () => {
-    test('it should pass om the correct sql', () => {
+    test('it should pass on the correct sql', () => {
       const agencyId = 'LEI'
       const startDate = moment()
       const endDate = moment().add(1, 'month')
 
       reportingClient.getIncidentLocationsAndTimes(agencyId, [startDate, endDate])
 
-      expect(db.query).toBeCalledWith({
+      expect(query).toBeCalledWith({
         text: `
-      select
-        incident_date "incidentDate",
-        form_response -> 'incidentDetails' -> 'locationId' "locationId"
-      from
-        report
-      where
-        agency_id = $1
-        and submitted_date between $2 and $3`,
+          select
+            incident_date "incidentDate",
+            form_response -> 'incidentDetails' -> 'locationId' "locationId"
+          from
+            report
+          where
+            agency_id = $1
+            and submitted_date between $2 and $3`,
         values: [agencyId, startDate.toDate(), endDate.toDate()],
       })
     })
   })
 
   describe('getIncidentCountByOffenderNo', () => {
-    test('it should pass om the correct sql', () => {
+    test('it should pass on the correct sql', () => {
       const agencyId = 'LEI'
       const startDate = moment()
       const endDate = moment().add(1, 'month')
 
       reportingClient.getIncidentCountByOffenderNo(agencyId, [startDate, endDate])
 
-      expect(db.query).toBeCalledWith({
+      expect(query).toBeCalledWith({
         text: `
-    select
-        count(*) "incidentCount",
-        offender_no "offenderNo"
-      from
-        v_report
-     where
-        agency_id = $1
-        and incident_date between $2 and $3
-    group by
-        offender_no`,
+        select
+          count(*) "incidentCount",
+          offender_no "offenderNo"
+        from
+          v_report
+        where
+          agency_id = $1
+          and incident_date between $2 and $3
+        group by
+            offender_no`,
         values: [agencyId, startDate.toDate(), endDate.toDate()],
       })
     })
   })
   describe('getIncidentsForAgencyAndDateRange', () => {
-    test('it should pass om the correct sql', () => {
+    test('it should pass on the correct sql', () => {
       const agencyId = 'WRI'
       const startDate = moment()
       const endDate = moment().add(1, 'month')
 
       reportingClient.getIncidentsForAgencyAndDateRange(agencyId, [startDate, endDate])
 
-      expect(db.query).toBeCalledWith({
+      expect(query).toBeCalledWith({
         text: `
-    select
-        offender_no "offenderNo",
-        incident_date "incidentDate"
-      from
-        v_report
-     where
-        agency_id = $1
-        and incident_date between $2 and $3`,
+        select
+          offender_no "offenderNo",
+          incident_date "incidentDate"
+        from
+          v_report
+        where
+          agency_id = $1
+          and incident_date between $2 and $3`,
         values: [agencyId, startDate.toDate(), endDate.toDate()],
       })
     })

--- a/server/data/reportingClient.ts
+++ b/server/data/reportingClient.ts
@@ -1,134 +1,159 @@
 import format from 'pg-format'
-import * as nonTransactionalClient from './dataAccess/db'
-import { AgencyId, DateRange, OffenderNoWithIncidentCount, OffenderNoWithIncidentDate } from '../types/uof'
+import type { QueryPerformer } from './dataAccess/db'
+import type { AgencyId, DateRange, OffenderNoWithIncidentCount, OffenderNoWithIncidentDate } from '../types/uof'
 
-export const getMostOftenInvolvedStaff = async (agencyId: AgencyId, [startDate, endDate]: DateRange) => {
-  const results = await nonTransactionalClient.query({
-    text: `select s.name, count(*) 
-          from statement s
-          join report r on r.id = s.report_id
-          where r.agency_id = $1
-          and   r.incident_date >= $2
-          and   r.incident_date <= $3
-          and   s.deleted is null
+export default class ReportingClient {
+  constructor(private readonly query: QueryPerformer) {}
+
+  async getMostOftenInvolvedStaff(
+    agencyId: AgencyId,
+    [startDate, endDate]: DateRange
+  ): Promise<{ name: string; count: number }[]> {
+    const results = await this.query({
+      text: `
+          select 
+            s.name, count(*) 
+          from 
+            statement s
+            join report r on r.id = s.report_id
+          where 
+            r.agency_id = $1
+            and   r.incident_date >= $2
+            and   r.incident_date <= $3
+            and   s.deleted is null
           group by s.user_id, s.name
           order by 2 desc
           limit 10`,
-    values: [agencyId, startDate.toDate(), endDate.toDate()],
-  })
-  return results.rows
-}
+      values: [agencyId, startDate.toDate(), endDate.toDate()],
+    })
+    return results.rows
+  }
 
-export const getMostOftenInvolvedPrisoners = async (agencyId: AgencyId, [startDate, endDate]: DateRange) => {
-  const results = await nonTransactionalClient.query({
-    text: `select r.offender_no "offenderNo", count(*)
-          from v_report r
-          where r.agency_id = $1
-          and   r.incident_date >= $2
-          and   r.incident_date <= $3
-          group by offender_no
-          order by 2 desc
-          limit 10`,
-    values: [agencyId, startDate.toDate(), endDate.toDate()],
-  })
-  return results.rows
-}
+  public async getMostOftenInvolvedPrisoners(
+    agencyId: AgencyId,
+    [startDate, endDate]: DateRange
+  ): Promise<{ offenderNo: string; count: number }[]> {
+    const results = await this.query({
+      text: `
+            select 
+              r.offender_no "offenderNo", count(*)
+            from 
+              v_report r
+            where 
+              r.agency_id = $1
+              and   r.incident_date >= $2
+              and   r.incident_date <= $3
+            group by offender_no
+            order by 2 desc
+            limit 10`,
+      values: [agencyId, startDate.toDate(), endDate.toDate()],
+    })
+    return results.rows
+  }
 
-export const getIncidentsOverview = async (agencyId: AgencyId, [startDate, endDate]: DateRange, statuses) => {
-  const statusValues = statuses.map(s => s.value)
-  const results = await nonTransactionalClient.query({
-    text: format(
-      `
-      select
-        count(*) "total",
-        count(*) filter (where (incidentDetails ->> 'plannedUseOfForce')::boolean = true) "planned",
-        count(*) filter (where (incidentDetails ->> 'plannedUseOfForce')::boolean = false) "unplanned",
-        count(*) filter (where (useOfForceDetails ->> 'handcuffsApplied')::boolean = true) "handcuffsApplied",
-        count(*) filter (where (useOfForceDetails ->> 'batonDrawn')::boolean = true) "batonDrawn",
-        count(*) filter (where (useOfForceDetails ->> 'batonUsed')::boolean = true) "batonUsed",
-        count(*) filter (where (useOfForceDetails ->> 'pavaDrawn')::boolean = true) "pavaDrawn",
-        count(*) filter (where (useOfForceDetails ->> 'pavaUsed')::boolean = true) "pavaUsed",
-        count(*) filter (where (useOfForceDetails ->> 'personalProtectionTechniques')::boolean = true) "personalProtectionTechniques",
-        count(*) filter (where evidence ->> 'cctvRecording' = 'YES') "cctvRecording",
-        count(*) filter (where evidence ->> 'bodyWornCamera' = 'YES') "bodyWornCamera",
-        count(*) filter (where evidence ->> 'bodyWornCamera' = 'NOT_KNOWN') "bodyWornCameraUnknown"
-      from
-        (
+  public async getIncidentsOverview(
+    agencyId: AgencyId,
+    [startDate, endDate]: DateRange,
+    statuses
+  ): Promise<Record<string, number>[]> {
+    const statusValues = statuses.map(s => s.value)
+    const results = await this.query({
+      text: format(
+        `
+          select
+            count(*) "total",
+            count(*) filter (where (incidentDetails ->> 'plannedUseOfForce')::boolean = true) "planned",
+            count(*) filter (where (incidentDetails ->> 'plannedUseOfForce')::boolean = false) "unplanned",
+            count(*) filter (where (useOfForceDetails ->> 'handcuffsApplied')::boolean = true) "handcuffsApplied",
+            count(*) filter (where (useOfForceDetails ->> 'batonDrawn')::boolean = true) "batonDrawn",
+            count(*) filter (where (useOfForceDetails ->> 'batonUsed')::boolean = true) "batonUsed",
+            count(*) filter (where (useOfForceDetails ->> 'pavaDrawn')::boolean = true) "pavaDrawn",
+            count(*) filter (where (useOfForceDetails ->> 'pavaUsed')::boolean = true) "pavaUsed",
+            count(*) filter (where (useOfForceDetails ->> 'personalProtectionTechniques')::boolean = true) "personalProtectionTechniques",
+            count(*) filter (where evidence ->> 'cctvRecording' = 'YES') "cctvRecording",
+            count(*) filter (where evidence ->> 'bodyWornCamera' = 'YES') "bodyWornCamera",
+            count(*) filter (where evidence ->> 'bodyWornCamera' = 'NOT_KNOWN') "bodyWornCameraUnknown"
+          from
+            (
+            select
+              form_response  -> 'incidentDetails'   incidentDetails,
+              form_response  -> 'useOfForceDetails' useOfForceDetails,
+              form_response  -> 'evidence'          evidence
+            from
+              v_report
+            where
+              status in (%L)
+              and agency_id = %L
+              and incident_date between %L and %L) incidents`,
+        statusValues,
+        agencyId,
+        startDate.toDate(),
+        endDate.toDate()
+      ),
+    })
+
+    return results.rows
+  }
+
+  public async getIncidentLocationsAndTimes(
+    agencyId: AgencyId,
+    [startDate, endDate]: DateRange
+  ): Promise<{ incidentDate: Date; locationId: number }[]> {
+    const results = await this.query({
+      text: `
+          select
+            incident_date "incidentDate",
+            form_response -> 'incidentDetails' -> 'locationId' "locationId"
+          from
+            report
+          where
+            agency_id = $1
+            and submitted_date between $2 and $3`,
+      values: [agencyId, startDate.toDate(), endDate.toDate()],
+    })
+
+    return results.rows
+  }
+
+  public async getIncidentCountByOffenderNo(
+    agencyId: AgencyId,
+    [startDate, endDate]: DateRange
+  ): Promise<Array<OffenderNoWithIncidentCount>> {
+    const results = await this.query<OffenderNoWithIncidentCount>({
+      text: `
         select
-          form_response  -> 'incidentDetails'   incidentDetails,
-          form_response  -> 'useOfForceDetails' useOfForceDetails,
-          form_response  -> 'evidence'          evidence
+          count(*) "incidentCount",
+          offender_no "offenderNo"
         from
           v_report
         where
-          status in (%L)
-          and agency_id = %L
-          and incident_date between %L and %L) incidents`,
-      statusValues,
-      agencyId,
-      startDate.toDate(),
-      endDate.toDate()
-    ),
-  })
+          agency_id = $1
+          and incident_date between $2 and $3
+        group by
+            offender_no`,
+      values: [agencyId, startDate.toDate(), endDate.toDate()],
+    })
 
-  return results.rows
-}
+    return results.rows
+  }
 
-export const getIncidentLocationsAndTimes = async (agencyId: AgencyId, [startDate, endDate]: DateRange) => {
-  const results = await nonTransactionalClient.query({
-    text: `
-      select
-        incident_date "incidentDate",
-        form_response -> 'incidentDetails' -> 'locationId' "locationId"
-      from
-        report
-      where
-        agency_id = $1
-        and submitted_date between $2 and $3`,
-    values: [agencyId, startDate.toDate(), endDate.toDate()],
-  })
+  public async getIncidentsForAgencyAndDateRange(
+    agencyId: AgencyId,
+    [startDate, endDate]: DateRange
+  ): Promise<Array<OffenderNoWithIncidentDate>> {
+    const results = await this.query<OffenderNoWithIncidentDate>({
+      text: `
+        select
+          offender_no "offenderNo",
+          incident_date "incidentDate"
+        from
+          v_report
+        where
+          agency_id = $1
+          and incident_date between $2 and $3`,
+      values: [agencyId, startDate.toDate(), endDate.toDate()],
+    })
 
-  return results.rows
-}
-
-export const getIncidentCountByOffenderNo = async (
-  agencyId: AgencyId,
-  [startDate, endDate]: DateRange
-): Promise<Array<OffenderNoWithIncidentCount>> => {
-  const results = await nonTransactionalClient.query<OffenderNoWithIncidentCount>({
-    text: `
-    select
-        count(*) "incidentCount",
-        offender_no "offenderNo"
-      from
-        v_report
-     where
-        agency_id = $1
-        and incident_date between $2 and $3
-    group by
-        offender_no`,
-    values: [agencyId, startDate.toDate(), endDate.toDate()],
-  })
-
-  return results.rows
-}
-
-export const getIncidentsForAgencyAndDateRange = async (
-  agencyId: AgencyId,
-  [startDate, endDate]: DateRange
-): Promise<Array<OffenderNoWithIncidentDate>> => {
-  const results = await nonTransactionalClient.query<OffenderNoWithIncidentDate>({
-    text: `
-    select
-        offender_no "offenderNo",
-        incident_date "incidentDate"
-      from
-        v_report
-     where
-        agency_id = $1
-        and incident_date between $2 and $3`,
-    values: [agencyId, startDate.toDate(), endDate.toDate()],
-  })
-
-  return results.rows
+    return results.rows
+  }
 }

--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,7 @@
 import { buildAppInsightsClient } from './utils/azure-appinsights'
 import PrisonerSearchClient from './data/prisonerSearchClient'
 import IncidentClient from './data/incidentClient'
+import ReportingClient from './data/reportingClient'
 import DraftReportClient from './data/draftReportClient'
 import StatementsClient from './data/statementsClient'
 import OffenderService from './services/offenderService'
@@ -29,8 +30,7 @@ import createHeatmapBuilder from './services/heatmapBuilder'
 
 const db = require('./data/dataAccess/db')
 
-const reportingClient = require('./data/reportingClient')
-
+const reportingClient = new ReportingClient(db.query)
 const incidentClient = new IncidentClient(db.query, db.inTransaction)
 const draftReportClient = new DraftReportClient(db.query, db.inTransaction)
 const statementsClient = new StatementsClient(db.query)

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,6 @@
+import { services } from './services'
+import createApp from './app'
+
+const app = createApp(services)
+
+export default app

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -3,7 +3,8 @@ const path = require('path')
 const asyncMiddleware = require('../middleware/asyncMiddleware')
 const { coordinatorOnly } = require('../middleware/roleCheck')
 
-module.exports = function Index({ authenticationMiddleware, offenderService, reportingService, systemToken }) {
+module.exports = function Index(authenticationMiddleware, services) {
+  const { offenderService, reportingService, systemToken } = services
   const router = express.Router()
 
   router.use(authenticationMiddleware)

--- a/server/routes/api.test.js
+++ b/server/routes/api.test.js
@@ -18,8 +18,7 @@ const offenderService = {
   getOffenderImage: jest.fn(),
 }
 
-const route = createRouter({
-  authenticationMiddleware,
+const route = createRouter(authenticationMiddleware, {
   offenderService,
   reportingService,
   systemToken: username => `${username}-system-token`,

--- a/server/routes/changePrison.test.ts
+++ b/server/routes/changePrison.test.ts
@@ -1,12 +1,13 @@
-const request = require('supertest')
-const { appWithAllRoutes } = require('./testutils/appSetup')
+import request from 'supertest'
+import { Prison } from '../data/elite2ClientBuilderTypes'
+import { LocationService, DraftReportService } from '../services'
+import { appWithAllRoutes } from './testutils/appSetup'
 
-const locationService = {
-  getPrisons: jest.fn(),
-}
-const draftReportService = {
-  updateAgencyId: jest.fn(),
-}
+jest.mock('../services/locationService')
+jest.mock('../services/report/draftReportService')
+
+const locationService = new LocationService(null) as jest.Mocked<LocationService>
+const draftReportService = new DraftReportService(null, null, null, null, null) as jest.Mocked<DraftReportService>
 
 let app
 
@@ -16,7 +17,7 @@ beforeEach(() => {
     {
       agencyId: 'BXI',
       description: 'Brixton',
-    },
+    } as Prison,
   ])
 })
 

--- a/server/routes/coordinator.test.ts
+++ b/server/routes/coordinator.test.ts
@@ -1,22 +1,20 @@
-const request = require('supertest')
-const { appWithAllRoutes, user, reviewerUser, coordinatorUser } = require('./testutils/appSetup')
+import request from 'supertest'
+import { StaffDetails } from '../data/draftReportClientTypes'
+import { InvolvedStaffService, OffenderService, ReportService, ReviewService } from '../services'
+import { AddStaffResult } from '../services/involvedStaffService'
+import { appWithAllRoutes, user, reviewerUser, coordinatorUser } from './testutils/appSetup'
+
+jest.mock('../services/offenderService')
+jest.mock('../services/report/reportService')
+jest.mock('../services/involvedStaffService')
+jest.mock('../services/reviewService')
+
+const offenderService = new OffenderService(null) as jest.Mocked<OffenderService>
+const reportService = new ReportService(null, null, null) as jest.Mocked<ReportService>
+const involvedStaffService = new InvolvedStaffService(null, null, null, null) as jest.Mocked<InvolvedStaffService>
+const reviewService = new ReviewService(null, null, null, null, null) as jest.Mocked<ReviewService>
 
 const userSupplier = jest.fn()
-
-const involvedStaffService = {
-  addInvolvedStaff: jest.fn(),
-  removeInvolvedStaff: jest.fn(),
-  loadInvolvedStaff: jest.fn(),
-}
-const reportService = {
-  deleteReport: jest.fn(),
-}
-const offenderService = {
-  getOffenderDetails: jest.fn(),
-}
-const reviewService = {
-  getReport: jest.fn(),
-}
 
 let app
 
@@ -76,7 +74,7 @@ describe('coordinator', () => {
   describe('submit add involved staff', () => {
     it('should resolve for coordinator', async () => {
       userSupplier.mockReturnValue(coordinatorUser)
-      involvedStaffService.addInvolvedStaff.mockResolvedValue('success')
+      involvedStaffService.addInvolvedStaff.mockResolvedValue(AddStaffResult.SUCCESS)
       await request(app)
         .post('/coordinator/report/1/add-staff')
         .send({ username: 'sally' })
@@ -116,7 +114,7 @@ describe('coordinator', () => {
   describe('view add involved staff results', () => {
     it('should resolve for coordinator', async () => {
       userSupplier.mockReturnValue(coordinatorUser)
-      involvedStaffService.addInvolvedStaff.mockResolvedValue('success')
+      involvedStaffService.addInvolvedStaff.mockResolvedValue(AddStaffResult.SUCCESS)
       await request(app)
         .get('/coordinator/report/1/add-staff/result/success')
         .expect(302)
@@ -149,8 +147,8 @@ describe('coordinator', () => {
   describe('Confirm delete report', () => {
     it('should resolve for reviewer', async () => {
       userSupplier.mockReturnValue(coordinatorUser)
-      offenderService.getOffenderDetails.mockReturnValue({})
-      reviewService.getReport.mockReturnValue({})
+      offenderService.getOffenderDetails.mockResolvedValue({})
+      reviewService.getReport.mockResolvedValue({})
 
       await request(app)
         .get('/coordinator/report/1/confirm-delete')
@@ -203,7 +201,7 @@ describe('coordinator', () => {
 
     it('when report status is SUBMITTED and confirming to delete', async () => {
       userSupplier.mockReturnValue(coordinatorUser)
-      reviewService.getReport.mockReturnValue({ status: 'SUBMITTED' })
+      reviewService.getReport.mockResolvedValue({ status: 'SUBMITTED' })
 
       await request(app)
         .post('/coordinator/report/123/delete')
@@ -217,7 +215,7 @@ describe('coordinator', () => {
 
     it('when report status is SUBMITTED and confirming not to delete', async () => {
       userSupplier.mockReturnValue(coordinatorUser)
-      reviewService.getReport.mockReturnValue({ status: 'SUBMITTED' })
+      reviewService.getReport.mockResolvedValue({ status: 'SUBMITTED' })
 
       await request(app)
         .post('/coordinator/report/123/delete')
@@ -231,7 +229,7 @@ describe('coordinator', () => {
 
     it('when report status is COMPLETE and confirming to delete', async () => {
       userSupplier.mockReturnValue(coordinatorUser)
-      reviewService.getReport.mockReturnValue({ status: 'COMPLETE' })
+      reviewService.getReport.mockResolvedValue({ status: 'COMPLETE' })
 
       await request(app)
         .post('/coordinator/report/123/delete')
@@ -245,7 +243,7 @@ describe('coordinator', () => {
 
     it('when report status is COMPLETE and confirming not to delete', async () => {
       userSupplier.mockReturnValue(coordinatorUser)
-      reviewService.getReport.mockReturnValue({ status: 'COMPLETE' })
+      reviewService.getReport.mockResolvedValue({ status: 'COMPLETE' })
 
       await request(app)
         .post('/coordinator/report/123/delete')
@@ -287,9 +285,9 @@ describe('coordinator', () => {
   describe('Confirm delete statement', () => {
     it('should resolve for reviewer', async () => {
       userSupplier.mockReturnValue(coordinatorUser)
-      offenderService.getOffenderDetails.mockReturnValue({})
-      reviewService.getReport.mockReturnValue({})
-      involvedStaffService.loadInvolvedStaff.mockResolvedValue({ name: 'Bob' })
+      offenderService.getOffenderDetails.mockResolvedValue({})
+      reviewService.getReport.mockResolvedValue({})
+      involvedStaffService.loadInvolvedStaff.mockResolvedValue({ name: 'Bob' } as StaffDetails)
 
       await request(app)
         .get('/coordinator/report/1/statement/2/confirm-delete')

--- a/server/routes/incidents.test.ts
+++ b/server/routes/incidents.test.ts
@@ -1,21 +1,17 @@
 import request from 'supertest'
 import { appWithAllRoutes, user } from './testutils/appSetup'
 import { PageResponse } from '../utils/page'
-import ReportService from '../services/report/reportService'
-import OffenderService from '../services/offenderService'
+import { ReportDetailBuilder, ReportService, OffenderService } from '../services'
 
 jest.mock('../services/report/reportService')
 jest.mock('../services/offenderService')
+jest.mock('../services/reportDetailBuilder')
 
 const userSupplier = jest.fn()
 
 const reportService = new ReportService(null, null, null) as jest.Mocked<ReportService>
-
 const offenderService = new OffenderService(null) as jest.Mocked<OffenderService>
-
-const reportDetailBuilder = {
-  build: jest.fn().mockResolvedValue({ id: 1, form: { incidentDetails: {} } }),
-}
+const reportDetailBuilder = new ReportDetailBuilder(null, null, null, null) as jest.Mocked<ReportDetailBuilder>
 
 let app
 

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -1,4 +1,4 @@
-import express from 'express'
+import express, { Handler, Router } from 'express'
 import flash from 'connect-flash'
 import bodyParser from 'body-parser'
 import asyncMiddleware from '../middleware/asyncMiddleware'
@@ -16,20 +16,23 @@ import CheckYourAnswerRoutes from './checkYourAnswers'
 import ReportUseOfForceRoutes from './reportUseOfForce'
 import CoordinatorRoutes from './coordinator'
 import ChangePrisonRoutes from './changePrison'
+import { Services } from '../services'
 
-export default function Index({
-  authenticationMiddleware,
-  statementService,
-  offenderService,
-  prisonerSearchService,
-  reportService,
-  draftReportService,
-  involvedStaffService,
-  reviewService,
-  systemToken,
-  locationService,
-  reportDetailBuilder,
-}) {
+export default function Index(
+  authenticationMiddleware: Handler,
+  {
+    statementService,
+    offenderService,
+    prisonerSearchService,
+    reportService,
+    draftReportService,
+    involvedStaffService,
+    reviewService,
+    systemToken,
+    locationService,
+    reportDetailBuilder,
+  }: Services
+): Router {
   const router = express.Router()
 
   const incidents = IncidentRoutes(reportService, reportDetailBuilder)

--- a/server/routes/reportUseOfForce.test.ts
+++ b/server/routes/reportUseOfForce.test.ts
@@ -1,14 +1,12 @@
-const request = require('supertest')
-const { appWithAllRoutes } = require('./testutils/appSetup')
+import request from 'supertest'
+import { DraftReportService, OffenderService } from '../services'
+import { appWithAllRoutes } from './testutils/appSetup'
 
-const draftReportService = {
-  getCurrentDraft: jest.fn(),
-  getReportStatus: jest.fn(),
-}
+jest.mock('../services/offenderService')
+jest.mock('../services/report/draftReportService')
 
-const offenderService = {
-  getOffenderDetails: jest.fn(),
-}
+const offenderService = new OffenderService(null) as jest.Mocked<OffenderService>
+const draftReportService = new DraftReportService(null, null, null, null, null) as jest.Mocked<DraftReportService>
 
 let app
 

--- a/server/routes/reviewer.test.ts
+++ b/server/routes/reviewer.test.ts
@@ -1,22 +1,19 @@
 import request from 'supertest'
 import { appWithAllRoutes, user, reviewerUser } from './testutils/appSetup'
 import { parseDate } from '../utils/utils'
-import ReviewService from '../services/reviewService'
 import { PageResponse } from '../utils/page'
-import OffenderService from '../services/offenderService'
+import type { ReportDetail } from '../services/reportDetailBuilder'
+import { OffenderService, ReviewService, ReportDetailBuilder } from '../services'
 
 const userSupplier = jest.fn()
 
 jest.mock('../services/reviewService')
 jest.mock('../services/offenderService')
+jest.mock('../services/reportDetailBuilder')
 
 const reviewService = new ReviewService(null, null, null, null, null) as jest.Mocked<ReviewService>
-
 const offenderService = new OffenderService(null) as jest.Mocked<OffenderService>
-
-const reportDetailBuilder = {
-  build: jest.fn().mockResolvedValue({ id: 1, form: { incidentDetails: {} } }),
-}
+const reportDetailBuilder = new ReportDetailBuilder(null, null, null, null) as jest.Mocked<ReportDetailBuilder>
 
 let app
 
@@ -29,6 +26,7 @@ beforeEach(() => {
     new PageResponse({ min: 0, max: 0, page: 1, totalCount: 0, totalPages: 1 }, [])
   )
   offenderService.getOffenderDetails.mockResolvedValue({ displayName: 'Jimmy Choo', offenderNo: '123456' })
+  reportDetailBuilder.build.mockResolvedValue({} as ReportDetail)
 })
 
 afterEach(() => {

--- a/server/routes/statements.test.ts
+++ b/server/routes/statements.test.ts
@@ -1,16 +1,13 @@
 import request from 'supertest'
 import { appWithAllRoutes } from './testutils/appSetup'
-import StatementService from '../services/statementService'
 import { PageResponse } from '../utils/page'
+import { StatementService, OffenderService } from '../services'
 
 jest.mock('../services/statementService')
+jest.mock('../services/offenderService')
 
 const statementService = new StatementService(null, null, null) as jest.Mocked<StatementService>
-
-const offenderService = {
-  getOffenderNames: () => [],
-  getOffenderDetails: () => ({ displayName: 'Jimmy Choo', offenderNo: '123456' }),
-}
+const offenderService = new OffenderService(null) as jest.Mocked<OffenderService>
 
 let app
 
@@ -33,6 +30,7 @@ beforeEach(() => {
     id: 1,
     statement: 'Some initial statement',
   })
+  offenderService.getOffenderDetails.mockResolvedValue({ displayName: 'Jimmy Choo', offenderNo: '123456' })
   app = appWithAllRoutes({ statementService, offenderService })
 })
 

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -1,4 +1,4 @@
-import express from 'express'
+import express, { Express } from 'express'
 import bodyParser from 'body-parser'
 import cookieSession from 'cookie-session'
 import path from 'path'
@@ -9,6 +9,20 @@ import nunjucksSetup from '../../utils/nunjucksSetup'
 import errorHandler from '../../errorHandler'
 
 import { authenticationMiddleware } from './mockAuthentication'
+import type {
+  Services,
+  StatementService,
+  OffenderService,
+  ReportService,
+  ReportingService,
+  ReportDetailBuilder,
+  ReviewService,
+  InvolvedStaffService,
+  DraftReportService,
+  LocationService,
+  PrisonerSearchService,
+} from '../../services'
+import UserService from '../../services/userService'
 
 export const user = {
   firstName: 'first',
@@ -45,7 +59,7 @@ export const coordinatorUser = {
   activeCaseLoadId: 'LEI',
 }
 
-export const appSetup = (route, userSupplier = (): any => user) => {
+export const appSetup = (route, userSupplier = (): any => user): Express => {
   const app = express()
 
   const mockTransactionalClient = { query: jest.fn(), release: jest.fn() }
@@ -70,19 +84,21 @@ export const appSetup = (route, userSupplier = (): any => user) => {
   return app
 }
 
-export const appWithAllRoutes = (overrides = {}, userSupplier = () => user) => {
-  const route = allRoutes({
-    authenticationMiddleware,
-    statementService: {},
-    offenderService: {},
-    reportService: {},
-    involvedStaffService: {},
-    reviewService: {},
-    prisonerSearchService: {},
-    systemToken: username => `${username}-system-token`,
-    locationService: {},
-    reportDetailBuilder: {},
-    draftReportService: {},
+export const appWithAllRoutes = (overrides: Partial<Services> = {}, userSupplier = () => user): Express => {
+  const route = allRoutes(authenticationMiddleware, {
+    statementService: {} as StatementService,
+    offenderService: {} as OffenderService,
+    reportService: {} as ReportService,
+    involvedStaffService: {} as InvolvedStaffService,
+    reviewService: {} as ReviewService,
+    prisonerSearchService: {} as PrisonerSearchService,
+    systemToken: async username => `${username}-system-token`,
+    locationService: {} as LocationService,
+    reportDetailBuilder: {} as ReportDetailBuilder,
+    draftReportService: {} as DraftReportService,
+    userService: {} as UserService,
+    reportingService: {} as ReportingService,
+    signInService: {} as any,
     ...overrides,
   })
   return appSetup(route, userSupplier)

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -1,45 +1,43 @@
-import { buildAppInsightsClient } from './utils/azure-appinsights'
-import PrisonerSearchClient from './data/prisonerSearchClient'
-import IncidentClient from './data/incidentClient'
-import ReportingClient from './data/reportingClient'
-import DraftReportClient from './data/draftReportClient'
-import StatementsClient from './data/statementsClient'
-import OffenderService from './services/offenderService'
-import ReportingService from './services/reportingService'
-import PrisonSearchService from './services/prisonerSearchService'
+import { buildAppInsightsClient } from '../utils/azure-appinsights'
+import PrisonerSearchClient from '../data/prisonerSearchClient'
+import IncidentClient from '../data/incidentClient'
+import ReportingClient from '../data/reportingClient'
+import DraftReportClient from '../data/draftReportClient'
+import StatementsClient from '../data/statementsClient'
+import OffenderService from './offenderService'
+import ReportingService from './reportingService'
+import PrisonerSearchService from './prisonerSearchService'
 
-import ReportService from './services/report/reportService'
-import UpdateDraftReportService from './services/report/updateDraftReportService'
-import SubmitDraftReportService from './services/report/submitDraftReportService'
-import DraftReportService from './services/report/draftReportService'
+import ReportService from './report/reportService'
+import UpdateDraftReportService from './report/updateDraftReportService'
+import SubmitDraftReportService from './report/submitDraftReportService'
+import DraftReportService from './report/draftReportService'
 
-import LocationService from './services/locationService'
-import ReportDetailBuilder from './services/reportDetailBuilder'
-import ReviewService from './services/reviewService'
-import StatementService from './services/statementService'
-import { InvolvedStaffService } from './services/involvedStaffService'
-import UserService from './services/userService'
+import LocationService from './locationService'
+import ReportDetailBuilder from './reportDetailBuilder'
+import ReviewService from './reviewService'
+import StatementService from './statementService'
+import { InvolvedStaffService } from './involvedStaffService'
+import UserService from './userService'
 
-import createApp from './app'
+import elite2ClientBuilder from '../data/elite2ClientBuilder'
 
-import elite2ClientBuilder from './data/elite2ClientBuilder'
+import { authClientBuilder, systemToken } from '../data/authClientBuilder'
 
-import { authClientBuilder, systemToken } from './data/authClientBuilder'
+import createHeatmapBuilder from './heatmapBuilder'
+import EventPublisher from './eventPublisher'
 
-import createHeatmapBuilder from './services/heatmapBuilder'
+import * as db from '../data/dataAccess/db'
+import createSignInService from '../authentication/signInService'
 
-const db = require('./data/dataAccess/db')
+import { notificationServiceFactory } from './notificationService'
 
 const reportingClient = new ReportingClient(db.query)
 const incidentClient = new IncidentClient(db.query, db.inTransaction)
 const draftReportClient = new DraftReportClient(db.query, db.inTransaction)
 const statementsClient = new StatementsClient(db.query)
 
-const createSignInService = require('./authentication/signInService')
-
-const { notificationServiceFactory } = require('./services/notificationService')
-const eventPublisher = require('./services/eventPublisher')(buildAppInsightsClient())
-
+const eventPublisher = EventPublisher(buildAppInsightsClient())
 // inject service dependencies
 
 const heatmapBuilder = createHeatmapBuilder(elite2ClientBuilder)
@@ -75,11 +73,11 @@ const reviewService = new ReviewService(
   systemToken
 )
 const reportingService = new ReportingService(reportingClient, offenderService, heatmapBuilder)
-const prisonerSearchService = new PrisonSearchService(PrisonerSearchClient, elite2ClientBuilder, systemToken)
+const prisonerSearchService = new PrisonerSearchService(PrisonerSearchClient, elite2ClientBuilder, systemToken)
 const locationService = new LocationService(elite2ClientBuilder)
 const reportDetailBuilder = new ReportDetailBuilder(involvedStaffService, locationService, offenderService, systemToken)
 
-const app = createApp({
+export const services = {
   involvedStaffService,
   offenderService,
   reportService,
@@ -93,6 +91,19 @@ const app = createApp({
   locationService,
   reportDetailBuilder,
   draftReportService,
-})
+}
 
-module.exports = app
+export type Services = typeof services
+
+export {
+  InvolvedStaffService,
+  DraftReportService,
+  ReportService,
+  ReportingService,
+  LocationService,
+  StatementService,
+  ReviewService,
+  OffenderService,
+  PrisonerSearchService,
+  ReportDetailBuilder,
+}

--- a/server/services/involvedStaffService.ts
+++ b/server/services/involvedStaffService.ts
@@ -81,7 +81,7 @@ export class InvolvedStaffService {
     })
   }
 
-  public removeInvolvedStaff = async (reportId: number, statementId: number): Promise<void> => {
+  public async removeInvolvedStaff(reportId: number, statementId: number): Promise<void> {
     logger.info(`Removing statement: ${statementId} from report: ${reportId}`)
 
     await this.inTransaction(async client => {

--- a/server/services/prisonerSearchService.ts
+++ b/server/services/prisonerSearchService.ts
@@ -18,7 +18,7 @@ export type SearchResult = {
 const isFormComplete = (form: SearchForm): boolean =>
   Boolean(form.prisonNumber || form.firstName || form.lastName || form.agencyId)
 
-export default class PrisonSearchService {
+export default class PrisonerSearchService {
   constructor(
     private readonly PrisonerSearchClient: PrisonerSearchClientBuilder,
     private readonly elite2ClientBuilder: Elite2ClientBuilder,

--- a/server/services/reportingService.test.ts
+++ b/server/services/reportingService.test.ts
@@ -3,17 +3,13 @@ import { ReportStatus } from '../config/types'
 import OffenderService from './offenderService'
 import { PrisonerDetail } from '../data/elite2ClientBuilderTypes'
 import ReportingService from './reportingService'
+import ReportingClient from '../data/reportingClient'
+import { OffenderNoWithIncidentCount } from '../types/uof'
 
 jest.mock('./offenderService')
+jest.mock('../data/reportingClient')
 
-const reportingClient = {
-  getMostOftenInvolvedStaff: jest.fn(),
-  getMostOftenInvolvedPrisoners: jest.fn(),
-  getIncidentsOverview: jest.fn(),
-  getIncidentLocationsAndTimes: jest.fn(),
-  getIncidentCountByOffenderNo: jest.fn(),
-  getIncidentsForAgencyAndDateRange: jest.fn(),
-}
+const reportingClient = new ReportingClient(null) as jest.Mocked<ReportingClient>
 
 const offenderService = new OffenderService(null) as jest.Mocked<OffenderService>
 
@@ -33,10 +29,10 @@ afterEach(() => {
 
 describe('reportingService', () => {
   it('getMostOftenInvolvedStaff', async () => {
-    reportingClient.getMostOftenInvolvedStaff.mockReturnValue([
-      { userId: 'AAAA', name: 'Arthur', count: 20 },
-      { userId: 'BBBB', name: 'Bella', count: 10 },
-      { userId: 'CCCC', name: 'Charlotte', count: 5 },
+    reportingClient.getMostOftenInvolvedStaff.mockResolvedValue([
+      { name: 'Arthur', count: 20 },
+      { name: 'Bella', count: 10 },
+      { name: 'Charlotte', count: 5 },
     ])
 
     const date = moment({ years: 2019, months: 1 })
@@ -61,7 +57,7 @@ Charlotte,5
       CCCC: 'Charlotte',
     })
 
-    reportingClient.getMostOftenInvolvedPrisoners.mockReturnValue([
+    reportingClient.getMostOftenInvolvedPrisoners.mockResolvedValue([
       { offenderNo: 'AAAA', count: 20 },
       { offenderNo: 'BBBB', count: 10 },
       { offenderNo: 'CCCC', count: 5 },
@@ -85,7 +81,7 @@ Charlotte,5
 
   it('getIncidentsOverview', async () => {
     reportingClient.getIncidentsOverview
-      .mockReturnValueOnce([
+      .mockResolvedValueOnce([
         {
           total: 1,
           planned: 2,
@@ -101,7 +97,7 @@ Charlotte,5
           bodyWornCameraUnknown: 12,
         },
       ])
-      .mockReturnValueOnce([
+      .mockResolvedValueOnce([
         {
           total: 11,
           planned: 22,
@@ -202,10 +198,10 @@ The bathroom,10,20,30,40,50,60,70,80,90,100,110,120,130,140,150
 
   test('getIncidentsByReligiousGroup', async () => {
     reportingClient.getIncidentCountByOffenderNo.mockResolvedValue([
-      { offenderNo: 'A1', incidentCount: '2' },
-      { offenderNo: 'A2', incidentCount: '1' },
-      { offenderNo: 'A3', incidentCount: '2' },
-    ])
+      { offenderNo: 'A1', incidentCount: 2 },
+      { offenderNo: 'A2', incidentCount: 1 },
+      { offenderNo: 'A3', incidentCount: 2 },
+    ] as OffenderNoWithIncidentCount[])
 
     offenderService.getPrisonersDetails.mockResolvedValue(
       Promise.resolve([
@@ -226,9 +222,9 @@ The bathroom,10,20,30,40,50,60,70,80,90,100,110,120,130,140,150
 
   test('getIncidentsByEthnicGroup', async () => {
     reportingClient.getIncidentCountByOffenderNo.mockResolvedValue([
-      { offenderNo: 'A1', incidentCount: '2' },
-      { offenderNo: 'A2', incidentCount: '1' },
-      { offenderNo: 'A3', incidentCount: '2' },
+      { offenderNo: 'A1', incidentCount: 2 },
+      { offenderNo: 'A2', incidentCount: 1 },
+      { offenderNo: 'A3', incidentCount: 2 },
     ])
 
     offenderService.getPrisonersDetails.mockResolvedValue([

--- a/server/types/uof.d.ts
+++ b/server/types/uof.d.ts
@@ -35,18 +35,6 @@ export type GetUsersResults = {
 
 export type SystemToken = (string?) => Promise<string>
 
-export interface ReportingClient {
-  getMostOftenInvolvedStaff: (agencyId: AgencyId, range: DateRange) => Promise<Array<any>>
-  getMostOftenInvolvedPrisoners: (agencyId: AgencyId, range: DateRange) => Promise<Array<any>>
-  getIncidentsOverview: (agencyId: AgencyId, range: DateRange, statuses) => Promise<Array<any>>
-  getIncidentLocationsAndTimes: (agencyId: AgencyId, range: DateRange) => Promise<Array<any>>
-  getIncidentCountByOffenderNo: (agencyId: AgencyId, range: DateRange) => Promise<Array<OffenderNoWithIncidentCount>>
-  getIncidentsForAgencyAndDateRange: (
-    agencyId: AgencyId,
-    range: DateRange
-  ) => Promise<Array<OffenderNoWithIncidentDate>>
-}
-
 export type LoggedInUser = {
   username: string
   token: string


### PR DESCRIPTION

    Separating out a service index.ts which does the service wiring up from
    the creation of the app.
    
    The type for the services container can then be passed straight through to the routers
    rather than threading through each service independently.
    
    This had a knock on effect of forcing tests to be tidied up a bit

Also moving reporting client over to class.

