### PR TITLE
DCS-1116 sorted prison list on Search for a prisoner page

### DIFF
--- a/server/services/prisonerSearchService.test.ts
+++ b/server/services/prisonerSearchService.test.ts
@@ -60,5 +60,20 @@ describe('prisonerSearchService', () => {
       expect(results).toStrictEqual(expected)
       expect(prisonClientBuilder).toBeCalledWith('user1-token-1')
     })
+
+    it('sorts lists of Prisons alphabetically', async () => {
+      const unsortedPrisonList = [
+        { agencyId: 'RSI', description: 'HMP Risley' },
+        { agencyId: 'MDI', description: 'HMP Moorlands' },
+        { agencyId: 'LEI', description: 'HMP Leeds' },
+      ] as Prison[]
+      prisonClient.getPrisons.mockResolvedValue(unsortedPrisonList)
+      const results = await service.getPrisons('user1')
+      expect(results).toStrictEqual([
+        { agencyId: 'LEI', description: 'HMP Leeds' },
+        { agencyId: 'MDI', description: 'HMP Moorlands' },
+        { agencyId: 'RSI', description: 'HMP Risley' },
+      ])
+    })
   })
 })

--- a/server/services/prisonerSearchService.ts
+++ b/server/services/prisonerSearchService.ts
@@ -28,7 +28,9 @@ export default class PrisonerSearchService {
   private async getPrisonsUsing(token: string): Promise<Prison[]> {
     const client = this.prisonClientBuilder(token)
     const prisons = await client.getPrisons()
-    return prisons.map(({ agencyId, description }) => ({ agencyId, description }))
+    return prisons
+      .map(({ agencyId, description }) => ({ agencyId, description }))
+      .sort((a, b) => a.description.localeCompare(b.description))
   }
 
   private async createPrisonNameLookup(token: string): Promise<(agencyId: string) => string> {


### PR DESCRIPTION
When a user searches for a prisoner via caseload on the Search for a prisoner page the list of prisons is now ordered alphabetically.

Previously unsorted:
<img width="784" alt="Screenshot 2021-08-04 at 16 02 59" src="https://user-images.githubusercontent.com/48809053/128205137-21fb1fb6-78c0-4f82-8c0b-6d123668c436.png">

Now sorted:
<img width="824" alt="Screenshot 2021-08-04 at 16 02 40" src="https://user-images.githubusercontent.com/48809053/128205186-d3f32c54-9d22-4740-ad8a-c8fb44cf91ab.png">