### PR TITLE
DCS-878 Make retrieval of locations more robust

### DIFF
--- a/integration-tests/integration/createIncident/view-your-report.spec.js
+++ b/integration-tests/integration/createIncident/view-your-report.spec.js
@@ -12,11 +12,12 @@ context('A reporter views their own report', () => {
     cy.task('stubLocations', offender.agencyId)
     cy.task('stubPrison', offender.agencyId)
     cy.task('stubOffenders', [offender])
-    cy.task('stubLocation', '357591')
     cy.task('stubUserDetailsRetrieval', ['MR_ZAGATO', 'MRS_JONES', 'TEST_USER'])
   })
 
-  it('A user can submit view their own report', () => {
+  it('A user can view their own report', () => {
+    cy.task('stubLocation', '357591')
+
     cy.login()
 
     cy.task('seedReport', {
@@ -63,5 +64,42 @@ context('A reporter views their own report', () => {
     yourReportPage.returnToYourReports().click()
 
     YourReportsPage.verifyOnPage()
+  })
+
+  it('A user can view their own report when location is not found', () => {
+    cy.task('stubLocationNotFound', '357591')
+
+    cy.login()
+
+    cy.task('seedReport', {
+      status: ReportStatus.SUBMITTED,
+      submittedDate: '2019-09-04 11:27:52',
+      involvedStaff: [
+        {
+          username: 'MR_ZAGATO',
+          name: 'MR_ZAGATO name',
+          email: 'MR_ZAGATO@gov.uk',
+        },
+        {
+          username: 'MRS_JONES',
+          name: 'MRS_JONES name',
+          email: 'MR_ZAGATO@gov.uk',
+        },
+        {
+          username: 'TEST_USER',
+          name: 'TEST_USER name',
+          email: 'TEST_USER@gov.uk',
+        },
+      ],
+    })
+
+    const yourStatementsPage = YourStatementsPage.goTo()
+    yourStatementsPage.yourReportsTab().click()
+
+    const yourReportsPage = YourReportsPage.verifyOnPage()
+    yourReportsPage.reports(0).action().click()
+
+    const yourReportPage = YourReportPage.verifyOnPage()
+    yourReportPage.location().contains('–')
   })
 })

--- a/integration-tests/mockApis/elite2api.js
+++ b/integration-tests/mockApis/elite2api.js
@@ -75,7 +75,7 @@ module.exports = {
     return stubFor({
       request: {
         method: 'GET',
-        urlPattern: `/api/locations/${locationId}`,
+        urlPattern: `/api/locations/${locationId}\\?includeInactive=true`,
       },
       response: {
         status: 200,
@@ -88,6 +88,19 @@ module.exports = {
       },
     })
   },
+
+  stubLocationNotFound: locationId => {
+    return stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `/api/locations/${locationId}\\?includeInactive=true`,
+      },
+      response: {
+        status: 404,
+      },
+    })
+  },
+
   stubPrison: prisonId => {
     const descriptions = { LEI: 'Leeds', MDI: 'Moorland' }
 

--- a/integration-tests/pages/yourReports/yourReportPage.js
+++ b/integration-tests/pages/yourReports/yourReportPage.js
@@ -15,6 +15,8 @@ const viewYourReportPage = () =>
 
     deleteInvolvedStaff: username => cy.get(`[data-qa="delete-staff-${username}"]`),
 
+    location: () => cy.get('[data-qa="location"]'),
+
     verifyInputs: reportDetails.verifyInputs,
 
     getReportId: () => {

--- a/integration-tests/plugins/index.js
+++ b/integration-tests/plugins/index.js
@@ -36,6 +36,8 @@ module.exports = on => {
 
     stubLocation: elite2api.stubLocation,
 
+    stubLocationNotFound: elite2api.stubLocationNotFound,
+
     stubUserDetailsRetrieval: auth.stubUserDetailsRetrieval,
 
     stubFindUsers: auth.stubFindUsers,

--- a/server/data/elite2ClientBuilder.test.ts
+++ b/server/data/elite2ClientBuilder.test.ts
@@ -84,6 +84,41 @@ describe('elite2Client', () => {
     })
   })
 
+  describe('getLocation', () => {
+    it('Should include inactive locations in request', async () => {
+      const location = {
+        agencyId: 'MDI',
+        currentOccupancy: 0,
+        description: 'Location',
+        internalLocationCode: 'ILOC-01-01',
+        locationId: 123,
+        locationPrefix: 'ILOC',
+        locationType: 'Thing',
+        locationUsage: 'For things',
+        operationalCapacity: 1,
+        parentLocationId: 0,
+        userDescription: 'Its a location',
+      }
+      fakeElite2Api
+        .get('/api/locations/123?includeInactive=true')
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, location)
+
+      const output = await elite2Client.getLocation(123)
+      expect(output).toEqual(location)
+    })
+
+    it('When location not found should return empty object', async () => {
+      fakeElite2Api
+        .get('/api/locations/123?includeInactive=true')
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(404)
+
+      const output = await elite2Client.getLocation(123)
+      expect(output).toStrictEqual({})
+    })
+  })
+
   describe('getOffenders', () => {
     const offenderNos = ['aaa', 'bbb']
     const offenders = []

--- a/server/data/elite2ClientBuilder.ts
+++ b/server/data/elite2ClientBuilder.ts
@@ -58,8 +58,16 @@ export class Elite2Client {
     })
   }
 
-  getLocation(locationId: number): Promise<PrisonLocation> {
-    return this.restClient.get({ path: `/api/locations/${locationId}` })
+  async getLocation(locationId: number): Promise<PrisonLocation | Record<string, unknown>> {
+    let location = {}
+    try {
+      location = await this.restClient.get({ path: `/api/locations/${locationId}?includeInactive=true` })
+    } catch (error) {
+      if (error?.status !== 404) {
+        throw error
+      }
+    }
+    return location
   }
 
   getOffenderImage(bookingId: number) {


### PR DESCRIPTION
Handled in two ways:
* When searching for details of a location ask prison-api to include inactive locations in the response.
* If prison-api replies 'Not Found' to a location request handle this and carry on.  The locationService already returns empty objects for particular conditions so I've assumed that its clients know how to deal with a Location that isn't.  The only change then is to ensure that elite2ClientBuilder.getLocation handles a 404 response by returning an empty object.