### PR TITLE
DCS-947 email reminders sent only if removal has not been requested

### DIFF
--- a/server/data/incidentClient.test.ts
+++ b/server/data/incidentClient.test.ts
@@ -242,6 +242,7 @@ test('getNextNotificationReminder', () => {
           where s.next_reminder_date < now()
           and s.statement_status = $1
           and s.deleted is null
+          and s.removal_requested_date is null
           order by s.id
           for update of s skip locked
           LIMIT 1`,

--- a/server/data/incidentClient.ts
+++ b/server/data/incidentClient.ts
@@ -227,6 +227,7 @@ export default class IncidentClient {
           where s.next_reminder_date < now()
           and s.statement_status = $1
           and s.deleted is null
+          and s.removal_requested_date is null
           order by s.id
           for update of s skip locked
           LIMIT 1`,


### PR DESCRIPTION
Bug fix.
Identified email reminders being sent even though a removal request had been made by involved staff. 
DB client sql changed so only returns results where there is no removal_requested_date