### PR TITLE
MAP-312 display service outage banner. 

### DIFF
--- a/server/views/pages/report-use-of-force.html
+++ b/server/views/pages/report-use-of-force.html
@@ -42,7 +42,7 @@
 
 {% set html %}
 <p class="govuk-notification-banner__heading">
-    Maintenance work is planned for 8am on Thursday 20 July.
+    Maintenance work is planned for 6pm on Saturday 16 September.
     Use of force may be temporarily unavailable.
 </p>
 {% endset %}

--- a/server/views/partials/incidentPage.html
+++ b/server/views/partials/incidentPage.html
@@ -18,7 +18,7 @@
 
 {% set html %}
 <p class="govuk-notification-banner__heading">
-    Maintenance work is planned for 8am on Thursday 20 July.
+    Maintenance work is planned for 6pm on Saturday 16 September.
     Use of force may be temporarily unavailable.
 </p>
 {% endset %}


### PR DESCRIPTION
Required because Nomis will be down
FEATURE_FLAG_OUTAGE_BANNER_ENABLED to be set to true in kube deployment directly