### PR TITLE
DCS-848 Fixing issue around showing stale data

### DIFF
--- a/server/routes/creatingReports/incidentDetails.ts
+++ b/server/routes/creatingReports/incidentDetails.ts
@@ -80,16 +80,16 @@ export default class IncidentDetailsRoutes {
     const { displayName, offenderNo } = offenderDetail
 
     const input = firstItem(req.flash('userInput'))
+    const pageData = input || form[formName]
 
     const prison = await this.locationService.getPrisonById(token, prisonId)
 
     const data = {
       bookingId,
-      ...form[formName],
-      ...input,
+      ...pageData,
       displayName,
       offenderNo,
-      incidentDate: this.getIncidentDate(incidentDate, input && input.incidentDate),
+      incidentDate: this.getIncidentDate(incidentDate, input?.incidentDate),
       locations,
       prison,
       types,


### PR DESCRIPTION
Once a field had been stored on the incident details page, if you then cleared out the value and clicked save, it would show the correct validation message but the old field value.

Moved to use the same pattern that we use on other form pages, which is:

If there is any flash then use that otherwise use values from the DB.
Previously it was showing the fields from the db and then overriding with flash entries which doesn't work when data is not present at all in flash