### PR TITLE
DCS-1094: code refactored to move filtering to DB query

### DIFF
--- a/server/data/draftReportClient.test.ts
+++ b/server/data/draftReportClient.test.ts
@@ -130,11 +130,16 @@ test('getDuplicateReports', () => {
   draftReportClient.getDuplicateReports(1, [startDate, endDate])
 
   expect(query).toBeCalledWith({
-    text: `select r.incident_date date, r.form_response form, r.reporter_name reporter, r.status status
-              from v_report r where r.booking_id >= $1
+    text: `select r.incident_date date
+              ,   r.form_response -> 'incidentDetails' ->> 'locationId' "locationId"
+              ,   r.reporter_name reporter
+              ,   r.status status
+              from v_report r
+              where r.booking_id >= $1
               and r.incident_date >= $2
-              and r.incident_date <= $3`,
-    values: [1, startDate, endDate],
+              and r.incident_date <= $3
+              and r.status != $4`,
+    values: [1, startDate, endDate, ReportStatus.IN_PROGRESS.value],
   })
 })
 

--- a/server/data/draftReportClient.ts
+++ b/server/data/draftReportClient.ts
@@ -93,11 +93,16 @@ export default class DraftReportClient {
 
   async getDuplicateReports(bookingId: number, [startDate, endDate]: DateRange): Promise<OffenderReport[]> {
     const results = await this.query({
-      text: `select r.incident_date date, r.form_response form, r.reporter_name reporter, r.status status
-              from v_report r where r.booking_id >= $1
+      text: `select r.incident_date date
+              ,   r.form_response -> 'incidentDetails' ->> 'locationId' "locationId"
+              ,   r.reporter_name reporter
+              ,   r.status status
+              from v_report r
+              where r.booking_id >= $1
               and r.incident_date >= $2
-              and r.incident_date <= $3`,
-      values: [bookingId, startDate, endDate],
+              and r.incident_date <= $3
+              and r.status != $4`,
+      values: [bookingId, startDate, endDate, ReportStatus.IN_PROGRESS.value],
     })
     return results.rows
   }

--- a/server/data/draftReportClientTypes.ts
+++ b/server/data/draftReportClientTypes.ts
@@ -18,9 +18,7 @@ export interface StaffDetails {
 
 export type OffenderReport = {
   date: moment.Moment
-  form: {
-    incidentDetails: Record<string, number>
-  }
+  locationId: number
   reporter: string
   status: string
 }

--- a/server/routes/creatingReports/incidentDetails.test.ts
+++ b/server/routes/creatingReports/incidentDetails.test.ts
@@ -291,7 +291,7 @@ describe('POST save and return to tasklist', () => {
       })
   })
 
-  test('Submitting without incident date is allowed', () => {
+  test('Submitting an update to a draft report without an incident date is allowed', () => {
     return request(app)
       .post(`/report/1/incident-details`)
       .send({

--- a/server/services/drafts/draftReportService.test.ts
+++ b/server/services/drafts/draftReportService.test.ts
@@ -315,9 +315,7 @@ describe('getPotentialDuplicates', () => {
     const dbMock = [
       {
         date: moment('10/07/2021', 'DDMMYYYY'),
-        form: {
-          incidentDetails: {},
-        },
+        locationId: 1,
         reporter: 'Bob',
         status: 'SUBMITTED',
       },
@@ -333,19 +331,15 @@ describe('getPotentialDuplicates', () => {
     const mockCurrentReports = [
       {
         date: moment('2021-10-07'),
-        form: {
-          incidentDetails: {},
-        },
+        locationId: 1,
         reporter: 'Bob',
         status: 'SUBMITTED',
       },
       {
         date: moment('2021-10-07'),
-        form: {
-          incidentDetails: {},
-        },
+        locationId: 1,
         reporter: 'Harry',
-        status: 'IN_PROGRESS',
+        status: 'COMPLETED',
       },
     ]
     draftReportClient.getDuplicateReports.mockResolvedValue(mockCurrentReports)
@@ -356,6 +350,11 @@ describe('getPotentialDuplicates', () => {
         date: moment('2021-10-07'),
         location: 'Room A',
         reporter: 'Bob',
+      },
+      {
+        date: moment('2021-10-07'),
+        location: 'Room A',
+        reporter: 'Harry',
       },
     ])
   })

--- a/server/services/drafts/draftReportService.ts
+++ b/server/services/drafts/draftReportService.ts
@@ -132,16 +132,14 @@ export default class DraftReportService {
     const endDate = moment(incidentDate).endOf('day')
     const reports = await this.draftReportClient.getDuplicateReports(bookingId, [startDate, endDate])
     return Promise.all(
-      reports
-        .filter(report => report.status !== ReportStatus.IN_PROGRESS.value)
-        .map(async r => {
-          const location = await this.locationService.getLocation(token, r.form.incidentDetails.locationId)
-          return {
-            reporter: r.reporter,
-            date: moment(r.date),
-            location: location?.userDescription?.toString(),
-          }
-        })
+      reports.map(async r => {
+        const location = await this.locationService.getLocation(token, r.locationId)
+        return {
+          reporter: r.reporter,
+          date: moment(r.date),
+          location: location?.userDescription?.toString(),
+        }
+      })
     )
   }
 


### PR DESCRIPTION
1. moved filtering out in-progress reports from the draft report service to the db client which also now returns the locationId rather than its parent object, to simplify code
2. renamed a test that suggested reports could be saved without an incident date. In fact the code was related
to updating an existing draft report. Reentering a date is not mandatory as it may be the user wants to change other values instead. Test description now reflects this.