### PR TITLE
MAP-286 - cypress updated to latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ parameters:
 
   node-version:
     type: string
-    default: ^18.17.1
+    default: 18.17.1
 
 executors:
   integration-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ parameters:
 
   node-version:
     type: string
-    default: 18.12-browsers
+    default: ^18.17.0
 
 executors:
   integration-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ parameters:
 
   node-version:
     type: string
-    default: ^18.17.0
+    default: ^18.17.1
 
 executors:
   integration-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ parameters:
 
   node-version:
     type: string
-    default: 18.17.1
+    default: 18.17.1-browsers
 
 executors:
   integration-tests:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.12-bullseye as builder
+FROM node:18.17.1 as builder
 
 ARG BUILD_NUMBER
 ARG GIT_REF
@@ -24,7 +24,7 @@ RUN CYPRESS_INSTALL_BINARY=0 npm ci --no-audit && \
 
 RUN npm prune --production
 
-FROM node:16.17-bullseye-slim
+FROM node:18.17.1-slim
 LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
 
 # Cache breaking

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -73,5 +73,6 @@ export default defineConfig({
     excludeSpecPattern: '**/!(*.cy).js',
     specPattern: 'integration-tests/integration/**/*.cy.{js,jsx,ts,tsx}',
     supportFile: 'integration-tests/support/index.js',
+    experimentalRunAllSpecs: true,
   },
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "@typescript-eslint/parser": "^5.59.6",
         "audit-ci": "^6.6.1",
         "concurrently": "^7.6.0",
-        "cypress": "^12.17.1",
+        "cypress": "^13.1.0",
         "cypress-multi-reporters": "^1.6.3",
         "dotenv": "^16.3.1",
         "eslint": "^8.40.0",
@@ -2114,9 +2114,9 @@
       }
     },
     "node_modules/@cypress/request": {
-      "version": "2.88.11",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.11.tgz",
-      "integrity": "sha512-M83/wfQ1EkspjkE2lNWNV5ui2Cv7UCv1swW1DqljahbzLVWltcsexQh8jYtuS/vzFXP+HySntGM83ZXA9fn17w==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.0.tgz",
+      "integrity": "sha512-GKFCqwZwMYmL3IBoNeR2MM1SnxRIGERsQOTWeQKoYBt2JLqcqiy7JXqO894FLrpjZYqGxW92MNwRH2BN56obdQ==",
       "dev": true,
       "dependencies": {
         "aws-sign2": "~0.7.0",
@@ -2134,7 +2134,7 @@
         "performance-now": "^2.1.0",
         "qs": "~6.10.3",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
+        "tough-cookie": "^4.1.3",
         "tunnel-agent": "^0.6.0",
         "uuid": "^8.3.2"
       },
@@ -5461,15 +5461,15 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.17.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.1.tgz",
-      "integrity": "sha512-eKfBgO6t8waEyhegL4gxD7tcI6uTCGttu+ZU7y9Hq8BlpMztd7iLeIF4AJFAnbZH1xjX+wwgg4cRKFNSvv3VWQ==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
+      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@cypress/request": "^2.88.11",
+        "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
-        "@types/node": "^14.14.31",
+        "@types/node": "^16.18.39",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",
@@ -5502,6 +5502,7 @@
         "minimist": "^1.2.8",
         "ospath": "^1.2.2",
         "pretty-bytes": "^5.6.0",
+        "process": "^0.11.10",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
         "semver": "^7.5.3",
@@ -5514,7 +5515,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
+        "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
       }
     },
     "node_modules/cypress-multi-reporters": {
@@ -5534,9 +5535,9 @@
       }
     },
     "node_modules/cypress/node_modules/@types/node": {
-      "version": "14.18.53",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.53.tgz",
-      "integrity": "sha512-soGmOpVBUq+gaBMwom1M+krC/NNbWlosh4AtGA03SyWNDiqSKtwp7OulO1M6+mg8YkHMvJ/y0AkCeO8d1hNb7A==",
+      "version": "16.18.48",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.48.tgz",
+      "integrity": "sha512-mlaecDKQ7rIZrYD7iiKNdzFb6e/qD5I9U1rAhq+Fd+DWvYVs+G2kv74UFHmSOlg5+i/vF3XxuR522V4u8BqO+Q==",
       "dev": true
     },
     "node_modules/dashdash": {
@@ -12075,6 +12076,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "@typescript-eslint/parser": "^5.59.6",
     "audit-ci": "^6.6.1",
     "concurrently": "^7.6.0",
-    "cypress": "^12.17.1",
+    "cypress": "^13.1.0",
     "cypress-multi-reporters": "^1.6.3",
     "dotenv": "^16.3.1",
     "eslint": "^8.40.0",


### PR DESCRIPTION
updated cypress to fix the vulnerability associated with the request library used by cypress.

Found vulnerable advisory paths:
GHSA-p8p7-x288-28g6|cypress>@cypress/request
Failed security audit due to moderate vulnerabilities.

Also added experimentalRunAllSpecs so can run ui specs in single click
