### PR TITLE
MAP-114 add notification banner for downtime

### DIFF
--- a/assets/sass/local.sass
+++ b/assets/sass/local.sass
@@ -440,3 +440,6 @@ dt.summary-list__key__wider
 .feedback-banner
   background: $govuk-brand-colour
   padding: govuk-spacing(4) govuk-spacing(6)
+
+.govuk-notification-banner__content > *
+  max-width: 700px; 

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -23,3 +23,4 @@ env:
   EMAIL_LOCATION_URL: https://dev.use-of-force.service.justice.gov.uk
   TOKENVERIFICATION_API_URL: https://token-verification-api-dev.prison.service.justice.gov.uk
   TOKENVERIFICATION_API_ENABLED: true
+  FEATURE_FLAG_OUTAGE_BANNER_ENABLED: false

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -23,6 +23,7 @@ env:
   EMAIL_LOCATION_URL: https://preprod.use-of-force.service.justice.gov.uk
   TOKENVERIFICATION_API_URL: https://token-verification-api-preprod.prison.service.justice.gov.uk
   TOKENVERIFICATION_API_ENABLED: true
+  FEATURE_FLAG_OUTAGE_BANNER_ENABLED: false
 
 allow_list:
   office: "217.33.148.210/32"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -23,6 +23,7 @@ env:
   EMAIL_LOCATION_URL: https://use-of-force.service.justice.gov.uk
   TOKENVERIFICATION_API_URL: https://token-verification-api.prison.service.justice.gov.uk
   TOKENVERIFICATION_API_ENABLED: true
+  FEATURE_FLAG_OUTAGE_BANNER_ENABLED: false
 
 allow_list:
   office: "217.33.148.210/32"

--- a/server/config.js
+++ b/server/config.js
@@ -117,4 +117,5 @@ module.exports = {
     key: get('TAG_MANAGER_KEY', null),
     environment: get('TAG_MANAGER_ENVIRONMENT', ''), // The additional GTM snippet string that configures a non-prod environment
   },
+  featureFlagOutageBannerEnabled: get('FEATURE_FLAG_OUTAGE_BANNER_ENABLED', false, requiredInProduction) === 'true',
 }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -37,6 +37,7 @@ export default function configureNunjucks(app: Express.Application): nunjucks.En
   njkEnv.addGlobal('links', links)
   njkEnv.addGlobal('authUrl', config.apis.oauth2.url)
   njkEnv.addGlobal('apiClientId', config.apis.oauth2.apiClientId)
+  njkEnv.addGlobal('featureFlagOutageBannerEnabled', config.featureFlagOutageBannerEnabled)
 
   // eslint-disable-next-line default-param-last
   njkEnv.addFilter('findError', (array: Error[] = [], formFieldId: string) => {

--- a/server/views/pages/report-use-of-force.html
+++ b/server/views/pages/report-use-of-force.html
@@ -1,5 +1,6 @@
 {% extends "../partials/layout.html" %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% set pageTitle = 'Report use of force' %}
 
@@ -34,7 +35,21 @@
 </p>
 {% endmacro %}
 
+{% set html %}
+<p class="govuk-notification-banner__heading">
+    Maintenance work is planned for 8am on Thursday 20 July.
+    Use of force may be temporarily unavailable.
+</p>
+{% endset %}
+
 {% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+      {{ govukNotificationBanner({
+          html: html
+      }) }}
+  </div>
+</div>
 <div class="govuk-grid-row govuk-body">
   <div class="govuk-grid-column-three-quarters">
     <h1 class="govuk-heading-xl mainHeading  ">{{ pageTitle }}</h1>

--- a/server/views/pages/report-use-of-force.html
+++ b/server/views/pages/report-use-of-force.html
@@ -45,12 +45,12 @@
 {% block content %}
 {% if featureFlagOutageBannerEnabled %}
   <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-          {{ govukNotificationBanner({
-              html: html
-          }) }}
-      </div>
+    <div class="govuk-grid-column-two-thirds">
+        {{ govukNotificationBanner({
+            html: html
+        }) }}
     </div>
+  </div>
 {% endif %}
 <div class="govuk-grid-row govuk-body">
   <div class="govuk-grid-column-three-quarters">

--- a/server/views/pages/report-use-of-force.html
+++ b/server/views/pages/report-use-of-force.html
@@ -43,13 +43,15 @@
 {% endset %}
 
 {% block content %}
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-      {{ govukNotificationBanner({
-          html: html
-      }) }}
-  </div>
-</div>
+{% if featureFlagOutageBannerEnabled %}
+  <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+          {{ govukNotificationBanner({
+              html: html
+          }) }}
+      </div>
+    </div>
+{% endif %}
 <div class="govuk-grid-row govuk-body">
   <div class="govuk-grid-column-three-quarters">
     <h1 class="govuk-heading-xl mainHeading  ">{{ pageTitle }}</h1>

--- a/server/views/partials/incidentPage.html
+++ b/server/views/partials/incidentPage.html
@@ -22,7 +22,7 @@
 
 {% block content %}
     {% if featureFlagOutageBannerEnabled %}
-    <div class="govuk-grid-row">
+        <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
                 {{ govukNotificationBanner({
                     html: html

--- a/server/views/partials/incidentPage.html
+++ b/server/views/partials/incidentPage.html
@@ -21,14 +21,15 @@
 
 
 {% block content %}
-
+    {% if featureFlagOutageBannerEnabled %}
     <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            {{ govukNotificationBanner({
-                html: html
-            }) }}
+            <div class="govuk-grid-column-two-thirds">
+                {{ govukNotificationBanner({
+                    html: html
+                }) }}
+            </div>
         </div>
-    </div>
+    {% endif %}
 
     <h1 class="govuk-heading-xl mainHeading">{{ pageTitle }}</h1>
 

--- a/server/views/partials/incidentPage.html
+++ b/server/views/partials/incidentPage.html
@@ -1,5 +1,6 @@
 {% extends "./layout.html" %} 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% from  "../macros.njk" import exitLink %}   
 
 {% set pageTitle = 'Use of force incidents' %}
@@ -11,7 +12,23 @@
       }) }}
 {% endblock %}
 
+{% set html %}
+<p class="govuk-notification-banner__heading">
+    Maintenance work is planned for 8am on Thursday 20 July.
+    Use of force may be temporarily unavailable.
+</p>
+{% endset %}
+
+
 {% block content %}
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            {{ govukNotificationBanner({
+                html: html
+            }) }}
+        </div>
+    </div>
 
     <h1 class="govuk-heading-xl mainHeading">{{ pageTitle }}</h1>
 


### PR DESCRIPTION
To be deployed to prod 17/7/23
( related to downtime for redis upgrade in prod. See MAP-167 )

FEATURE_FLAG_OUTAGE_BANNER_ENABLED is defaulted to false. Top be set to true directly in  kubernetes deployments either via kubectl or Lens. 

looks like this

<img width="500" alt="Screenshot 2023-07-13 at 12 13 59" src="https://github.com/ministryofjustice/use-of-force/assets/50441412/463bac00-742d-40b0-a60e-28858697f1a9">
