### PR TITLE
DCS-663 correcting link

### DIFF
--- a/server/views/formPages/formTemplate.html
+++ b/server/views/formPages/formTemplate.html
@@ -55,7 +55,7 @@
     <br/>
     {{ 
       submitLink({
-        label: 'Save and return to report use of force incidents',
+        label: 'Save and return to report use of force',
         qa: 'save-and-return', 
         value: 'save-and-return'
       }) 


### PR DESCRIPTION
These links all go to the "Report use of force" page so do not need the incidents suffix