### PR TITLE
DCS-727 CSS changes to change width of date fields.

### DIFF
--- a/assets/sass/local.sass
+++ b/assets/sass/local.sass
@@ -260,9 +260,6 @@ i[class^="arrow-"]
 dt.summary-list__key__wider
   width: 80%
 
-.narrow-date
-  width: 85%
-
 .incident-search
   background-color: govuk-colour("light-grey")
   padding: govuk-spacing(3)
@@ -283,12 +280,7 @@ dt.summary-list__key__wider
   .reporter
     @include govuk-media-query($from: tablet)
       width: 18%
-  .date-from
-    @include govuk-media-query($from: tablet)
-      width: 11%
-  .date-to
-    @include govuk-media-query($from: tablet)
-      width: 11%
+
   .apply
     @include govuk-media-query($from: tablet)
       margin-top: govuk-spacing(7)

--- a/server/views/partials/incidentSearchPanel.html
+++ b/server/views/partials/incidentSearchPanel.html
@@ -39,7 +39,6 @@
             label: 'Date from',
             name: 'dateFrom',
             date: query.dateFrom | formatDate('D MMM YYYY'),
-            classes: 'narrow-date',
             attributes: {
               'disable-future-dates': 'true'
             }
@@ -51,7 +50,6 @@
             label: 'Date to',
             name: 'dateTo',
             date: query.dateTo | formatDate('D MMM YYYY'),
-            classes: 'narrow-date',
             attributes: {
               'disable-future-dates': 'true'
             }


### PR DESCRIPTION
The css classes that have been removed are not used elsewhere in the app so this change does not affect any other pages

screenshots
**before**

<img width="300" alt="727-before" src="https://user-images.githubusercontent.com/50441412/100601608-b2ecac80-32fa-11eb-8ea4-93cc9e3fd21e.png">

<img width="200" alt="727 S5 before" src="https://user-images.githubusercontent.com/50441412/100601628-bb44e780-32fa-11eb-8aee-683cfcff7ff3.png">


**after**

<img width="300" alt="727-after" src="https://user-images.githubusercontent.com/50441412/100601644-bf710500-32fa-11eb-85ab-43af6f8d29a9.png">

<img width="300" alt="727 S5 after" src="https://user-images.githubusercontent.com/50441412/100601650-c3048c00-32fa-11eb-8247-7f761cd7e9aa.png">

