### PR TITLE
DCS-958 coordinator will be redirected to view-statements page

### DIFF
--- a/server/data/statementsClient.test.ts
+++ b/server/data/statementsClient.test.ts
@@ -295,11 +295,9 @@ test('getRemovalRequest', async () => {
   statementsClient.getRemovalRequest(1)
 
   expect(query).toBeCalledWith({
-    text: `select removal_requested_reason "removalRequestedReason"
-              , (select count(*) from "v_statement" s
-                      where s.id = $1
-                      and s.removal_requested_date is not null) > 0 "isRemovalRequested" 
-              from v_statement 
+    text: `select s.removal_requested_reason "removalRequestedReason"
+              , s.removal_requested_date is not null "isRemovalRequested"
+              from v_statement s 
               where id = $1`,
     values: [1],
   })

--- a/server/data/statementsClient.test.ts
+++ b/server/data/statementsClient.test.ts
@@ -297,7 +297,8 @@ test('getRemovalRequest', async () => {
   expect(query).toBeCalledWith({
     text: `select removal_requested_reason "removalRequestedReason"
               , (select count(*) from "v_statement" s
-    where s.removal_requested_date is not null) > 0 "isRemovalRequested" 
+                      where s.id = $1
+                      and s.removal_requested_date is not null) > 0 "isRemovalRequested" 
               from v_statement 
               where id = $1`,
     values: [1],

--- a/server/data/statementsClient.test.ts
+++ b/server/data/statementsClient.test.ts
@@ -291,11 +291,15 @@ test('refuseStatementRemoval', async () => {
   })
 })
 
-test('getRemovalRequestedReasonByStatementId', async () => {
-  statementsClient.getRemovalRequestedReasonByStatementId(1)
+test('getRemovalRequest', async () => {
+  statementsClient.getRemovalRequest(1)
 
   expect(query).toBeCalledWith({
-    text: `select removal_requested_reason  "removalRequestedReason" from v_statement where id = $1`,
+    text: `select removal_requested_reason "removalRequestedReason"
+              , (select count(*) from "v_statement" s
+    where s.removal_requested_date is not null) > 0 "isRemovalRequested" 
+              from v_statement 
+              where id = $1`,
     values: [1],
   })
 })

--- a/server/data/statementsClient.ts
+++ b/server/data/statementsClient.ts
@@ -294,14 +294,10 @@ export default class StatementsClient {
   }
 
   async getRemovalRequest(statementId: number): Promise<RemovalRequest> {
-    const isRemovalRequested = `(select count(*) from "v_statement" s
-                      where s.id = $1
-                      and s.removal_requested_date is not null) > 0`
-
     const { rows } = await this.query({
-      text: `select removal_requested_reason "removalRequestedReason"
-              , ${isRemovalRequested} "isRemovalRequested" 
-              from v_statement 
+      text: `select s.removal_requested_reason "removalRequestedReason"
+              , s.removal_requested_date is not null "isRemovalRequested"
+              from v_statement s 
               where id = $1`,
       values: [statementId],
     })

--- a/server/data/statementsClient.ts
+++ b/server/data/statementsClient.ts
@@ -9,7 +9,7 @@ import type {
   UsernameToStatementIds,
   StatementUpdate,
   ReviewerStatement,
-  RemovalRequestedReason,
+  RemovalRequest,
 } from './statementsClientTypes'
 import type { DraftInvolvedStaff } from '../services/drafts/draftInvolvedStaffService'
 import { StatementStatus, LabelledValue } from '../config/types'
@@ -293,9 +293,15 @@ export default class StatementsClient {
     })
   }
 
-  async getRemovalRequestedReasonByStatementId(statementId: number): Promise<RemovalRequestedReason> {
+  async getRemovalRequest(statementId: number): Promise<RemovalRequest> {
+    const isRemovalRequested = `(select count(*) from "v_statement" s
+    where s.removal_requested_date is not null) > 0`
+
     const { rows } = await this.query({
-      text: `select removal_requested_reason  "removalRequestedReason" from v_statement where id = $1`,
+      text: `select removal_requested_reason "removalRequestedReason"
+              , ${isRemovalRequested} "isRemovalRequested" 
+              from v_statement 
+              where id = $1`,
       values: [statementId],
     })
     return rows[0]

--- a/server/data/statementsClient.ts
+++ b/server/data/statementsClient.ts
@@ -295,7 +295,8 @@ export default class StatementsClient {
 
   async getRemovalRequest(statementId: number): Promise<RemovalRequest> {
     const isRemovalRequested = `(select count(*) from "v_statement" s
-    where s.removal_requested_date is not null) > 0`
+                      where s.id = $1
+                      and s.removal_requested_date is not null) > 0`
 
     const { rows } = await this.query({
       text: `select removal_requested_reason "removalRequestedReason"

--- a/server/data/statementsClientTypes.ts
+++ b/server/data/statementsClientTypes.ts
@@ -60,4 +60,7 @@ export type ReviewerStatement = {
   submittedDate: Date
 }
 
-export type RemovalRequestedReason = { removalRequestedReason: string }
+export type RemovalRequest = {
+  isRemovalRequested: boolean
+  removalRequestedReason: string
+}

--- a/server/routes/maintainingReports/coordinator.test.ts
+++ b/server/routes/maintainingReports/coordinator.test.ts
@@ -453,7 +453,10 @@ describe('coordinator', () => {
           userId: 'someUserId',
           email: '',
         })
-        involvedStaffService.getInvolvedStaffRemovalRequestedReason.mockResolvedValue('')
+        involvedStaffService.getInvolvedStaffRemovalRequest.mockResolvedValue({
+          isRemovalRequested: true,
+          removalRequestedReason: 'I was not there',
+        })
         userService.getUserLocation.mockResolvedValue('Leeds')
         userSupplier.mockReturnValue(coordinatorUser)
 
@@ -465,7 +468,7 @@ describe('coordinator', () => {
           })
 
         expect(involvedStaffService.loadInvolvedStaff).toBeCalledWith(123, 2)
-        expect(involvedStaffService.getInvolvedStaffRemovalRequestedReason).toBeCalledWith(2)
+        expect(involvedStaffService.getInvolvedStaffRemovalRequest).toBeCalledWith(2)
         expect(userService.getUserLocation).toBeCalledWith('user1-system-token', 'someUserId')
       })
     })
@@ -545,6 +548,25 @@ describe('coordinator', () => {
             expect(res.text).toContain('Bob Smith')
             expect(res.text).toContain('bob@gmail.com')
           })
+      })
+      it('should redirect to view-statements because removal_requested_date is null', async () => {
+        userSupplier.mockReturnValue(coordinatorUser)
+        involvedStaffService.loadInvolvedStaff.mockResolvedValue({
+          statementId: 2,
+          name: 'Bob Smith',
+          userId: 'someUserId',
+          email: 'bob@gmail.com',
+        })
+
+        involvedStaffService.getInvolvedStaffRemovalRequest.mockResolvedValue({
+          isRemovalRequested: false,
+          removalRequestedReason: '',
+        })
+
+        await request(app)
+          .get(paths.viewRemovalRequest(123, 2))
+          .expect(302)
+          .expect('Location', paths.viewStatements(123))
       })
     })
   })

--- a/server/routes/maintainingReports/coordinator.ts
+++ b/server/routes/maintainingReports/coordinator.ts
@@ -44,7 +44,7 @@ export default class CoordinatorRoutes {
     const errors = req.flash('errors')
 
     if (!removalRequest.isRemovalRequested) {
-      return res.redirect(paths.viewStatements(reportId))
+      return res.redirect(paths.viewStatements(parseInt(reportId, 10)))
     }
     return res.render('pages/coordinator/view-removal-request.html', { data, errors })
   }

--- a/server/routes/maintainingReports/coordinator.ts
+++ b/server/routes/maintainingReports/coordinator.ts
@@ -29,9 +29,9 @@ export default class CoordinatorRoutes {
   viewRemovalRequest: RequestHandler = async (req, res) => {
     const { reportId, statementId } = req.params
     const token = await this.systemToken(res.locals.user.username)
-    const [{ name, userId, email }, removalReason] = await Promise.all([
+    const [{ name, userId, email }, removalRequest] = await Promise.all([
       this.involvedStaffService.loadInvolvedStaff(parseInt(reportId, 10), parseInt(statementId, 10)),
-      this.involvedStaffService.getInvolvedStaffRemovalRequestedReason(parseInt(statementId, 10)),
+      this.involvedStaffService.getInvolvedStaffRemovalRequest(parseInt(statementId, 10)),
     ])
     const location = await this.userService.getUserLocation(token, userId)
     const data = {
@@ -39,10 +39,14 @@ export default class CoordinatorRoutes {
       userId,
       location,
       email,
-      removalReason,
+      removalReason: removalRequest.removalRequestedReason,
     }
     const errors = req.flash('errors')
-    res.render('pages/coordinator/view-removal-request.html', { data, errors })
+
+    if (!removalRequest.isRemovalRequested) {
+      return res.redirect(paths.viewStatements(reportId))
+    }
+    return res.render('pages/coordinator/view-removal-request.html', { data, errors })
   }
 
   submitRemovalRequest: RequestHandler = async (req, res) => {

--- a/server/services/involvedStaffService.test.ts
+++ b/server/services/involvedStaffService.test.ts
@@ -56,15 +56,19 @@ describe('getInvolvedStaff', () => {
   })
 })
 
-describe('getInvolvedStaffRemovalRequestedReason', () => {
+describe('getInvolvedStaffRemovalRequest', () => {
   test('it should call query on db and return removal requested reason', async () => {
-    statementsClient.getRemovalRequestedReasonByStatementId.mockResolvedValue({
-      removalRequestedReason: 'reason',
+    statementsClient.getRemovalRequest.mockResolvedValue({
+      isRemovalRequested: true,
+      removalRequestedReason: 'Some reason',
     })
 
-    await expect(service.getInvolvedStaffRemovalRequestedReason(1)).resolves.toBe('reason')
+    await expect(service.getInvolvedStaffRemovalRequest(1)).resolves.toStrictEqual({
+      isRemovalRequested: true,
+      removalRequestedReason: 'Some reason',
+    })
 
-    expect(statementsClient.getRemovalRequestedReasonByStatementId).toBeCalledWith(1)
+    expect(statementsClient.getRemovalRequest).toBeCalledWith(1)
   })
 })
 

--- a/server/services/involvedStaffService.ts
+++ b/server/services/involvedStaffService.ts
@@ -5,6 +5,7 @@ import type { IncidentClient, StatementsClient } from '../data'
 import type { InTransaction } from '../data/dataAccess/db'
 import type UserService from './userService'
 import { InvolvedStaff } from '../data/incidentClientTypes'
+import { RemovalRequest } from '../data/statementsClientTypes'
 
 export enum AddStaffResult {
   SUCCESS = 'success',
@@ -26,9 +27,9 @@ export class InvolvedStaffService {
     return this.incidentClient.getInvolvedStaff(reportId)
   }
 
-  public async getInvolvedStaffRemovalRequestedReason(statementId: number): Promise<string> {
-    const reason = await this.statementsClient.getRemovalRequestedReasonByStatementId(statementId)
-    return reason.removalRequestedReason
+  public async getInvolvedStaffRemovalRequest(statementId: number): Promise<RemovalRequest> {
+    const removalRequest = await this.statementsClient.getRemovalRequest(statementId)
+    return removalRequest
   }
 
   public async loadInvolvedStaff(reportId: number, statementId: number): Promise<InvolvedStaff> {


### PR DESCRIPTION
This ticket was about preventing the coordinator landing on the /vew-removal-request page if they had already decided to disallow an involved member's request to be removed from the report. 
The normal flow is /view-statements —> /view-removal-request —> /staff-member-not-removed

The /staff-member-not-removed page contains a hyperlink to return back to /view-statements  but if the coordinator chooses to use the browser back button instead, the browser will try to return to /view-removal-request. We want to prevent this. So in all cases the return from /staff-member-not-removed should be to  /view-statements

There are 2 data items in the DB to indicate a current removal request: the removal_requested_date and the removal_requested_reason. If a coordinator is on the /staff-member-not-removed page, then they are rejecting the users request. Hence the removal_requested_date and reason are nulled. 
Have just used the presence/absence of the removal_requested_date to determine the page to display if user uses the browser back button. 

There aren’t any new cypress integration tests because there is no way to mimic a browser back action