### PR TITLE
MAP-260 update application insights version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@hapi/joi-date": "^2.0.1",
         "@ministryofjustice/frontend": "^1.6.6",
         "agentkeepalive": "^4.3.0",
-        "applicationinsights": "^2.6.0",
+        "applicationinsights": "^2.7.3",
         "applicationinsights-native-metrics": "^0.0.9",
         "bunyan": "^1.8.15",
         "bunyan-format": "^0.2.1",
@@ -130,15 +130,16 @@
       }
     },
     "node_modules/@azure/core-auth": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.4.0.tgz",
-      "integrity": "sha512-HFrcTgmuSuukRf/EdPmqBrc5l6Q5Uu+2TbuhaKbgaCpP2TfAeiNaQPAadxO+CYBRHGUzIDteMAjFspFLDLnKVQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.5.0.tgz",
+      "integrity": "sha512-udzoBuYG1VBoHVohDTrvKjyzel34zt77Bhp7dQntVGGD0ehVq48owENbBG8fIgkHRNUBQH5k1r0hpoMu5L8+kw==",
       "dependencies": {
         "@azure/abort-controller": "^1.0.0",
+        "@azure/core-util": "^1.1.0",
         "tslib": "^2.2.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@azure/core-rest-pipeline": {
@@ -204,15 +205,15 @@
       }
     },
     "node_modules/@azure/opentelemetry-instrumentation-azure-sdk": {
-      "version": "1.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@azure/opentelemetry-instrumentation-azure-sdk/-/opentelemetry-instrumentation-azure-sdk-1.0.0-beta.4.tgz",
-      "integrity": "sha512-bSF2l47Od7kH+u/O67cmQCj5jmNeC+gUNDKr2cMfLBwSqk12T7B4JZQ34viEq2vhLWoKbZO7j6srPmKiSGPzNg==",
+      "version": "1.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@azure/opentelemetry-instrumentation-azure-sdk/-/opentelemetry-instrumentation-azure-sdk-1.0.0-beta.5.tgz",
+      "integrity": "sha512-fsUarKQDvjhmBO4nIfaZkfNSApm1hZBzcvpNbSrXdcUBxu7lRvKsV5DnwszX7cnhLyVOW9yl1uigtRQ1yDANjA==",
       "dependencies": {
         "@azure/core-tracing": "^1.0.0",
         "@azure/logger": "^1.0.0",
         "@opentelemetry/api": "^1.4.1",
-        "@opentelemetry/core": "^1.14.0",
-        "@opentelemetry/instrumentation": "^0.40.0",
+        "@opentelemetry/core": "^1.15.2",
+        "@opentelemetry/instrumentation": "^0.41.2",
         "tslib": "^2.2.0"
       },
       "engines": {
@@ -2891,12 +2892,11 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.15.0.tgz",
-      "integrity": "sha512-GGTS6BytfaN8OgbCUOnxg/a9WVsVUj0484zXHZuBzvIXx7V4Tmkb0IHnnhS7Q0cBLNLgjNuvrCpQaP8fIvO4bg==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.15.2.tgz",
+      "integrity": "sha512-+gBv15ta96WqkHZaPpcDHiaz0utiiHZVfm2YOYSqFGrUaJpPkMoSuLBB58YFQGi6Rsb9EHos84X6X5+9JspmLw==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.15.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/semantic-conventions": "1.15.2"
       },
       "engines": {
         "node": ">=14"
@@ -2906,14 +2906,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.40.0.tgz",
-      "integrity": "sha512-23TzBKPflUS1uEq5SXymnQKQDSda35KvHjnvxdcDQGE+wg6hwDHgScUCWiBmZW4sxAaPcANfs+Wc9B7yDuyT6Q==",
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.41.2.tgz",
+      "integrity": "sha512-rxU72E0pKNH6ae2w5+xgVYZLzc5mlxAbGzF4shxMVK8YC2QQsfN38B2GPbj0jvrKWWNUElfclQ+YTykkNg/grw==",
       "dependencies": {
         "@types/shimmer": "^1.0.2",
-        "import-in-the-middle": "1.3.5",
-        "require-in-the-middle": "^7.1.0",
-        "semver": "^7.3.2",
+        "import-in-the-middle": "1.4.2",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.1",
         "shimmer": "^1.2.1"
       },
       "engines": {
@@ -2924,13 +2924,12 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.15.0.tgz",
-      "integrity": "sha512-Sb8A6ZXHXDlgHv32UNRE3y8McWE3vkb5dsSttYArYa5ZpwjiF5ge0vnnKUUnG7bY0AgF9VBIOORZE8gsrnD2WA==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.15.2.tgz",
+      "integrity": "sha512-xmMRLenT9CXmm5HMbzpZ1hWhaUowQf8UB4jMjFlAxx1QzQcsD3KFNAVX/CAWzFPtllTyTplrA4JrQ7sCH3qmYw==",
       "dependencies": {
-        "@opentelemetry/core": "1.15.0",
-        "@opentelemetry/semantic-conventions": "1.15.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/semantic-conventions": "1.15.2"
       },
       "engines": {
         "node": ">=14"
@@ -2940,14 +2939,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.15.0.tgz",
-      "integrity": "sha512-udt1c9VHipbZwvCPIQR1VLg25Z4AMR/g0X8KmcInbFruGWQ/lptVPkz3yvWAsGSta5yHNQ3uoPwcyCygGnQ6Lg==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.15.2.tgz",
+      "integrity": "sha512-BEaxGZbWtvnSPchV98qqqqa96AOcb41pjgvhfzDij10tkBhIu9m0Jd6tZ1tJB5ZHfHbTffqYVYE0AOGobec/EQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.15.0",
-        "@opentelemetry/resources": "1.15.0",
-        "@opentelemetry/semantic-conventions": "1.15.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/resources": "1.15.2",
+        "@opentelemetry/semantic-conventions": "1.15.2"
       },
       "engines": {
         "node": ">=14"
@@ -2957,12 +2955,9 @@
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.15.0.tgz",
-      "integrity": "sha512-f3wwFrFyCpGrFBrFs7lCUJSCSCGyeKG52c+EKeobs3Dd29M75yO6GYkt6PkYPfDawxSlV5p+4yJPPk8tPObzTQ==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.15.2.tgz",
+      "integrity": "sha512-CjbOKwk2s+3xPIMcd5UNYQzsf+v94RczbdNix9/kQh38WiQkM90sUOi3if8eyHFgiBjBjhwXrA7W3ydiSQP9mw==",
       "engines": {
         "node": ">=14"
       }
@@ -3627,12 +3622,19 @@
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
       "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
-      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-assertions": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
+      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+      "peerDependencies": {
+        "acorn": "^8"
       }
     },
     "node_modules/acorn-jsx": {
@@ -3780,23 +3782,23 @@
       }
     },
     "node_modules/applicationinsights": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.7.0.tgz",
-      "integrity": "sha512-/vV5X6M4TlRA5NxNZAdCE0gukzfK24mb3z18D5Kl/CyIfSVIkafsIji3mK+Zi5q+7dn6H1CkFazlcnLf40anHw==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-2.7.3.tgz",
+      "integrity": "sha512-JY8+kTEkjbA+kAVNWDtpfW2lqsrDALfDXuxOs74KLPu2y13fy/9WB52V4LfYVTVcW1/jYOXjTxNS2gPZIDh1iw==",
       "dependencies": {
-        "@azure/core-auth": "^1.4.0",
+        "@azure/core-auth": "^1.5.0",
         "@azure/core-rest-pipeline": "1.10.1",
         "@azure/core-util": "1.2.0",
-        "@azure/opentelemetry-instrumentation-azure-sdk": "^1.0.0-beta.3",
+        "@azure/opentelemetry-instrumentation-azure-sdk": "^1.0.0-beta.5",
         "@microsoft/applicationinsights-web-snippet": "^1.0.1",
-        "@opentelemetry/api": "^1.0.4",
-        "@opentelemetry/core": "^1.12.0",
-        "@opentelemetry/sdk-trace-base": "^1.12.0",
-        "@opentelemetry/semantic-conventions": "^1.12.0",
+        "@opentelemetry/api": "^1.4.1",
+        "@opentelemetry/core": "^1.15.2",
+        "@opentelemetry/sdk-trace-base": "^1.15.2",
+        "@opentelemetry/semantic-conventions": "^1.15.2",
         "cls-hooked": "^4.2.2",
         "continuation-local-storage": "^3.2.1",
-        "diagnostic-channel": "1.1.0",
-        "diagnostic-channel-publishers": "1.0.6"
+        "diagnostic-channel": "1.1.1",
+        "diagnostic-channel-publishers": "1.0.7"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -4872,8 +4874,7 @@
     "node_modules/cjs-module-lexer": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
-      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
-      "dev": true
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
@@ -5893,27 +5894,19 @@
       }
     },
     "node_modules/diagnostic-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-1.1.0.tgz",
-      "integrity": "sha512-fwujyMe1gj6rk6dYi9hMZm0c8Mz8NDMVl2LB4iaYh3+LIAThZC8RKFGXWG0IML2OxAit/ZFRgZhMkhQ3d/bobQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-1.1.1.tgz",
+      "integrity": "sha512-r2HV5qFkUICyoaKlBEpLKHjxMXATUf/l+h8UZPGBHGLy4DDiY2sOLcIctax4eRnTw5wH2jTMExLntGPJ8eOJxw==",
       "dependencies": {
-        "semver": "^5.3.0"
+        "semver": "^7.5.3"
       }
     },
     "node_modules/diagnostic-channel-publishers": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.6.tgz",
-      "integrity": "sha512-RE5AP4JmEm/CV06gOyFdgWWm3gMNOoXulod2mq4ysiz9s77ZhHb1P1DGrfePHjNOmgvWglhegmj5q8DNtjRrEg==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.7.tgz",
+      "integrity": "sha512-SEECbY5AiVt6DfLkhkaHNeshg1CogdLLANA8xlG/TKvS+XUgvIKl7VspJGYiEdL5OUyzMVnr7o0AwB7f+/Mjtg==",
       "peerDependencies": {
         "diagnostic-channel": "*"
-      }
-    },
-    "node_modules/diagnostic-channel/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/diff": {
@@ -8013,10 +8006,13 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.3.5.tgz",
-      "integrity": "sha512-yzHlBqi1EBFrkieAnSt8eTgO5oLSl+YJ7qaOpUH/PMqQOMZoQ/RmDlwnTLQrwYto+gHYjRG+i/IbsB1eDx32NQ==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.2.tgz",
+      "integrity": "sha512-9WOz1Yh/cvO/p69sxRmhyQwrIGGSp7EIdcb+fFNVi7CzQGQB8U1/1XrKVSbEd/GNOAeM0peJtmi7+qphe7NvAw==",
       "dependencies": {
+        "acorn": "^8.8.2",
+        "acorn-import-assertions": "^1.9.0",
+        "cjs-module-lexer": "^1.2.2",
         "module-details-from-path": "^1.0.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@hapi/joi-date": "^2.0.1",
     "@ministryofjustice/frontend": "^1.6.6",
     "agentkeepalive": "^4.3.0",
-    "applicationinsights": "^2.6.0",
+    "applicationinsights": "^2.7.3",
     "applicationinsights-native-metrics": "^0.0.9",
     "bunyan": "^1.8.15",
     "bunyan-format": "^0.2.1",


### PR DESCRIPTION
updated app insights to 2.7.3

both @opentelemetry/instrumentation and import-in-the-middle are child dependencies of app insights