### PR TITLE
⬆️ DCS-1374: update hmpps-circle-orb version to 3.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ parameters:
     default: 16.13-browsers
 
 orbs:
-  hmpps: ministryofjustice/hmpps@3.11
+  hmpps: ministryofjustice/hmpps@3.12
 
 executors:
   integration-tests:


### PR DESCRIPTION
⬆️ DCS-1374: update hmpps-circle-orb version to 3.12