### PR TITLE
DCS-948 Use removal request date as source of truth of removal status

### DIFF
--- a/server/config/types.ts
+++ b/server/config/types.ts
@@ -54,7 +54,6 @@ export const ReportStatus = toEnum({
 export const StatementStatus = toEnum({
   PENDING: { value: 'PENDING', label: 'Pending' },
   SUBMITTED: { value: 'SUBMITTED', label: 'Submitted' },
-  REMOVAL_REQUESTED: { value: 'REMOVAL_REQUESTED', label: 'Removal requested' },
 })
 
 export const RelocationType = toEnum({

--- a/server/data/incidentClient.test.ts
+++ b/server/data/incidentClient.test.ts
@@ -64,7 +64,7 @@ test('getIncompleteReportsForReviewer', () => {
 
   const isRemovalRequested = `(select count(*) from "v_statement" s
                       where r.id = s.report_id
-                      and s.statement_status = $4) > 0`
+                      and s.removal_requested_date is not null) > 0`
 
   incidentClient.getIncompleteReportsForReviewer('agency-1')
 
@@ -80,12 +80,7 @@ test('getIncompleteReportsForReviewer', () => {
           where r.status = $1
           and   r.agency_id = $2
           order by r.incident_date`,
-    values: [
-      ReportStatus.SUBMITTED.value,
-      'agency-1',
-      StatementStatus.PENDING.value,
-      StatementStatus.REMOVAL_REQUESTED.value,
-    ],
+    values: [ReportStatus.SUBMITTED.value, 'agency-1', StatementStatus.PENDING.value],
   })
 })
 

--- a/server/data/incidentClient.ts
+++ b/server/data/incidentClient.ts
@@ -81,7 +81,7 @@ export default class IncidentClient {
 
     const isRemovalRequested = `(select count(*) from "v_statement" s
                       where r.id = s.report_id
-                      and s.statement_status = $4) > 0`
+                      and s.removal_requested_date is not null) > 0`
 
     const results = await this.query({
       text: `select r.id
@@ -95,12 +95,7 @@ export default class IncidentClient {
           where r.status = $1
           and   r.agency_id = $2
           order by r.incident_date`,
-      values: [
-        ReportStatus.SUBMITTED.value,
-        agencyId,
-        StatementStatus.PENDING.value,
-        StatementStatus.REMOVAL_REQUESTED.value,
-      ],
+      values: [ReportStatus.SUBMITTED.value, agencyId, StatementStatus.PENDING.value],
     })
     return results.rows
   }

--- a/server/data/statementsClient.test.ts
+++ b/server/data/statementsClient.test.ts
@@ -190,24 +190,24 @@ test('getStatementsForReviewer', () => {
 
   expect(query).toBeCalledWith({
     text: `select s.id
-            ,      r.id                       "reportId"
+            ,      r.id                                   "reportId"
             ,      s.name
-            ,      s.user_id                  "userId"
-            ,      s.overdue_date <= now()    "isOverdue"
-            ,      s.statement_status = $1    "isSubmitted"
-            ,      s.statement_status = $2    "isRemovalRequested"
-            ,      r.booking_id               "bookingId"
-            ,      r.incident_date            "incidentDate"
-            ,      s.last_training_month      "lastTrainingMonth"
-            ,      s.last_training_year       "lastTrainingYear"
-            ,      s.job_start_year           "jobStartYear"
-            ,      s.statement  
-            ,      s.submitted_date           "submittedDate"
+            ,      s.user_id                              "userId"
+            ,      s.overdue_date <= now()                "isOverdue"
+            ,      s.statement_status = $1                "isSubmitted"
+            ,      s.removal_requested_date is not null   "isRemovalRequested"
+            ,      r.booking_id                           "bookingId"
+            ,      r.incident_date                        "incidentDate"
+            ,      s.last_training_month                  "lastTrainingMonth"
+            ,      s.last_training_year                   "lastTrainingYear"
+            ,      s.job_start_year                       "jobStartYear"
+            ,      s.statement
+            ,      s.submitted_date                       "submittedDate"
             from v_report r
             left join v_statement s on r.id = s.report_id
-            where report_id = $3
+            where report_id = $2
             order by s.name`,
-    values: [StatementStatus.SUBMITTED.value, StatementStatus.REMOVAL_REQUESTED.value, 1],
+    values: [StatementStatus.SUBMITTED.value, 1],
   })
 })
 
@@ -216,23 +216,23 @@ test('getStatementForReviewer', () => {
 
   expect(query).toBeCalledWith({
     text: `select s.id
-            ,      r.id                       "reportId"
+            ,      r.id                                      "reportId"
             ,      s.name
-            ,      s.user_id                  "userId"
-            ,      s.overdue_date <= now()    "isOverdue"
-            ,      s.statement_status = $1    "isSubmitted"
-            ,      s.statement_status = $2    "isRemovalRequested"
-            ,      r.booking_id               "bookingId"
-            ,      r.incident_date            "incidentDate"
-            ,      s.last_training_month      "lastTrainingMonth"
-            ,      s.last_training_year       "lastTrainingYear"
-            ,      s.job_start_year           "jobStartYear"
+            ,      s.user_id                                 "userId"
+            ,      s.overdue_date <= now()                   "isOverdue"
+            ,      s.statement_status = $1                   "isSubmitted"
+            ,      s.removal_requested_date is not null      "isRemovalRequested"
+            ,      r.booking_id                              "bookingId"
+            ,      r.incident_date                           "incidentDate"
+            ,      s.last_training_month                     "lastTrainingMonth"
+            ,      s.last_training_year                      "lastTrainingYear"
+            ,      s.job_start_year                          "jobStartYear"
             ,      s.statement
-            ,      s.submitted_date           "submittedDate"
+            ,      s.submitted_date                          "submittedDate"
             from v_report r
             left join v_statement s on r.id = s.report_id
-            where s.id = $3`,
-    values: [StatementStatus.SUBMITTED.value, StatementStatus.REMOVAL_REQUESTED.value, 1],
+            where s.id = $2`,
+    values: [StatementStatus.SUBMITTED.value, 1],
   })
 })
 
@@ -253,26 +253,24 @@ test('requestStatementRemoval', async () => {
 
   expect(query).toBeCalledWith({
     text: `update "statement"
-              set statement_status = $1
-              ,   removal_requested_date = now()
-              ,   removal_requested_reason = $2
+              set removal_requested_date = now()
+              ,   removal_requested_reason = $1
               ,   updated_date = now()
-              where id = $3`,
-    values: [StatementStatus.REMOVAL_REQUESTED.value, 'removal reason', 1],
+              where id = $2`,
+    values: ['removal reason', 1],
   })
 })
 
 test('refuseStatementRemoval', async () => {
-  await statementsClient.refuseStatementRemoval(StatementStatus.PENDING, 1)
+  await statementsClient.refuseStatementRemoval(1)
 
   expect(query).toBeCalledWith({
     text: `update "statement"
-              set statement_status = $1
-              ,   removal_requested_date = null
+              set removal_requested_date = null
               ,   removal_requested_reason = null
               ,   updated_date = now()
-              where id = $2`,
-    values: [StatementStatus.PENDING.value, 1],
+              where id = $1`,
+    values: [1],
   })
 })
 

--- a/server/services/statementService.test.ts
+++ b/server/services/statementService.test.ts
@@ -177,31 +177,7 @@ describe('statmentService', () => {
   })
 
   describe('refuseRequest', () => {
-    test('refuse pending statement removal request', async () => {
-      const date = new Date()
-      statementsClient.getStatementForReviewer.mockResolvedValue({
-        id: 1,
-        bookingId: 19,
-        reportId: 1223,
-        userId: 'user1',
-        isOverdue: false,
-        isSubmitted: false,
-        isRemovalRequested: true,
-        incidentDate: date,
-        lastTrainingMonth: 1,
-        lastTrainingYear: 2000,
-        jobStartYear: 1998,
-        statement: 'A statement',
-        submittedDate: null,
-        name: 'bob',
-      })
-
-      await service.refuseRequest(1)
-      expect(statementsClient.getStatementForReviewer).toBeCalledWith(1)
-      expect(statementsClient.refuseStatementRemoval).toBeCalledWith(StatementStatus.PENDING, 1)
-    })
-
-    test('refuse submitted statement removal request', async () => {
+    test('calls statment client correctly', async () => {
       const date = new Date()
       statementsClient.getStatementForReviewer.mockResolvedValue({
         id: 1,
@@ -221,8 +197,7 @@ describe('statmentService', () => {
       })
 
       await service.refuseRequest(1)
-      expect(statementsClient.getStatementForReviewer).toBeCalledWith(1)
-      expect(statementsClient.refuseStatementRemoval).toBeCalledWith(StatementStatus.SUBMITTED, 1)
+      expect(statementsClient.refuseStatementRemoval).toBeCalledWith(1)
     })
   })
 })

--- a/server/services/statementService.ts
+++ b/server/services/statementService.ts
@@ -69,8 +69,6 @@ export default class StatementService {
 
   async refuseRequest(statementId: number): Promise<void> {
     logger.info(`Removal request refused for statement with id: ${statementId}`)
-    const statement = await this.statementsClient.getStatementForReviewer(statementId)
-    const statusToSet = statement.submittedDate ? StatementStatus.SUBMITTED : StatementStatus.PENDING
-    await this.statementsClient.refuseStatementRemoval(statusToSet, statementId)
+    await this.statementsClient.refuseStatementRemoval(statementId)
   }
 }


### PR DESCRIPTION
We used to set the status but this made it tricky to workout how to determine whether people were requesting to remove a pending statement or submitted one

It turned out we needed to present statements based on their status before requesting removal