### PR TITLE
MAP-402 fixed header bar alignment

### DIFF
--- a/assets/sass/local.sass
+++ b/assets/sass/local.sass
@@ -2,7 +2,6 @@
 
 div.govuk-width-container
   max-width: 1170px
-  margin-top: 15px
 
 .hmpps-header__container
   max-width: 1170px


### PR DESCRIPTION


**was**
<img width="1142" alt="Screenshot 2023-11-01 at 08 11 04" src="https://github.com/ministryofjustice/use-of-force/assets/50441412/2ca35edc-d789-4dfc-8cd5-ffc76aade30a">


**now**
<img width="1139" alt="Screenshot 2023-11-01 at 08 12 58" src="https://github.com/ministryofjustice/use-of-force/assets/50441412/c5deea36-c7db-48c1-8858-446becc63eb0">



