### PR TITLE
DCS-895 added breadcrumbs

### DIFF
--- a/server/views/macros.njk
+++ b/server/views/macros.njk
@@ -14,3 +14,9 @@
 {% macro removalRequestedBadge(props) %}
 <span data-qa="{{props.qa}}" class="moj-badge moj-badge--bright-purple {{props.class}}">{{props.text}}</span>
 {% endmacro %}
+
+{% macro exitLink(props) %}
+    <div class="govuk-grid-column-full">
+        <a href="{{ links.exitUrl }}" class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" data-qa="{{props.qa}}">Exit to Digital Prison Services</a>
+    </div>
+{% endmacro %}

--- a/server/views/pages/report-use-of-force.html
+++ b/server/views/pages/report-use-of-force.html
@@ -1,6 +1,14 @@
 {% extends "../partials/layout.html" %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% set pageTitle = 'Report use of force' %}
+
+{% block beforeContent %}
+    {{ govukBackLink({
+        text: "Digital Prison Services",
+        href: links.exitUrl
+      }) }}
+{% endblock %}
 
 {% macro section(name, label, url, value) %}
 <li class="app-task-list__item" data-qa-{{name}}={{value}}>

--- a/server/views/pages/reviewer/view-report.html
+++ b/server/views/pages/reviewer/view-report.html
@@ -6,6 +6,10 @@
 
 {% set pageTitle = 'Use of force report' %}
 
+{% block beforeContent %}
+  {% include "../../partials/breadcrumbs.njk" %}
+{% endblock %}
+
 {% block content %}
 <div class="govuk-grid-row govuk-body">
   <div class="govuk-grid-column-three-quarters govuk-!-margin-bottom-9 ">

--- a/server/views/pages/reviewer/view-statements.html
+++ b/server/views/pages/reviewer/view-statements.html
@@ -6,6 +6,10 @@
 {% import "../reportDetailMacro.njk" as reportDetail %} 
 {% set pageTitle = 'Use of force incident' %}
 
+{% block beforeContent %}
+  {% include "../../partials/breadcrumbs.njk" %}
+{% endblock %}
+
 {% block content %}
 <div class="govuk-body">
   <div class="govuk-grid-row no-print">     

--- a/server/views/pages/statement/add-comment-to-statement.html
+++ b/server/views/pages/statement/add-comment-to-statement.html
@@ -10,6 +10,10 @@
 
 {% set pageTitle = 'Add a comment to your statement' %}
 
+{% block beforeContent %}
+  {% include "../../partials/breadcrumbs.njk" %}
+{% endblock %}
+
 {% block content %}
 <div class="govuk-body">
   {% if errors.length > 0 %}

--- a/server/views/pages/statement/write-your-statement.html
+++ b/server/views/pages/statement/write-your-statement.html
@@ -17,6 +17,10 @@
 {% set lastTrainingYearClass = 'govuk-!-margin-left-5 govuk-input--width-4' %}
 {% endif %}
 
+{% block beforeContent %}
+  {% include "../../partials/breadcrumbs.njk" %}
+{% endblock %}
+
 {% block content %}
 <div class="govuk-body">
   {% if errors.length > 0 %}

--- a/server/views/pages/statement/your-statement.html
+++ b/server/views/pages/statement/your-statement.html
@@ -10,6 +10,10 @@
 
 {% set pageTitle = 'Your use of force statement' %}
 
+{% block beforeContent %}
+  {% include "../../partials/breadcrumbs.njk" %}
+{% endblock %}
+
 {% block content %}
 
 <div class="govuk-body">

--- a/server/views/pages/your-report.html
+++ b/server/views/pages/your-report.html
@@ -6,6 +6,10 @@
 
 {% set pageTitle = 'Use of force report' %}
 
+{% block beforeContent %}
+  {% include "../partials/breadcrumbs.njk" %}
+{% endblock %}
+
 {% block content %}
 <div class="govuk-grid-row govuk-body">
   <div class="govuk-grid-column-three-quarters govuk-!-margin-bottom-9 no-print">

--- a/server/views/partials/breadcrumbs.njk
+++ b/server/views/partials/breadcrumbs.njk
@@ -1,0 +1,16 @@
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+
+  {{ govukBreadcrumbs({
+    items: [
+      {
+        text: "Digital Prison Services",
+        href: links.exitUrl
+      },
+      {
+        text: "Use of force incidents",
+        href: "/not-completed-incidents"
+      }
+    ],
+    classes: "govuk-!-display-none-print"
+  }) }}
+  

--- a/server/views/partials/incidentPage.html
+++ b/server/views/partials/incidentPage.html
@@ -1,17 +1,14 @@
 {% extends "./layout.html" %} 
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from  "../macros.njk" import exitLink %}   
 
 {% set pageTitle = 'Use of force incidents' %}
 
-{% macro exitLink(qa) %}
-    <div class="govuk-grid-column-full">
-        <a href="{{ links.exitUrl }}" class="govuk-link govuk-link--no-visited-state govuk-!-font-size-19" data-qa="{{qa}}">Exit to Digital Prison Services</a>
-    </div>
-{% endmacro %}
-
 {% block beforeContent %}
-    <div class="govuk-grid-row">
-        {{ exitLink("exit-to-dps-link-top") }}
-    </div>    
+    {{ govukBackLink({
+        text: "Digital Prison Services",
+        href: links.exitUrl
+      }) }}
 {% endblock %}
 
 {% block content %}
@@ -55,7 +52,11 @@
         {% block tabContent %}
         {% endblock %}
         <div class="govuk-grid-row govuk-!-margin-top-4">
-            {{ exitLink("exit-to-dps-link") }}
+            {{ 
+                exitLink({
+                  qa: 'exit-to-dps-link' 
+                }) 
+              }}  
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
Added back link to Digital Prison Services on the page showing Not Completed, Completed, Your statements and Your reports tabs as well (as the report use of force page):
<img width="1211" alt="Screenshot 2021-04-27 at 11 06 38" src="https://user-images.githubusercontent.com/48809053/116224606-be78be00-a748-11eb-84f1-dc2f0b6cd5f7.png">

Added 'Digital Prison Services > Use of force incidents' breadcrumb path to lower level incident pages:
<img width="1219" alt="Screenshot 2021-04-27 at 11 06 51" src="https://user-images.githubusercontent.com/48809053/116224574-b587ec80-a748-11eb-88ae-785232a33a47.png">

Do we need integration tests to check these links (back link and breadcrumbs) work as they should? 