### PR TITLE
chore: Upgrade Redis container image to 7.2 to match the live environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.1'
 services:
 
   use-of-force-redis:
-    image: 'bitnami/redis:5.0'
+    image: 'bitnami/redis:7.2'
     networks:
       - hmpps
     container_name: use-of-force-redis


### PR DESCRIPTION
Upgrade Redis container image to 7.2 to match the live environment.

Also this makes it compatible with M1 MacBook Pro.