### PR TITLE
DCS-910: email will be sent when involved staff removed

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -47,6 +47,7 @@ module.exports = {
             REQUEST: 'a58349d2-8a5f-4a22-8cb3-6a1410201a01',
             REMINDER: 'f561f2bc-9a64-4af2-a34c-ebee08c7503b',
             OVERDUE: 'da6a4684-ec87-4ead-8fcd-ec3a126c4926',
+            REMOVED: 'fc24f4e4-a927-492b-9bb4-dfe4f9e6c383',
           }
         : {
             REQUEST: '6c231fa9-316d-40c7-8cc0-efee73845009',

--- a/server/data/statementsClient.test.ts
+++ b/server/data/statementsClient.test.ts
@@ -212,6 +212,22 @@ test('getStatementsForReviewer', () => {
   })
 })
 
+test('getInvolvedStaffToRemove', () => {
+  statementsClient.getInvolvedStaffToRemove(1)
+
+  expect(query).toBeCalledWith({
+    text: `select s.id
+            ,      s.user_id                                 "userId"
+            ,      s.name                                    "name" 
+            ,      s.email                                   "email"
+            ,      r.incident_date                           "incidentDate"
+            ,      r.submitted_date                          "submittedDate"
+            from v_report r
+            left join v_statement s on r.id = s.report_id
+            where s.id = $1`,
+    values: [1],
+  })
+})
 test('getStatementForReviewer', () => {
   statementsClient.getStatementForReviewer(1)
 

--- a/server/data/statementsClient.ts
+++ b/server/data/statementsClient.ts
@@ -4,6 +4,7 @@ import { PageResponse, buildPageResponse, HasTotalCount, offsetAndLimitForPage }
 import type {
   StatementSummary,
   Statement,
+  InvolvedStaffToRemove,
   AdditionalComment,
   UsernameToStatementIds,
   StatementUpdate,
@@ -63,6 +64,22 @@ export default class StatementsClient {
               and s.statement_status = $3
               and s.deleted is null`,
       values: [reportId, userId, status.value],
+    })
+    return results.rows[0]
+  }
+
+  async getInvolvedStaffToRemove(statementId: number): Promise<InvolvedStaffToRemove> {
+    const results = await this.query({
+      text: `select s.id
+            ,      s.user_id                                 "userId"
+            ,      s.name                                    "name" 
+            ,      s.email                                   "email"
+            ,      r.incident_date                           "incidentDate"
+            ,      r.submitted_date                          "submittedDate"
+            from v_report r
+            left join v_statement s on r.id = s.report_id
+            where s.id = $1`,
+      values: [statementId],
     })
     return results.rows[0]
   }

--- a/server/data/statementsClientTypes.ts
+++ b/server/data/statementsClientTypes.ts
@@ -23,6 +23,15 @@ export type Statement = {
   reporterName: string
 }
 
+export type InvolvedStaffToRemove = {
+  id: number
+  userId: string
+  name: string
+  email: string
+  incidentDate: Date
+  submittedDate: Date
+}
+
 export type StatementUpdate = {
   lastTrainingMonth: number
   lastTrainingYear: number

--- a/server/routes/maintainingReports/coordinator.test.ts
+++ b/server/routes/maintainingReports/coordinator.test.ts
@@ -21,7 +21,7 @@ jest.mock('../../services/statementService')
 
 const offenderService = new OffenderService(null) as jest.Mocked<OffenderService>
 const reportService = new ReportService(null, null, null, null) as jest.Mocked<ReportService>
-const involvedStaffService = new InvolvedStaffService(null, null, null, null) as jest.Mocked<InvolvedStaffService>
+const involvedStaffService = new InvolvedStaffService(null, null, null, null, null) as jest.Mocked<InvolvedStaffService>
 const reviewService = new ReviewService(null, null, null, null, null) as jest.Mocked<ReviewService>
 const userService = new UserService(null, null) as jest.Mocked<UserService>
 const statementService = new StatementService(null, null, null) as jest.Mocked<StatementService>

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -40,7 +40,13 @@ const eventPublisher = EventPublisher(telemetryClient)
 const heatmapBuilder = createHeatmapBuilder(prisonClientBuilder)
 const userService = new UserService(prisonClientBuilder, authClientBuilder)
 const notificationService = notificationServiceFactory(eventPublisher)
-const involvedStaffService = new InvolvedStaffService(incidentClient, statementsClient, userService, db.inTransaction)
+const involvedStaffService = new InvolvedStaffService(
+  incidentClient,
+  statementsClient,
+  userService,
+  db.inTransaction,
+  notificationService
+)
 const offenderService = new OffenderService(prisonClientBuilder)
 const locationService = new LocationService(prisonClientBuilder)
 const reportService = new ReportService(incidentClient, offenderService, locationService, systemToken)

--- a/server/services/involvedStaffService.test.ts
+++ b/server/services/involvedStaffService.test.ts
@@ -20,10 +20,29 @@ const db = {
   inTransaction: fn => fn(client),
 }
 
+const notificationService = {
+  sendInvolvedStaffRemovedFromReport: jest.fn(),
+}
+
 let service: InvolvedStaffService
 
 beforeEach(() => {
-  service = new InvolvedStaffService(incidentClient, statementsClient, userService, db.inTransaction)
+  service = new InvolvedStaffService(
+    incidentClient,
+    statementsClient,
+    userService,
+    db.inTransaction,
+    notificationService
+  )
+
+  statementsClient.getInvolvedStaffToRemove.mockResolvedValue({
+    id: 1,
+    userId: 'some_user',
+    name: 'Some User',
+    email: 'some.user@email.com',
+    incidentDate: new Date('2021-04-01 10:00:00'),
+    submittedDate: new Date('2021-05-01 10:00:00'),
+  })
 })
 
 afterEach(() => {
@@ -158,6 +177,17 @@ describe('update', () => {
         query: client,
       })
 
+      expect(statementsClient.getInvolvedStaffToRemove).toBeCalledWith(2)
+      expect(notificationService.sendInvolvedStaffRemovedFromReport).toBeCalledWith(
+        'some.user@email.com',
+        {
+          incidentDate: moment('2021-04-01 10:00:00').toDate(),
+          involvedName: 'Some User',
+          submittedDate: moment('2021-05-01 10:00:00').toDate(),
+        },
+        { reportId: 1, statementId: 2 }
+      )
+
       expect(incidentClient.changeStatus).not.toHaveBeenCalled()
     })
 
@@ -171,6 +201,17 @@ describe('update', () => {
         query: client,
       })
 
+      expect(statementsClient.getInvolvedStaffToRemove).toBeCalledWith(2)
+      expect(notificationService.sendInvolvedStaffRemovedFromReport).toBeCalledWith(
+        'some.user@email.com',
+        {
+          incidentDate: moment('2021-04-01 10:00:00').toDate(),
+          involvedName: 'Some User',
+          submittedDate: moment('2021-05-01 10:00:00').toDate(),
+        },
+        { reportId: 1, statementId: 2 }
+      )
+
       expect(incidentClient.changeStatus).toHaveBeenCalledWith(1, ReportStatus.SUBMITTED, ReportStatus.COMPLETE, client)
     })
 
@@ -183,7 +224,16 @@ describe('update', () => {
         statementId: 2,
         query: client,
       })
-
+      expect(statementsClient.getInvolvedStaffToRemove).toBeCalledWith(2)
+      expect(notificationService.sendInvolvedStaffRemovedFromReport).toBeCalledWith(
+        'some.user@email.com',
+        {
+          incidentDate: moment('2021-04-01 10:00:00').toDate(),
+          involvedName: 'Some User',
+          submittedDate: moment('2021-05-01 10:00:00').toDate(),
+        },
+        { reportId: 1, statementId: 2 }
+      )
       expect(incidentClient.changeStatus).not.toHaveBeenCalled()
     })
   })

--- a/server/services/notificationService.js
+++ b/server/services/notificationService.js
@@ -56,6 +56,34 @@ const createNotificationService = (emailClient, eventPublisher) => {
         })
       )
 
+  const sendInvolvedStaffRemovedFromReport = async (
+    emailAddress,
+    { involvedName, incidentDate, submittedDate },
+    context
+  ) =>
+    emailClient
+      .sendEmail(involvedStaff.REMOVED, emailAddress, {
+        personalisation: {
+          INVOLVED_NAME: involvedName,
+          INCIDENT_DATE: asDate(incidentDate),
+        },
+        reference: null,
+      })
+      .then(({ body }) =>
+        eventPublisher.publish({
+          name: 'SendInvolvedStaffRemovedFromReportSuccess',
+          properties: { involvedName, incidentDate, submittedDate, ...context },
+          detail: body,
+        })
+      )
+      .catch(({ message }) =>
+        eventPublisher.publish({
+          name: 'SendInvolvedStaffRemovedFromReportFailure',
+          properties: { involvedName, incidentDate, submittedDate, ...context },
+          detail: message,
+        })
+      )
+
   const sendInvolvedStaffStatementReminder = async (
     emailAddress,
     { involvedName, incidentDate, submittedDate, overdueDate },
@@ -195,6 +223,7 @@ const createNotificationService = (emailClient, eventPublisher) => {
     sendReporterStatementOverdue,
     sendInvolvedStaffStatementOverdue,
     getRemovalRequestLink,
+    sendInvolvedStaffRemovedFromReport,
   }
 }
 

--- a/server/services/notificationService.test.js
+++ b/server/services/notificationService.test.js
@@ -141,6 +141,27 @@ describe('send involved staff notifications', () => {
     })
   })
 
+  test('sendInvolvedStaffRemovedFromReport', async () => {
+    await service.sendInvolvedStaffRemovedFromReport(
+      'user@email.com',
+      { involvedName, incidentDate, submittedDate },
+      context
+    )
+
+    expect(client.sendEmail).toBeCalledWith(involvedStaff.REMOVED, 'user@email.com', {
+      personalisation: {
+        INVOLVED_NAME: 'Thelma Jones',
+        INCIDENT_DATE: 'Tuesday 12 February',
+      },
+      reference: null,
+    })
+
+    expect(eventPublisher.publish).toBeCalledWith({
+      name: 'SendInvolvedStaffRemovedFromReportSuccess',
+      properties: { reportId: 1, statementId: 2, incidentDate, submittedDate, involvedName },
+      detail: 'response 1',
+    })
+  })
   test('sendStatementRequest', async () => {
     await service.sendStatementRequest(
       'user@email.com',

--- a/server/services/reportDetailBuilder.test.ts
+++ b/server/services/reportDetailBuilder.test.ts
@@ -5,7 +5,7 @@ import ReportDetailBuilder from './reportDetailBuilder'
 
 jest.mock('.')
 
-const involvedStaffService = new InvolvedStaffService(null, null, null, null) as jest.Mocked<InvolvedStaffService>
+const involvedStaffService = new InvolvedStaffService(null, null, null, null, null) as jest.Mocked<InvolvedStaffService>
 
 const locationService = new LocationService(null) as jest.Mocked<LocationService>
 


### PR DESCRIPTION
There are two ways an involved staff can be removed from an incident report.
First is by coordinator using the 'delete' link in view-report page and the second
is the coordinator using the 'view removal request' link in view-statements and following the process through.
Ultimately they both do the same thing. The action to send an email to the involved staff member starts in the involvedStaffService.removeInvolvedStaff() method. 
It contains new code notificationService.sendInvolvedStaffRemovedFromReport(...) to send the email.
A new template has been created in Govuk Notify.

example of email
<img width="300" alt="Screenshot 2021-04-21 at 17 38 47" src="https://user-images.githubusercontent.com/50441412/115590116-839a0480-a2c8-11eb-9cf8-3a67b1188a42.png">
