### PR TITLE
DCS-1341 update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "@types/hapi__joi": "^17.1.7",
         "@types/http-errors": "^1.8.1",
         "@types/jest": "^27.0.2",
+        "@types/node": "^16.11.7",
         "@types/nunjucks": "^3.2.0",
         "@types/pg": "8.6.1",
         "@types/superagent": "^4.1.13",
@@ -93,8 +94,8 @@
         "typescript": "^4.4.4"
       },
       "engines": {
-        "node": "^14.*",
-        "npm": "^7.5.*"
+        "node": "^16",
+        "npm": "^7"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -3146,9 +3147,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "12.6.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.9.tgz",
-      "integrity": "sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw=="
+      "version": "16.11.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.12.tgz",
+      "integrity": "sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.5.12",
@@ -7236,7 +7237,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -18066,9 +18066,9 @@
       }
     },
     "@types/node": {
-      "version": "12.6.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.9.tgz",
-      "integrity": "sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw=="
+      "version": "16.11.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.12.tgz",
+      "integrity": "sha512-+2Iggwg7PxoO5Kyhvsq9VarmPbIelXP070HMImEpbtGCoyWNINQj4wzjbQCXzdHTRXnqufutJb5KAURZANNBAw=="
     },
     "@types/node-fetch": {
       "version": "2.5.12",
@@ -21233,7 +21233,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "optional": true
     },
     "function-bind": {


### PR DESCRIPTION
fix
```
+-------------+------------------+----------+-------------------+---------------+--------------------------------------+
|   LIBRARY   | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |                TITLE                 |
+-------------+------------------+----------+-------------------+---------------+--------------------------------------+
| json-schema | CVE-2021-3918    | CRITICAL | 0.2.3             | 0.4.0         | nodejs-json-schema: Prototype        |
|             |                  |          |                   |               | pollution vulnerability              |
|             |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-3918 |
+-------------+------------------+----------+-------------------+---------------+--------------------------------------+
```
and 

```npm ERR! Invalid: lock file's @types/node@12.6.9 does not satisfy @types/node@^16.11.7```

in trivy and security scans