### PR TITLE
User location displayed as title case

### DIFF
--- a/integration-tests/pages/sections/reportDetails.js
+++ b/integration-tests/pages/sections/reportDetails.js
@@ -37,7 +37,7 @@ module.exports = {
 
     prison().contains('Moorland')
 
-    cy.get('[data-qa="location"]').contains('ASSO A WING')
+    cy.get('[data-qa="location"]').contains('ASSO A Wing')
     useOfForcePlanned().contains('Yes')
     authorisedBy().contains('Eric Bloodaxe')
 

--- a/server/data/prisonClient.test.ts
+++ b/server/data/prisonClient.test.ts
@@ -116,7 +116,7 @@ describe('prisonClient', () => {
         .reply(404)
 
       const output = await prisonClient.getLocation(123)
-      expect(output).toStrictEqual({})
+      expect(output).toStrictEqual(undefined)
     })
   })
 

--- a/server/data/prisonClient.ts
+++ b/server/data/prisonClient.ts
@@ -59,16 +59,15 @@ export default class PrisonClient {
     })
   }
 
-  async getLocation(locationId: number): Promise<PrisonLocation | Record<string, unknown>> {
-    let location = {}
+  async getLocation(locationId: number): Promise<PrisonLocation> {
     try {
-      location = await this.restClient.get({ path: `/api/locations/${locationId}?includeInactive=true` })
+      return await this.restClient.get({ path: `/api/locations/${locationId}?includeInactive=true` })
     } catch (error) {
       if (error?.status !== 404) {
         throw error
       }
+      return undefined
     }
-    return location
   }
 
   getOffenderImage(bookingId: number): Promise<Readable> {

--- a/server/routes/creatingReports/checkYourAnswers.test.ts
+++ b/server/routes/creatingReports/checkYourAnswers.test.ts
@@ -1,5 +1,5 @@
 import request from 'supertest'
-import { Prison } from '../../data/prisonClientTypes'
+import { Prison, PrisonLocation } from '../../data/prisonClientTypes'
 import LocationService from '../../services/locationService'
 import OffenderService from '../../services/offenderService'
 import DraftReportService from '../../services/drafts/draftReportService'
@@ -189,6 +189,21 @@ describe('GET /check-your-answers', () => {
       })
       .expect(res => {
         expect(res.text).toContain('Sheffield')
+      })
+  })
+
+  it('Should match location format', () => {
+    draftReportService.getReportStatus.mockReturnValue({ complete: true })
+    locationService.getLocation.mockResolvedValue({
+      description: 'VCC VISITS',
+      userDescription: 'VCC Visits',
+    } as PrisonLocation)
+    return request(app)
+      .get('/report/-35/check-your-answers')
+      .expect(200)
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain('VCC Visits')
       })
   })
 })

--- a/server/routes/creatingReports/checkYourAnswers.test.ts
+++ b/server/routes/creatingReports/checkYourAnswers.test.ts
@@ -28,7 +28,7 @@ beforeEach(() => {
   draftReportService.getCurrentDraft.mockResolvedValue({ id: 1, form: { incidentDetails: {} } })
 
   offenderService.getOffenderDetails.mockResolvedValue({})
-  locationService.getLocation.mockResolvedValue({})
+  locationService.getLocation.mockResolvedValue('')
   locationService.getPrisonById.mockResolvedValue({ description: 'prison name' } as Prison)
   draftReportService.getInvolvedStaff.mockResolvedValue([])
 })
@@ -194,10 +194,7 @@ describe('GET /check-your-answers', () => {
 
   it('Should match location format', () => {
     draftReportService.getReportStatus.mockReturnValue({ complete: true })
-    locationService.getLocation.mockResolvedValue({
-      description: 'VCC VISITS',
-      userDescription: 'VCC Visits',
-    } as PrisonLocation)
+    locationService.getLocation.mockResolvedValue('VCC Visits')
     return request(app)
       .get('/report/-35/check-your-answers')
       .expect(200)

--- a/server/routes/creatingReports/checkYourAnswers.ts
+++ b/server/routes/creatingReports/checkYourAnswers.ts
@@ -32,10 +32,7 @@ export default class CheckAnswerRoutes {
 
     const offenderDetail = await this.offenderService.getOffenderDetails(token, parseInt(bookingId, 10))
 
-    const { userDescription: locationDescription = '' } = await this.locationService.getLocation(
-      token,
-      form.incidentDetails.locationId
-    )
+    const locationDescription = await this.locationService.getLocation(token, form.incidentDetails.locationId)
 
     const draftInvolvedStaff = await this.draftReportService.getInvolvedStaff(
       token,
@@ -50,14 +47,7 @@ export default class CheckAnswerRoutes {
 
     const prison = await this.locationService.getPrisonById(token, prisonId)
 
-    const data = reportSummary(
-      form,
-      offenderDetail,
-      prison,
-      locationDescription.toString(),
-      involvedStaff,
-      incidentDate
-    )
+    const data = reportSummary(form, offenderDetail, prison, locationDescription, involvedStaff, incidentDate)
 
     return res.render('pages/check-your-answers', { data, bookingId })
   }

--- a/server/routes/creatingReports/checkYourAnswers.ts
+++ b/server/routes/creatingReports/checkYourAnswers.ts
@@ -32,7 +32,7 @@ export default class CheckAnswerRoutes {
 
     const offenderDetail = await this.offenderService.getOffenderDetails(token, parseInt(bookingId, 10))
 
-    const { description: locationDescription = '' } = await this.locationService.getLocation(
+    const { userDescription: locationDescription = '' } = await this.locationService.getLocation(
       token,
       form.incidentDetails.locationId
     )

--- a/server/services/drafts/draftReportService.test.ts
+++ b/server/services/drafts/draftReportService.test.ts
@@ -343,7 +343,7 @@ describe('getPotentialDuplicates', () => {
       },
     ]
     draftReportClient.getDuplicateReports.mockResolvedValue(mockCurrentReports)
-    locationService.getLocation.mockResolvedValue({ userDescription: 'Room A' })
+    locationService.getLocation.mockResolvedValue('Room A')
     const results = await service.getPotentialDuplicates(1, moment('2021-10-07'), 'USER-1')
     await expect(results).toStrictEqual([
       {

--- a/server/services/drafts/draftReportService.ts
+++ b/server/services/drafts/draftReportService.ts
@@ -136,7 +136,7 @@ export default class DraftReportService {
         return {
           reporter: r.reporter,
           date: moment(r.date),
-          location: location?.userDescription?.toString(),
+          location,
         }
       })
     )

--- a/server/services/locationService.ts
+++ b/server/services/locationService.ts
@@ -17,12 +17,13 @@ export default class LocationService {
     return prisonClient.getPrisonById(agencyId)
   }
 
-  async getLocation(token: string, locationId: number): Promise<PrisonLocation | Record<string, unknown>> {
+  async getLocation(token: string, locationId: number): Promise<string> {
     if (!locationId) {
-      return Promise.resolve({})
+      return ''
     }
     const prisonClient = this.prisonClientBuilder(token)
-    return prisonClient.getLocation(locationId)
+    const { userDescription, locationPrefix } = (await prisonClient.getLocation(locationId)) || {}
+    return userDescription || locationPrefix || ''
   }
 
   async getIncidentLocations(token: string, agencyId: AgencyId): Promise<PrisonLocation[]> {

--- a/server/services/reportDetailBuilder.test.ts
+++ b/server/services/reportDetailBuilder.test.ts
@@ -29,7 +29,7 @@ afterEach(() => {
 
 describe('Build details', () => {
   it('succeeds', async () => {
-    locationService.getLocation.mockResolvedValue({ userDescription: 'Wing A' })
+    locationService.getLocation.mockResolvedValue('Wing A')
 
     involvedStaffService.getInvolvedStaff.mockResolvedValue([
       { name: 'JANET SMITH', userId: 'J_SMITH', statementId: 22 },

--- a/server/services/reportDetailBuilder.test.ts
+++ b/server/services/reportDetailBuilder.test.ts
@@ -29,7 +29,7 @@ afterEach(() => {
 
 describe('Build details', () => {
   it('succeeds', async () => {
-    locationService.getLocation.mockResolvedValue({ description: 'Wing A' })
+    locationService.getLocation.mockResolvedValue({ userDescription: 'Wing A' })
 
     involvedStaffService.getInvolvedStaff.mockResolvedValue([
       { name: 'JANET SMITH', userId: 'J_SMITH', statementId: 22 },

--- a/server/services/reportDetailBuilder.ts
+++ b/server/services/reportDetailBuilder.ts
@@ -37,7 +37,7 @@ export default class ReportDataBuilder {
 
     const { id, form, username, incidentDate, bookingId, reporterName, submittedDate, agencyId: prisonId } = report
     const offenderDetail = await this.offenderService.getOffenderDetails(token, bookingId)
-    const { description: locationDescription = '' } = await this.locationService.getLocation(
+    const { userDescription: locationDescription = '' } = await this.locationService.getLocation(
       token,
       form.incidentDetails.locationId
     )

--- a/server/services/reportDetailBuilder.ts
+++ b/server/services/reportDetailBuilder.ts
@@ -37,10 +37,7 @@ export default class ReportDataBuilder {
 
     const { id, form, username, incidentDate, bookingId, reporterName, submittedDate, agencyId: prisonId } = report
     const offenderDetail = await this.offenderService.getOffenderDetails(token, bookingId)
-    const { userDescription: locationDescription = '' } = await this.locationService.getLocation(
-      token,
-      form.incidentDetails.locationId
-    )
+    const locationDescription = await this.locationService.getLocation(token, form.incidentDetails.locationId)
     const involvedStaff = await this.involvedStaffService.getInvolvedStaff(id)
     const involvedStaffNameAndUsernames = involvedStaff.map(this.format(id, username))
 
@@ -51,14 +48,7 @@ export default class ReportDataBuilder {
       reporterName,
       submittedDate,
       bookingId,
-      ...reportSummary(
-        form,
-        offenderDetail,
-        prison,
-        locationDescription.toString(),
-        involvedStaffNameAndUsernames,
-        incidentDate
-      ),
+      ...reportSummary(form, offenderDetail, prison, locationDescription, involvedStaffNameAndUsernames, incidentDate),
     }
   }
 }


### PR DESCRIPTION
Amended the location data format to user description rather than all upper case description. Changed in check your answers and report detail sections