### PR TITLE
DCS-1001-bugfix for username

### DIFF
--- a/server/services/involvedStaffService.test.ts
+++ b/server/services/involvedStaffService.test.ts
@@ -81,7 +81,7 @@ describe('update', () => {
       email: 'an@email',
       name: 'Bob Smith',
       staffId: 3,
-      username: 'Bob',
+      username: 'BOB',
       exists: true,
       verified: true,
       activeCaseLoadId: 'MDI',
@@ -132,6 +132,12 @@ describe('update', () => {
       expect(incidentClient.changeStatus).not.toBeCalled()
     })
 
+    test('passes correctly formatted arguments to statements client', async () => {
+      incidentClient.getReportForReviewer.mockResolvedValue({} as Report)
+
+      await service.addInvolvedStaff('token1', 1, 'Bob')
+      expect(statementsClient.isStatementPresentForUser).toBeCalledWith(1, 'BOB')
+    })
     test('when user already has a statement', async () => {
       incidentClient.getReportForReviewer.mockResolvedValue({
         submittedDate: reportSubmittedDate,
@@ -140,10 +146,12 @@ describe('update', () => {
 
       statementsClient.isStatementPresentForUser.mockResolvedValue(true)
 
-      await expect(service.addInvolvedStaff('token1', 1, 'Bob')).resolves.toBe(AddStaffResult.ALREADY_EXISTS)
+      const result = await service.addInvolvedStaff('token1', 1, 'Bob')
+      expect(result).toBe(AddStaffResult.ALREADY_EXISTS)
 
       expect(statementsClient.createStatements).not.toBeCalled()
       expect(incidentClient.changeStatus).not.toBeCalled()
+      expect(result).toBe('already-exists')
     })
 
     test('when user is unverified', async () => {

--- a/server/services/involvedStaffService.ts
+++ b/server/services/involvedStaffService.ts
@@ -66,7 +66,7 @@ export class InvolvedStaffService {
       throw new Error(`Report: '${reportId}' does not exist`)
     }
 
-    if (await this.statementsClient.isStatementPresentForUser(reportId, username)) {
+    if (await this.statementsClient.isStatementPresentForUser(reportId, foundUser.username)) {
       return AddStaffResult.ALREADY_EXISTS
     }
 


### PR DESCRIPTION
Application error if coordinator attempted to add an involved staff who was already in the report. Error only happened if the username was input in lower or mixed case rather than all uppercase.
Fix was to supply the uppercased username string when checking if user was already in the report.