### PR TITLE
DCS-1135 fix for feedback survey link

### DIFF
--- a/server/middleware/populateCurrentUser.js
+++ b/server/middleware/populateCurrentUser.js
@@ -1,16 +1,16 @@
 const logger = require('../../log')
 
 module.exports = userService => async (req, res, next) => {
+  res.locals = {
+    ...res.locals,
+    currentUrlPath: req.baseUrl + req.path,
+    hostname: req.hostname,
+  }
   try {
     const user = res.locals.user && (await userService.getSelf(res.locals.user.token))
 
     if (user) {
       res.locals.user = { ...user, ...res.locals.user }
-      res.locals = {
-        ...res.locals,
-        currentUrlPath: req.baseUrl + req.path,
-        hostname: req.hostname,
-      }
     } else {
       logger.info('No user available')
     }


### PR DESCRIPTION
If non prison users log into UoF and try to access the feedback survey link the link is missing hostname and current url path information as this was only set when a current prison user is present. Updated populate current user middleware to set these parameters whether a user is present or not as a short term fix. Maybe in the future UoF should not allow non prison users to access it.  
<img width="366" alt="Screenshot 2021-08-05 at 10 43 05" src="https://user-images.githubusercontent.com/48809053/128334617-d96bd07c-f93b-46f4-ab97-9b06bfd5f747.png">
