### PR TITLE
Map 581 move question on body worn cameras to details screen

### DIFF
--- a/assets/js/add-another-evidence.js
+++ b/assets/js/add-another-evidence.js
@@ -1,2 +1,2 @@
 new AddAnother($('.add-another-evidence'), '.remove-button-container')
-new AddAnother($('.add-another-camera'), '.remove-button-container')
+new AddAnother($('.add-another-input'), '.remove-button-container')

--- a/integration-tests/integration/createIncident/form-submit.cy.js
+++ b/integration-tests/integration/createIncident/form-submit.cy.js
@@ -23,7 +23,7 @@ context('Submit the incident report', () => {
     cy.task('stubUserDetailsRetrieval', ['MR_ZAGATO', 'MRS_JONES', 'TEST_USER'])
   })
 
-  it.only('Submitting a form', () => {
+  it('Submitting a form', () => {
     cy.login()
 
     const reportUseOfForcePage = ReportUseOfForcePage.visit(offender.bookingId)

--- a/integration-tests/integration/createIncident/form-submit.cy.js
+++ b/integration-tests/integration/createIncident/form-submit.cy.js
@@ -23,7 +23,7 @@ context('Submit the incident report', () => {
     cy.task('stubUserDetailsRetrieval', ['MR_ZAGATO', 'MRS_JONES', 'TEST_USER'])
   })
 
-  it('Submitting a form', () => {
+  it.only('Submitting a form', () => {
     cy.login()
 
     const reportUseOfForcePage = ReportUseOfForcePage.visit(offender.bookingId)
@@ -78,6 +78,12 @@ context('Submit the incident report', () => {
 
     const useOfForceDetailsPage = UseOfForceDetailsPage.verifyOnPage()
     useOfForceDetailsPage.fillForm()
+    useOfForceDetailsPage.bodyWornCamera().check('YES')
+    useOfForceDetailsPage.bodyWornCameraNumber(0).type('123')
+    useOfForceDetailsPage.addAnotherBodyWornCamera()
+    useOfForceDetailsPage.bodyWornCameraNumber(1).type('789')
+    useOfForceDetailsPage.addAnotherBodyWornCamera()
+    useOfForceDetailsPage.bodyWornCameraNumber(2).type('456')
     const relocationAndInjuriesPage = useOfForceDetailsPage.save()
     relocationAndInjuriesPage.fillForm()
     const evidencePage = relocationAndInjuriesPage.save()

--- a/integration-tests/integration/reportPages/enter-use-of-force-details.cy.js
+++ b/integration-tests/integration/reportPages/enter-use-of-force-details.cy.js
@@ -1,3 +1,4 @@
+const { use } = require('passport')
 const { offender } = require('../../mockApis/data')
 
 const ReportUseOfForcePage = require('../../pages/createReport/reportUseOfForcePage')
@@ -21,6 +22,11 @@ context('Enter use of force details page', () => {
 
     const useOfForceDetailsPage = UseOfForceDetailsPage.verifyOnPage()
     useOfForceDetailsPage.positiveCommunication().check('true')
+    useOfForceDetailsPage.bodyWornCamera().check('YES')
+    useOfForceDetailsPage.bodyWornCameraNumber(0).type('123')
+    useOfForceDetailsPage.addAnotherBodyWornCamera()
+    useOfForceDetailsPage.bodyWornCameraNumber(1).type('345')
+    useOfForceDetailsPage.removeBodyWornCamera(0)
     useOfForceDetailsPage.personalProtectionTechniques().check('true')
     useOfForceDetailsPage.batonDrawn().check('true')
     useOfForceDetailsPage.batonUsed().check('true')
@@ -45,6 +51,8 @@ context('Enter use of force details page', () => {
 
     cy.task('getFormSection', { bookingId: offender.bookingId, formName: 'useOfForceDetails' }).then(({ section }) => {
       expect(section).to.deep.equal({
+        bodyWornCamera: 'YES',
+        bodyWornCameraNumbers: [{ cameraNum: '345' }],
         batonDrawn: true,
         batonUsed: true,
         guidingHold: true,
@@ -70,6 +78,8 @@ context('Enter use of force details page', () => {
 
     cy.task('getFormSection', { bookingId: offender.bookingId, formName: 'useOfForceDetails' }).then(({ section }) => {
       expect(section).to.deep.equal({
+        bodyWornCamera: 'YES',
+        bodyWornCameraNumbers: [{ cameraNum: '345' }],
         batonDrawn: true,
         batonUsed: true,
         guidingHold: true,
@@ -96,6 +106,8 @@ context('Enter use of force details page', () => {
 
     const useOfForceDetailsPage = UseOfForceDetailsPage.verifyOnPage()
     useOfForceDetailsPage.positiveCommunication().should('have.value', 'true')
+    useOfForceDetailsPage.bodyWornCamera().should('have.value', 'YES')
+    useOfForceDetailsPage.bodyWornCameraNumber(0).should('have.value', '345')
     useOfForceDetailsPage.personalProtectionTechniques().should('have.value', 'true')
     useOfForceDetailsPage.batonDrawn().should('have.value', 'true')
     useOfForceDetailsPage.batonUsed().should('have.value', 'true')
@@ -123,6 +135,7 @@ context('Enter use of force details page', () => {
 
     const useOfForceDetailsPage = UseOfForceDetailsPage.verifyOnPage()
     useOfForceDetailsPage.positiveCommunication().check('true')
+    useOfForceDetailsPage.bodyWornCamera().check('YES')
     useOfForceDetailsPage.personalProtectionTechniques().check('true')
     useOfForceDetailsPage.pavaDrawn().check('true')
     useOfForceDetailsPage.pavaUsed().check('true')
@@ -134,5 +147,6 @@ context('Enter use of force details page', () => {
     useOfForceDetailsPage.painInducingTechniques().check('true')
     useOfForceDetailsPage.clickSaveAndContinue()
     useOfForceDetailsPage.errorSummary().contains('Select yes if a baton was drawn')
+    useOfForceDetailsPage.errorSummary().contains('Enter the body-worn camera number')
   })
 })

--- a/integration-tests/integration/seedData.js
+++ b/integration-tests/integration/seedData.js
@@ -2,9 +2,7 @@ const expectedPayload = {
   evidence: {
     cctvRecording: 'NOT_KNOWN',
     baggedEvidence: true,
-    bodyWornCamera: 'YES',
     photographsTaken: true,
-    bodyWornCameraNumbers: [{ cameraNum: '123' }, { cameraNum: '789' }, { cameraNum: '456' }],
     evidenceTagAndDescription: [
       { description: 'This evidence was collected from the prisoner 1', evidenceTagReference: 'Bagged evidence 1' },
       { description: 'This evidence was collected from the prisoner 2', evidenceTagReference: 'Bagged evidence 2' },
@@ -25,6 +23,8 @@ const expectedPayload = {
     reasons: ['FIGHT_BETWEEN_PRISONERS'],
   },
   useOfForceDetails: {
+    bodyWornCamera: 'YES',
+    bodyWornCameraNumbers: [{ cameraNum: '123' }, { cameraNum: '789' }, { cameraNum: '456' }],
     pavaUsed: true,
     batonUsed: true,
     pavaDrawn: true,

--- a/integration-tests/pages/createReport/evidencePage.js
+++ b/integration-tests/pages/createReport/evidencePage.js
@@ -20,15 +20,6 @@ const evidencePage = () =>
       cy.get('[name="evidenceTagAndDescription[2][description]"]').type('Clothes samples')
       this.photosTaken().check('true')
       cy.get('[name="cctvRecording"]').check('NOT_KNOWN')
-      cy.get('[name="bodyWornCamera"]').check('YES')
-      cy.get('[name="bodyWornCameraNumbers[0][cameraNum]"]').type('123')
-      cy.get('[data-qa-add-another-camera = true]').click()
-      cy.get('[name="bodyWornCameraNumbers[1][cameraNum]"]').type('456')
-      cy.get('[data-qa-add-another-camera = true]').click()
-      cy.get('[name="bodyWornCameraNumbers[2][cameraNum]"]').type('789')
-      cy.get('.add-another-camera .add-another__remove-button').eq(1).click()
-      cy.get('[data-qa-add-another-camera = true]').click()
-      cy.get('[name="bodyWornCameraNumbers[2][cameraNum]"]').type('456')
     },
 
     save: () => {

--- a/integration-tests/pages/createReport/useOfForceDetailsPage.js
+++ b/integration-tests/pages/createReport/useOfForceDetailsPage.js
@@ -4,6 +4,12 @@ import RelocationAndInjuriesPage from './relocationAndInjuriesPage'
 const useOfForceDetailsPage = () =>
   page('Use of force details', {
     positiveCommunication: () => cy.get('[name="positiveCommunication"]'),
+
+    bodyWornCamera: () => cy.get('[name="bodyWornCamera"]'),
+    bodyWornCameraNumber: index => cy.get(`[name="bodyWornCameraNumbers[${index}][cameraNum]"]`),
+    addAnotherBodyWornCamera: () => cy.get('[data-qa-add-another-camera = true]').click(),
+    removeBodyWornCamera: index => cy.get('.add-another-camera .add-another__remove-button').eq(index).click(),
+
     personalProtectionTechniques: () => cy.get('[name="personalProtectionTechniques"]'),
     batonDrawn: () => cy.get('[name="batonDrawn"]'),
     batonUsed: () => cy.get('[name="batonUsed"]'),
@@ -45,6 +51,7 @@ const useOfForceDetailsPage = () =>
 
     fillForm() {
       this.positiveCommunication().check('true')
+      this.bodyWornCamera().check('NO')
       this.personalProtectionTechniques().check('true')
       this.batonDrawn().check('true')
       this.batonUsed().check('true')

--- a/integration-tests/pages/createReport/useOfForceDetailsPage.js
+++ b/integration-tests/pages/createReport/useOfForceDetailsPage.js
@@ -7,8 +7,8 @@ const useOfForceDetailsPage = () =>
 
     bodyWornCamera: () => cy.get('[name="bodyWornCamera"]'),
     bodyWornCameraNumber: index => cy.get(`[name="bodyWornCameraNumbers[${index}][cameraNum]"]`),
-    addAnotherBodyWornCamera: () => cy.get('[data-qa-add-another-camera = true]').click(),
-    removeBodyWornCamera: index => cy.get('.add-another-camera .add-another__remove-button').eq(index).click(),
+    addAnotherBodyWornCamera: () => cy.get('[data-qa-add-another-input = true]').click(),
+    removeBodyWornCamera: index => cy.get('.add-another-input .add-another__remove-button').eq(index).click(),
 
     personalProtectionTechniques: () => cy.get('[name="personalProtectionTechniques"]'),
     batonDrawn: () => cy.get('[name="batonDrawn"]'),

--- a/server/config/forms/evidenceForm.js
+++ b/server/config/forms/evidenceForm.js
@@ -39,27 +39,6 @@ const completeSchema = joi.object({
     'NO',
     'NOT_KNOWN'
   )('Select yes if any part of the incident captured on CCTV').alter(optionalForPartialValidation),
-
-  bodyWornCamera: requiredOneOfMsg(
-    'YES',
-    'NO',
-    'NOT_KNOWN'
-  )('Select yes if any part of the incident was captured on a body-worn camera').alter(optionalForPartialValidation),
-  bodyWornCameraNumbers: joi
-    .when('bodyWornCamera', {
-      is: 'YES',
-      then: arrayOfObjects({
-        cameraNum: requiredStringMsg('Enter the body-worn camera number').alter(optionalForPartialValidation),
-      })
-        .min(1)
-        .message('Enter the body-worn camera number')
-        .ruleset.unique('cameraNum')
-        .message("Camera '{#value.cameraNum}' has already been added - remove this camera")
-        .required()
-        .alter(minZeroForPartialValidation),
-      otherwise: joi.any().strip(),
-    })
-    .meta({ firstFieldName: 'bodyWornCameraNumbers[0]' }),
 })
 
 module.exports = {

--- a/server/config/forms/evidenceValidation.test.js
+++ b/server/config/forms/evidenceValidation.test.js
@@ -20,8 +20,6 @@ const validInput = () => ({
   ],
   photographsTaken: 'true',
   cctvRecording: 'YES',
-  bodyWornCamera: 'YES',
-  bodyWornCameraNumbers: [{ cameraNum: 'ABC123' }, { cameraNum: '' }],
 })
 
 describe("'complete' validation", () => {
@@ -34,8 +32,6 @@ describe("'complete' validation", () => {
 
       expect(formResponse).toEqual({
         baggedEvidence: true,
-        bodyWornCamera: 'YES',
-        bodyWornCameraNumbers: [{ cameraNum: 'ABC123' }],
         cctvRecording: 'YES',
         evidenceTagAndDescription: [{ description: 'A Description', evidenceTagReference: '12345' }],
         photographsTaken: true,
@@ -57,10 +53,6 @@ describe("'complete' validation", () => {
         {
           href: '#cctvRecording',
           text: 'Select yes if any part of the incident captured on CCTV',
-        },
-        {
-          href: '#bodyWornCamera',
-          text: 'Select yes if any part of the incident was captured on a body-worn camera',
         },
       ])
 
@@ -85,8 +77,6 @@ describe("'complete' validation", () => {
       ])
 
       expect(formResponse).toEqual({
-        bodyWornCamera: 'YES',
-        bodyWornCameraNumbers: [{ cameraNum: 'ABC123' }],
         cctvRecording: 'YES',
         photographsTaken: true,
       })
@@ -122,8 +112,6 @@ describe("'complete' validation", () => {
 
       expect(formResponse).toEqual({
         baggedEvidence: true,
-        bodyWornCamera: 'YES',
-        bodyWornCameraNumbers: [{ cameraNum: 'ABC123' }],
         cctvRecording: 'YES',
         evidenceTagAndDescription: [
           { description: 'A Description', evidenceTagReference: '12345' },
@@ -152,8 +140,6 @@ describe("'complete' validation", () => {
 
       expect(formResponse).toEqual({
         baggedEvidence: true,
-        bodyWornCamera: 'YES',
-        bodyWornCameraNumbers: [{ cameraNum: 'ABC123' }],
         cctvRecording: 'YES',
         photographsTaken: true,
       })
@@ -177,8 +163,6 @@ describe("'complete' validation", () => {
 
       expect(formResponse).toEqual({
         baggedEvidence: true,
-        bodyWornCamera: 'YES',
-        bodyWornCameraNumbers: [{ cameraNum: 'ABC123' }],
         cctvRecording: 'YES',
         photographsTaken: true,
         evidenceTagAndDescription: [{ description: '', evidenceTagReference: 'ref-1' }],
@@ -198,123 +182,16 @@ describe("'complete' validation", () => {
 
       expect(formResponse).toEqual({
         baggedEvidence: false,
-        bodyWornCamera: 'YES',
-        bodyWornCameraNumbers: [{ cameraNum: 'ABC123' }],
         cctvRecording: 'YES',
         photographsTaken: true,
       })
     })
   })
 
-  describe('Body Worn Cameras', () => {
-    it('Conditional field not selected  - errors and filters out camera number list', () => {
-      const input = { ...validInput(), bodyWornCamera: undefined, bodyWornCameraNumbers: [{ cameraNum: 'AAA123' }] }
-      const { errors, formResponse } = check(input)
-
-      expect(errors).toEqual([
-        {
-          href: '#bodyWornCamera',
-          text: 'Select yes if any part of the incident was captured on a body-worn camera',
-        },
-      ])
-
-      expect(formResponse).toEqual({
-        baggedEvidence: true,
-        cctvRecording: 'YES',
-        evidenceTagAndDescription: [{ description: 'A Description', evidenceTagReference: '12345' }],
-        photographsTaken: true,
-      })
-    })
-
-    it('Conditional field must be one of allowed values', () => {
-      const input = { ...validInput(), bodyWornCamera: 'BOB', bodyWornCameraNumbers: [{ cameraNum: 'AAA123' }] }
-      const { errors, formResponse } = check(input)
-
-      expect(errors).toEqual([
-        {
-          href: '#bodyWornCamera',
-          text: 'Select yes if any part of the incident was captured on a body-worn camera',
-        },
-      ])
-
-      expect(formResponse).toEqual({
-        baggedEvidence: true,
-        cctvRecording: 'YES',
-        bodyWornCamera: 'BOB',
-        evidenceTagAndDescription: [{ description: 'A Description', evidenceTagReference: '12345' }],
-        photographsTaken: true,
-      })
-    })
-
-    it('Conditional field selected: Yes, check at least one number is present', () => {
-      const input = { ...validInput(), bodyWornCamera: 'YES', bodyWornCameraNumbers: [] }
-      const { errors, formResponse } = check(input)
-
-      expect(errors).toEqual([
-        {
-          href: '#bodyWornCameraNumbers[0]',
-          text: 'Enter the body-worn camera number',
-        },
-      ])
-
-      expect(formResponse).toEqual({
-        baggedEvidence: true,
-        bodyWornCamera: 'YES',
-        cctvRecording: 'YES',
-        evidenceTagAndDescription: [{ description: 'A Description', evidenceTagReference: '12345' }],
-        photographsTaken: true,
-      })
-    })
-
-    it('Conditional field selected: Yes, empty numbers are ignored', () => {
-      const input = {
-        ...validInput(),
-        bodyWornCamera: 'YES',
-        bodyWornCameraNumbers: [{ cameraNum: 'AAA' }, { cameraNum: '' }, { cameraNum: 'BBB' }],
-      }
-      const { errors, formResponse } = check(input)
-
-      expect(errors).toEqual([])
-
-      expect(formResponse).toEqual({
-        baggedEvidence: true,
-        bodyWornCamera: 'YES',
-        bodyWornCameraNumbers: [{ cameraNum: 'AAA' }, { cameraNum: 'BBB' }],
-        cctvRecording: 'YES',
-        evidenceTagAndDescription: [{ description: 'A Description', evidenceTagReference: '12345' }],
-        photographsTaken: true,
-      })
-    })
-
-    it('Duplicate camera numbers are rejected', () => {
-      const input = {
-        ...validInput(),
-        bodyWornCamera: 'YES',
-        bodyWornCameraNumbers: [{ cameraNum: 'AAA' }, { cameraNum: '' }, { cameraNum: 'AAA' }],
-      }
-      const { errors, formResponse } = check(input)
-
-      expect(errors).toEqual([
-        {
-          href: '#bodyWornCameraNumbers[1]',
-          text: "Camera 'AAA' has already been added - remove this camera",
-        },
-      ])
-
-      expect(formResponse).toEqual({
-        baggedEvidence: true,
-        bodyWornCamera: 'YES',
-        bodyWornCameraNumbers: [{ cameraNum: 'AAA' }, { cameraNum: 'AAA' }],
-        cctvRecording: 'YES',
-        evidenceTagAndDescription: [{ description: 'A Description', evidenceTagReference: '12345' }],
-        photographsTaken: true,
-      })
-    })
-
+  describe('Evidence tags', () => {
     it('Duplicate evidence tags are rejected', () => {
       const input = {
         ...validInput(),
-        bodyWornCamera: 'NO',
         evidenceTagAndDescription: [
           { description: 'D2', evidenceTagReference: '12345' },
           { description: 'D1', evidenceTagReference: '12345' },
@@ -331,51 +208,11 @@ describe("'complete' validation", () => {
 
       expect(formResponse).toEqual({
         baggedEvidence: true,
-        bodyWornCamera: 'NO',
         cctvRecording: 'YES',
         evidenceTagAndDescription: [
           { description: 'D2', evidenceTagReference: '12345' },
           { description: 'D1', evidenceTagReference: '12345' },
         ],
-        photographsTaken: true,
-      })
-    })
-
-    it('Conditional field selected: Yes, unknown fields are ignored, known fields are trimmed', () => {
-      const input = {
-        ...validInput(),
-        bodyWornCamera: 'YES',
-        bodyWornCameraNumbers: [{ cameraNum: '    AAA  ', age: '29' }, { cameraNum: '' }, { cameraNum: 'BBB' }],
-      }
-      const { errors, formResponse } = check(input)
-
-      expect(errors).toEqual([])
-
-      expect(formResponse).toEqual({
-        baggedEvidence: true,
-        bodyWornCamera: 'YES',
-        bodyWornCameraNumbers: [{ cameraNum: 'AAA' }, { cameraNum: 'BBB' }],
-        cctvRecording: 'YES',
-        evidenceTagAndDescription: [{ description: 'A Description', evidenceTagReference: '12345' }],
-        photographsTaken: true,
-      })
-    })
-
-    it('Conditional field selected: No, numbers are not required', () => {
-      const input = {
-        ...validInput(),
-        bodyWornCamera: 'NO',
-        bodyWornCameraNumbers: [{ cameraNum: 'AAA' }, { cameraNum: '' }, { cameraNum: 'AAA' }],
-      }
-      const { errors, formResponse } = check(input)
-
-      expect(errors).toEqual([])
-
-      expect(formResponse).toEqual({
-        baggedEvidence: true,
-        bodyWornCamera: 'NO',
-        cctvRecording: 'YES',
-        evidenceTagAndDescription: [{ description: 'A Description', evidenceTagReference: '12345' }],
         photographsTaken: true,
       })
     })
@@ -394,12 +231,6 @@ describe("'partial' validation", () => {
     const { errors, formResponse } = check(validInput())
     expect(formResponse).toEqual({
       baggedEvidence: true,
-      bodyWornCamera: 'YES',
-      bodyWornCameraNumbers: [
-        {
-          cameraNum: 'ABC123',
-        },
-      ],
       cctvRecording: 'YES',
       evidenceTagAndDescription: [
         {
@@ -416,12 +247,9 @@ describe("'partial' validation", () => {
     const { errors, formResponse } = check({
       baggedEvidence: 'true',
       evidenceTagAndDescription: [],
-      bodyWornCamera: 'YES',
-      bodyWornCameraNumbers: [],
     })
     expect(formResponse).toEqual({
       baggedEvidence: true,
-      bodyWornCamera: 'YES',
     })
     expect(errors).toEqual([])
   })

--- a/server/config/forms/useOfForceDetailsValidation.test.js
+++ b/server/config/forms/useOfForceDetailsValidation.test.js
@@ -11,6 +11,7 @@ let validInput = {}
 beforeEach(() => {
   validInput = {
     positiveCommunication: 'true',
+    bodyWornCamera: 'NO',
     personalProtectionTechniques: 'true',
     batonDrawn: 'true',
     batonUsed: 'true',
@@ -38,6 +39,7 @@ describe('complete schema', () => {
 
       expect(formResponse).toEqual({
         positiveCommunication: true,
+        bodyWornCamera: 'NO',
         personalProtectionTechniques: true,
         batonDrawn: true,
         batonUsed: true,
@@ -54,7 +56,7 @@ describe('complete schema', () => {
       })
     })
 
-    it('Should return 9 error massages if no input field is completed', () => {
+    it('Should return 10 error massages if no input field is completed', () => {
       const input = {}
       const { errors, formResponse } = check(input)
 
@@ -62,6 +64,10 @@ describe('complete schema', () => {
         {
           href: '#positiveCommunication',
           text: 'Select yes if positive communication was used',
+        },
+        {
+          href: '#bodyWornCamera',
+          text: 'Select yes if any part of the incident was captured on a body-worn camera',
         },
         {
           href: '#personalProtectionTechniques',
@@ -97,7 +103,7 @@ describe('complete schema', () => {
         },
       ])
 
-      expect(errors.length).toEqual(9)
+      expect(errors.length).toEqual(10)
 
       expect(formResponse).toEqual({})
     })
@@ -118,6 +124,141 @@ describe('complete schema', () => {
       ])
     })
 
+    it("Not selecting an option for 'body worn cameras' returns a validation error message", () => {
+      const input = {
+        ...validInput,
+        bodyWornCamera: undefined,
+      }
+      const { errors } = check(input)
+      expect(errors).toEqual([
+        {
+          href: '#bodyWornCamera',
+          text: 'Select yes if any part of the incident was captured on a body-worn camera',
+        },
+      ])
+    })
+
+    it('Not adding camera numbers but selecting YES for bodyWornCameras returns validation error messages', () => {
+      validInput.bodyWornCamera = 'YES'
+      const { errors } = check(validInput)
+
+      expect(errors).toEqual([{ href: '#bodyWornCameraNumbers[0]', text: '"bodyWornCameraNumbers" is required' }])
+    })
+
+    it('Should return validation error if more than one body-worn camera with same identifier', () => {
+      validInput.bodyWornCamera = 'YES'
+      validInput.bodyWornCameraNumbers = [{ cameraNum: '1' }, { cameraNum: '1' }]
+      const { errors } = check(validInput)
+
+      expect(errors).toEqual([
+        { href: '#bodyWornCameraNumbers[1]', text: "Camera '1' has already been added - remove this camera" },
+      ])
+    })
+
+    it('Should not return validation error if all body-worn camera identifiers are unique', () => {
+      validInput.bodyWornCamera = 'YES'
+      validInput.bodyWornCameraNumbers = [{ cameraNum: '1' }, { cameraNum: '2' }]
+      const { errors } = check(validInput)
+
+      expect(errors).toEqual([])
+    })
+
+    it('Should trim empty-string body-worn camera identifiers', () => {
+      validInput.bodyWornCamera = 'YES'
+      validInput.bodyWornCameraNumbers = [
+        { cameraNum: '    AAA  ', age: '29' },
+        { cameraNum: '' },
+        { cameraNum: 'BBB' },
+      ]
+
+      const { errors, formResponse } = check(validInput)
+
+      expect(errors).toEqual([])
+
+      expect(formResponse).toEqual({
+        batonDrawn: true,
+        batonUsed: true,
+        bodyWornCamera: 'YES',
+        bodyWornCameraNumbers: [
+          {
+            cameraNum: 'AAA',
+          },
+          {
+            cameraNum: 'BBB',
+          },
+        ],
+        escortingHold: true,
+        guidingHold: true,
+        guidingHoldOfficersInvolved: 2,
+        handcuffsApplied: true,
+        painInducingTechniques: true,
+        painInducingTechniquesUsed: ['FINAL_LOCK_FLEXION', 'THUMB_LOCK'],
+        pavaDrawn: true,
+        pavaUsed: true,
+        personalProtectionTechniques: true,
+        positiveCommunication: true,
+        restraint: true,
+        restraintPositions: ['STANDING', 'FACE_DOWN'],
+      })
+    })
+
+    it('Body-worn camera identifiers are not required when bodyWornCamera is NO', () => {
+      validInput.bodyWornCamer = 'NO'
+      validInput.bodyWornCameraNumbers = [{ cameraNum: 'AAA' }, { cameraNum: '' }, { cameraNum: 'AAA' }]
+
+      const { errors, formResponse } = check(validInput)
+
+      expect(errors).toEqual([])
+
+      expect(formResponse).toEqual({
+        batonDrawn: true,
+        batonUsed: true,
+        bodyWornCamera: 'NO',
+        escortingHold: true,
+        guidingHold: true,
+        guidingHoldOfficersInvolved: 2,
+        handcuffsApplied: true,
+        painInducingTechniques: true,
+        painInducingTechniquesUsed: ['FINAL_LOCK_FLEXION', 'THUMB_LOCK'],
+        pavaDrawn: true,
+        pavaUsed: true,
+        personalProtectionTechniques: true,
+        positiveCommunication: true,
+        restraint: true,
+        restraintPositions: ['STANDING', 'FACE_DOWN'],
+      })
+    })
+
+    it('Body worn camera field must be one of allowed values', () => {
+      validInput.bodyWornCamera = 'SOMETHING_RANDOM'
+      validInput.bodyWornCameraNumbers = [{ cameraNum: 'AAA' }, { cameraNum: '' }, { cameraNum: 'AAA' }]
+      const { errors, formResponse } = check(validInput)
+
+      expect(errors).toEqual([
+        {
+          href: '#bodyWornCamera',
+          text: 'Select yes if any part of the incident was captured on a body-worn camera',
+        },
+      ])
+
+      expect(formResponse).toEqual({
+        batonDrawn: true,
+        batonUsed: true,
+        bodyWornCamera: 'SOMETHING_RANDOM',
+        escortingHold: true,
+        guidingHold: true,
+        guidingHoldOfficersInvolved: 2,
+        handcuffsApplied: true,
+        painInducingTechniques: true,
+        painInducingTechniquesUsed: ['FINAL_LOCK_FLEXION', 'THUMB_LOCK'],
+        pavaDrawn: true,
+        pavaUsed: true,
+        personalProtectionTechniques: true,
+        positiveCommunication: true,
+        restraint: true,
+        restraintPositions: ['STANDING', 'FACE_DOWN'],
+      })
+    })
     it("Not selecting an option for 'personal protection techniques' returns a validation error message", () => {
       const input = {
         ...validInput,
@@ -408,6 +549,7 @@ describe('partial schema', () => {
 
       expect(formResponse).toEqual({
         positiveCommunication: true,
+        bodyWornCamera: 'NO',
         personalProtectionTechniques: true,
         batonDrawn: true,
         batonUsed: true,

--- a/server/data/UseOfForceReport.ts
+++ b/server/data/UseOfForceReport.ts
@@ -7,6 +7,8 @@ export type IncidentDetails = {
 
 export type UseOfForceDetails = {
   positiveCommunication: boolean
+  bodyWornCamera: string
+  bodyWornCameraNumbers: { cameraNum: string }[]
   personalProtectionTechniques: boolean
   batonDrawn: boolean
   batonUsed: boolean
@@ -46,8 +48,6 @@ export type Evidence = {
   baggedEvidence: boolean
   photographsTaken: boolean
   cctvRecording: string
-  bodyWornCamera: string
-  bodyWornCameraNumbers: { cameraNum: string }[]
 }
 
 export type InvolvedStaff = {

--- a/server/data/UseOfForceReport.ts
+++ b/server/data/UseOfForceReport.ts
@@ -7,8 +7,8 @@ export type IncidentDetails = {
 
 export type UseOfForceDetails = {
   positiveCommunication: boolean
-  bodyWornCamera: string
-  bodyWornCameraNumbers: { cameraNum: string }[]
+  bodyWornCamera?: string
+  bodyWornCameraNumbers?: { cameraNum: string }[]
   personalProtectionTechniques: boolean
   batonDrawn: boolean
   batonUsed: boolean
@@ -48,6 +48,8 @@ export type Evidence = {
   baggedEvidence: boolean
   photographsTaken: boolean
   cctvRecording: string
+  bodyWornCamera?: string
+  bodyWornCameraNumbers?: { cameraNum: string }[]
 }
 
 export type InvolvedStaff = {

--- a/server/routes/creatingReports/createReport.test.ts
+++ b/server/routes/creatingReports/createReport.test.ts
@@ -38,6 +38,8 @@ describe('GET /section/form', () => {
 })
 
 const validUseOfForceDetailsRequest = {
+  bodyWornCamera: 'YES',
+  bodyWornCameraNumbers: [{ cameraNum: 'ABC123' }],
   positiveCommunication: 'false',
   personalProtectionTechniques: 'false',
   batonDrawn: 'false',
@@ -55,6 +57,8 @@ const validUseofForceDetailUpdate = [
   1,
   'useOfForceDetails',
   {
+    bodyWornCamera: 'YES',
+    bodyWornCameraNumbers: [{ cameraNum: 'ABC123' }],
     batonDrawn: false,
     guidingHold: false,
     escortingHold: false,
@@ -107,7 +111,7 @@ describe('POST save and return to tasklist', () => {
   test('Submitting invalid update is allowed', () => {
     return request(app)
       .post(`/report/1/use-of-force-details`)
-      .send({ ...validUseOfForceDetailsRequest, batonDrawn: null, submitType: 'save-and-return' })
+      .send({ ...validUseOfForceDetailsRequest, batonDrawn: null, bodyWornCamera: null, submitType: 'save-and-return' })
       .expect(302)
       .expect('Location', '/report/1/report-use-of-force')
       .expect(() => {
@@ -132,6 +136,7 @@ describe('POST save and return to tasklist', () => {
         ...validUseOfForceDetailsRequest,
         restraint: 'true',
         restraintPositions: ['not a valid value'],
+        bodyWornCamera: ['another invalid input'],
         submitType: 'save-and-return',
       })
       .expect(302)
@@ -186,8 +191,6 @@ describe('Submitting evidence page', () => {
         .send({
           submitType,
           baggedEvidence: 'true',
-          bodyWornCamera: 'YES',
-          bodyWornCameraNumbers: [{ cameraNum: 'ABC123' }],
           cctvRecording: 'YES',
           evidenceTagAndDescription: [{ description: 'A Description', evidenceTagReference: '12345' }],
           photographsTaken: 'true',
@@ -199,8 +202,6 @@ describe('Submitting evidence page', () => {
 
           expect(draftReportService.process).toBeCalledWith(user, 1, 'evidence', {
             baggedEvidence: true,
-            bodyWornCamera: 'YES',
-            bodyWornCameraNumbers: [{ cameraNum: 'ABC123' }],
             cctvRecording: 'YES',
             evidenceTagAndDescription: [{ description: 'A Description', evidenceTagReference: '12345' }],
             photographsTaken: true,

--- a/server/services/drafts/reportStatusChecker.test.ts
+++ b/server/services/drafts/reportStatusChecker.test.ts
@@ -22,13 +22,13 @@ describe('statusCheck', () => {
       positiveCommunication: false,
       personalProtectionTechniques: true,
       painInducingTechniques: false,
+      bodyWornCamera: 'YES',
+      bodyWornCameraNumbers: [{ cameraNum: '1111' }, { cameraNum: '2222' }],
     },
     evidence: {
       cctvRecording: 'NO',
       baggedEvidence: true,
-      bodyWornCamera: 'YES',
       photographsTaken: false,
-      bodyWornCameraNumbers: [{ cameraNum: '1111' }, { cameraNum: '2222' }],
       evidenceTagAndDescription: [
         { description: 'aaaaa', evidenceTagReference: '1111' },
         { description: 'bbbb', evidenceTagReference: '2222' },

--- a/server/services/reportDetailBuilder.test.ts
+++ b/server/services/reportDetailBuilder.test.ts
@@ -107,6 +107,7 @@ describe('Build details', () => {
       reporterName: 'A User',
       submittedDate: new Date('2015-03-25T12:00:00.000Z'),
       useOfForceDetails: {
+        bodyCameras: undefined,
         batonDrawn: undefined,
         controlAndRestraintUsed: undefined,
         guidingHoldUsed: undefined,

--- a/server/services/reportDetailBuilder.test.ts
+++ b/server/services/reportDetailBuilder.test.ts
@@ -55,7 +55,6 @@ describe('Build details', () => {
     expect(result).toStrictEqual({
       bookingId: 33,
       evidence: {
-        bodyCameras: undefined,
         cctv: undefined,
         evidenceBaggedTagged: 'No',
         photographs: undefined,

--- a/server/services/reportSummary.test.ts
+++ b/server/services/reportSummary.test.ts
@@ -3,7 +3,12 @@ import { Prison } from '../data/prisonClientTypes'
 import { UseOfForceDraftReport } from '../data/UseOfForceReport'
 import reportSummary from './reportSummary'
 
-const form: UseOfForceDraftReport = { useOfForceDetails: {}, relocationAndInjuries: {}, reasonsForUseOfForce: {} }
+const form: UseOfForceDraftReport = {
+  useOfForceDetails: {},
+  relocationAndInjuries: {},
+  reasonsForUseOfForce: {},
+  evidence: {},
+}
 const offenderDetail = {}
 const prison: Prison = { agencyId: 'MDI', description: 'Moorland HMP', active: true, agencyType: 'INST' }
 const locationDescription = ''
@@ -46,7 +51,33 @@ describe('reportSummary', () => {
       expect(result.useOfForceDetails.painInducingTechniques).toEqual('No')
     })
   })
+  describe('Use of force details', () => {
+    it("should return body-camera details in 'details' even if in 'evidence' data ", () => {
+      form.useOfForceDetails = {}
+      form.evidence.bodyWornCamera = 'NO'
+      const result = reportSummary(form, offenderDetail, prison, locationDescription, involvedStaff, incidentDate)
+      expect(result.useOfForceDetails.bodyCameras).toEqual('No')
+    })
 
+    it("should return body-camera reference numbers within 'details' section even if they are part of 'evidence' data", () => {
+      form.useOfForceDetails = {}
+      form.evidence = {
+        bodyWornCamera: 'YES',
+        bodyWornCameraNumbers: [{ cameraNum: '1' }, { cameraNum: '2' }],
+      }
+      const result = reportSummary(form, offenderDetail, prison, locationDescription, involvedStaff, incidentDate)
+      expect(result.useOfForceDetails.bodyCameras).toEqual('Yes - 1, 2')
+    })
+
+    it("should return body-camera details saved in 'details' data", () => {
+      form.useOfForceDetails = {
+        bodyWornCamera: 'YES',
+        bodyWornCameraNumbers: [{ cameraNum: '1' }, { cameraNum: '2' }],
+      }
+      const result = reportSummary(form, offenderDetail, prison, locationDescription, involvedStaff, incidentDate)
+      expect(result.useOfForceDetails.bodyCameras).toEqual('Yes - 1, 2')
+    })
+  })
   describe('Use of force reasons', () => {
     it('should return undefined', () => {
       form.reasonsForUseOfForce.reasons = undefined

--- a/server/services/reportSummary.ts
+++ b/server/services/reportSummary.ts
@@ -68,6 +68,11 @@ const createUseOfForceDetails = (
 
     painInducingTechniques: getPainInducingTechniques(details),
     handcuffsApplied: details.handcuffsApplied,
+    bodyCameras: whenPresent(details.bodyWornCamera, value =>
+      value === BodyWornCameras.YES.value
+        ? `${YES} - ${extractCommaSeparatedList('cameraNum', details.bodyWornCameraNumbers)}` || YES
+        : toLabel(BodyWornCameras, value)
+    ),
   }
 }
 
@@ -108,11 +113,6 @@ const createEvidence = (evidence: Partial<Evidence> = {}) => {
     evidenceBaggedTagged: baggedAndTaggedEvidence(evidence.evidenceTagAndDescription, evidence.baggedEvidence),
     photographs: evidence.photographsTaken,
     cctv: toLabel(Cctv, evidence.cctvRecording),
-    bodyCameras: whenPresent(evidence.bodyWornCamera, value =>
-      value === Cctv.YES.value
-        ? `${YES} - ${extractCommaSeparatedList('cameraNum', evidence.bodyWornCameraNumbers)}` || YES
-        : toLabel(BodyWornCameras, value)
-    ),
   }
 }
 

--- a/server/services/reportSummary.ts
+++ b/server/services/reportSummary.ts
@@ -47,8 +47,14 @@ const createIncidentDetails = (
 
 const createUseOfForceDetails = (
   details: Partial<UseOfForceDetails> = {},
-  reasonsForUseOfForce: Partial<ReasonsForUseOfForce> = {}
+  reasonsForUseOfForce: Partial<ReasonsForUseOfForce> = {},
+  evidence: Partial<Evidence> = {}
 ) => {
+  const bodyWornCamera = details.bodyWornCamera ? details.bodyWornCamera : evidence.bodyWornCamera
+  const bodyWornCameraNumbers = details.bodyWornCameraNumbers
+    ? details.bodyWornCameraNumbers
+    : evidence.bodyWornCameraNumbers
+
   return {
     reasonsForUseOfForce: whenPresent(reasonsForUseOfForce.reasons, reasons =>
       reasons.map(value => toLabel(UofReasons, value)).join(', ')
@@ -68,9 +74,9 @@ const createUseOfForceDetails = (
 
     painInducingTechniques: getPainInducingTechniques(details),
     handcuffsApplied: details.handcuffsApplied,
-    bodyCameras: whenPresent(details.bodyWornCamera, value =>
+    bodyCameras: whenPresent(bodyWornCamera, value =>
       value === BodyWornCameras.YES.value
-        ? `${YES} - ${extractCommaSeparatedList('cameraNum', details.bodyWornCameraNumbers)}` || YES
+        ? `${YES} - ${extractCommaSeparatedList('cameraNum', bodyWornCameraNumbers)}` || YES
         : toLabel(BodyWornCameras, value)
     ),
   }
@@ -193,7 +199,7 @@ export = (
       incidentDate
     ),
     offenderDetail,
-    useOfForceDetails: createUseOfForceDetails(useOfForceDetails, reasonsForUseOfForce),
+    useOfForceDetails: createUseOfForceDetails(useOfForceDetails, reasonsForUseOfForce, evidence),
     relocationAndInjuries: createRelocation(relocationAndInjuries),
     evidence: createEvidence(evidence),
   }

--- a/server/views/formPages/incident/evidence.html
+++ b/server/views/formPages/incident/evidence.html
@@ -1,8 +1,6 @@
 {% extends "../formTemplate.html" %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
-{% from "govuk/components/select/macro.njk" import govukSelect %}
-{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% import "../incidentMacros.njk" as incidentMacro %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
@@ -195,105 +193,6 @@
           }) 
           }}
       </div>
-
-      <!-- Q4 -->
-
-      <div class="govuk-!-margin-bottom-9
-        {% if errors | findError('bodyWornCamera') %}
-          govuk-form-group--error
-          {% set cameraErrMsg =  errors | findError('bodyWornCamera') %}
-        {% endif %}">
-        <fieldset class="govuk-fieldset">
-          <legend class="govuk-fieldset__legend ">
-            Was any part of the incident captured on a body-worn camera?
-          </legend>
-          <span id="cameraErrMsg" class="govuk-error-message">
-            <span class="govuk-visually-hidden">Error:</span>
-            {{ cameraErrMsg.text}}
-          </span>
-
-          <div class="govuk-radios" data-module="govuk-radios">
-            <div class=" govuk-radios">
-              <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="bodyWornCamera" name="bodyWornCamera" type="radio" value="YES" data-aria-controls="body-worn-camera-conditional" {% if data.bodyWornCamera === 'YES' %} checked="checked" {% endif %}>
-                <label class="govuk-label govuk-radios__label" for="bodyWornCamera">
-                  Yes
-                </label>
-              </div>
-              <!-- hidden panel starts here -->
-              <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="body-worn-camera-conditional">
-
-                <!-- add another starts here -->
-                <div class="add-another-camera" id="bodyWornCameraNumbers">
-                  {% macro addCameraNumber(index, value, showRemove) %}
-                    {% call govukFieldset({ classes: 'add-another__item' }) %}
-                    <div class="govuk-grid-row">
-                        <div class="govuk-grid-column-one-third" id="bodyWornCameraNumbers[{{index}}]">
-                        {{
-                        govukInput({
-                          label: {
-                            html: 'Camera number'
-                          },
-                          id: 'bodyWornCameraNumbers[' + index + '][cameraNum]',
-                          name: 'bodyWornCameraNumbers[' + index + '][cameraNum]',
-                          value: value,
-                          errorMessage: errors | findErrors(['bodyWornCameraNumbers[' + index + ']', 'bodyWornCameraNumbers[' + index + '][cameraNum]']),
-                          attributes: {
-                            'data-name': 'bodyWornCameraNumbers[%index%][cameraNum]',
-                            'data-id': 'bodyWornCameraNumbers[%index%][cameraNum]'
-                          }
-                          })
-                        }}
-                        </div>
-                        <div class="govuk-grid-column-one-third remove-button-container govuk-!-margin-top-6">
-                          {% if showRemove %}
-                            <button type="button" class="govuk-button govuk-button--secondary add-another__remove-button">
-                            Remove
-                            </button>
-                          {% endif  %}
-                        </div>
-                    </div>  
-                    {% endcall %}
-                  {% endmacro%}
-
-                  {% for camera in data.bodyWornCameraNumbers %}
-                    {{ addCameraNumber(index = loop.index0, value = camera.cameraNum, showRemove = loop.length != 1) }}
-                  {% else %}
-                    {{ addCameraNumber(index = 0, value = null, showRemove = false) }}
-                  {% endfor %}
-                  <div class="button-action">
-                    {{
-                    govukButton({
-                      text: 'Add another',
-                      classes: 'govuk-button--secondary  add-another__add-button govuk-!-margin-bottom-4',
-                      attributes: { 'data-qa-add-another-camera': true }
-                    })
-                  }}
-                  </div>
-                </div>
-                <!-- add another ends here -->
-              </div>
-              <!-- hidden panel end -->
-
-              <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="body-worn-camera-no" name="bodyWornCamera" type="radio" value="NO" {% if data.bodyWornCamera === 'NO' %} checked="checked" {% endif %}>
-                <label class="govuk-label govuk-radios__label" for="body-worn-camera-no">
-                  No
-                </label>
-              </div>
-              <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="body-worn-camera-notKnown" name="bodyWornCamera" type="radio" value="NOT_KNOWN" {% if data.bodyWornCamera === 'NOT_KNOWN' %} checked="checked" {% endif %}>
-                <label class="govuk-label govuk-radios__label" for="body-worn-camera-notKnown">
-                  Not known
-                </label>
-              </div>
-            </div>
-          </div>
-          <!-- end of radios -->
-        </fieldset>
-      </div>
-      <!-- end of this Q4 component -->
-
     </div>
     <!-- end of govuk-grid-column-full-->
   </div>

--- a/server/views/formPages/incident/useOfForceDetails.html
+++ b/server/views/formPages/incident/useOfForceDetails.html
@@ -31,7 +31,15 @@
       errorMessage: errors | findError('positiveCommunication')
     })}}
 
-    <!-- Q2 -->
+    <!-- Q2 new question body-worn camera question which was previously in the evidence page -->
+    {{ incidentMacro.radioWithNestedTextBox({
+      text: "Was any part of the incident captured on a body-worn camera?",
+      name: "bodyWornCamera",
+      value: data,
+      errors: errors 
+    }) }}
+
+    <!-- Q3 -->
     {{ incidentMacro.radio( {
       text: "Were any personal protection techniques used?",
       name: "personalProtectionTechniques",
@@ -40,7 +48,7 @@
       errorMessage: errors | findError('personalProtectionTechniques')
     })}}
 
-    <!-- Q3 -->
+    <!-- Q4 -->
     {{ incidentMacro.radiosWithNestedRadios({
       primaryQuestion: {
         text: "Was a baton drawn by anyone during this incident?",
@@ -61,7 +69,7 @@
     }
     )}}
 
-    <!-- Q4 -->
+    <!-- Q5 -->
     {{ incidentMacro.radiosWithNestedRadios({
       primaryQuestion: {
         text: "Was PAVA drawn by anyone during this incident?",
@@ -83,7 +91,7 @@
     }
     )}}
 
-    <!-- Q5 -->
+    <!-- Q6 -->
     {{ incidentMacro.radiosWithNestedRadios({
       primaryQuestion: {
         text: "Was a guiding hold used?",
@@ -112,7 +120,7 @@
     }
     )}}
 
-    <!-- Q6 -->
+    <!-- Q7 -->
     {{ incidentMacro.radio( {
     text: "Was an escorting hold used?",
     name: "escortingHold",
@@ -121,7 +129,7 @@
     errorMessage: errors | findError('escortingHold')
     })}}
 
-    <!-- Q7 -->
+    <!-- Q8 -->
     <div id="control-and-restraint">
     {{ incidentMacro.radiosWithNestedCheckboxes({
       primaryQuestion: {
@@ -142,7 +150,7 @@
   }}
   </div>
 
-  <!-- Q8 -->
+  <!-- Q9 -->
     <div id="pain-inducing-techniques">
       {{ incidentMacro.radiosWithNestedCheckboxes({
         primaryQuestion: {
@@ -163,7 +171,7 @@
     }}
     </div>
 
-    <!-- Q9 -->
+    <!-- 10 -->
     {{ incidentMacro.radio( {
       text: "Were handcuffs applied?",
       name: "handcuffsApplied",
@@ -174,4 +182,8 @@
   </div>
 </div>
 
+{% endblock %}
+
+{% block script %}
+<script src="/assets/add-another-evidence.js"></script>
 {% endblock %}

--- a/server/views/formPages/incident/useOfForceDetails.html
+++ b/server/views/formPages/incident/useOfForceDetails.html
@@ -32,11 +32,19 @@
     })}}
 
     <!-- Q2 new question body-worn camera question which was previously in the evidence page -->
-    {{ incidentMacro.radioWithNestedTextBox({
-      text: "Was any part of the incident captured on a body-worn camera?",
-      name: "bodyWornCamera",
-      value: data,
-      errors: errors 
+    {{ incidentMacro.radioWithMultipleNestedTextBox({
+      primaryQuestion:{
+        text: "Was any part of the incident captured on a body-worn camera?",
+        name: "bodyWornCamera",
+        value: data.bodyWornCamera,
+        errorMessage: errors | findError('bodyWornCamera')
+    },
+      followUpQuestion:{      
+        name: "bodyWornCameraNumbers",
+        value: data.bodyWornCameraNumbers,
+        errorMessage: errors,
+        otherIds: ['cameraNum', 'Camera number']
+      }
     }) }}
 
     <!-- Q3 -->

--- a/server/views/formPages/incidentMacros.njk
+++ b/server/views/formPages/incidentMacros.njk
@@ -1,3 +1,7 @@
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
 {% macro radio(question) %}
 {% if question.errorMessage.text %}
 {% set govukFormGroupError =  'govuk-form-group--error' %}
@@ -47,6 +51,108 @@
 </div>
 {% endmacro %}
 
+
+{% macro radioWithNestedTextBox(question) %}
+    <div class="govuk-!-margin-bottom-9
+    {% if question.errors | findError('bodyWornCamera') %}
+      govuk-form-group--error
+      {% set cameraErrMsg =  question.errors | findError('bodyWornCamera') %}
+    {% endif %}">
+    
+    <fieldset class="govuk-fieldset">
+      <legend class="govuk-fieldset__legend ">
+        Was any part of the incident captured on a body-worn camera?
+      </legend>
+      <span id="cameraErrMsg" class="govuk-error-message">
+        <span class="govuk-visually-hidden">Error:</span>
+        {{ cameraErrMsg.text }}
+      </span>
+      
+      <div class="govuk-radios" data-module="govuk-radios">
+        <div class=" govuk-radios">
+          <div class="govuk-radios__item">
+            <input class="govuk-radios__input" id="bodyWornCamera" name="bodyWornCamera" 
+            type="radio" value="YES" data-aria-controls="body-worn-camera-conditional" 
+            {% if question.value.bodyWornCamera === 'YES' %} checked="checked" {% endif %}>
+            <label class="govuk-label govuk-radios__label" for="bodyWornCamera">
+              Yes
+            </label>
+          </div>
+          <!-- hidden panel starts here -->
+          <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="body-worn-camera-conditional">
+
+            <!-- add another starts here -->
+            <div class="add-another-camera" id="bodyWornCameraNumbers">
+
+              {% for camera in question.value.bodyWornCameraNumbers %}
+                {{ addCameraNumber(question.errors, index = loop.index0, value = camera.cameraNum, showRemove = loop.length != 1) }}
+              {% else %}
+                {{ addCameraNumber(question.errors, index = 0, value = null, showRemove = false) }}
+              {% endfor %}
+
+              <div class="button-action">
+                {{
+                govukButton({
+                  text: 'Add another',
+                  classes: 'govuk-button--secondary  add-another__add-button govuk-!-margin-bottom-4',
+                  attributes: { 'data-qa-add-another-camera': true }
+                })
+              }}
+              </div>
+            </div>
+            <!-- add another ends here -->
+          </div>
+          <!-- hidden panel end -->
+
+          <div class="govuk-radios__item">
+            <input class="govuk-radios__input" id="body-worn-camera-no" name="bodyWornCamera" type="radio" value="NO" {% if question.value.bodyWornCamera === 'NO' %} checked="checked" {% endif %}>
+            <label class="govuk-label govuk-radios__label" for="body-worn-camera-no">
+              No
+            </label>
+          </div>
+          <div class="govuk-radios__item">
+            <input class="govuk-radios__input" id="body-worn-camera-notKnown" name="bodyWornCamera" type="radio" value="NOT_KNOWN" {% if question.value.bodyWornCamera === 'NOT_KNOWN' %} checked="checked" {% endif %}>
+            <label class="govuk-label govuk-radios__label" for="body-worn-camera-notKnown">
+              Not known
+            </label>
+          </div>
+        </div>
+      </div>
+      <!-- end of radios -->
+    </fieldset>
+  </div>
+{% endmacro %}
+
+{% macro addCameraNumber(errors, index, value, showRemove) %}
+  {% call govukFieldset({ classes: 'add-another__item' }) %}
+  <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-third" id="bodyWornCameraNumbers[{{index}}]">
+      {{
+      govukInput({
+        errorMessage: errors | findErrors(['bodyWornCameraNumbers[' + index + ']', 'bodyWornCameraNumbers[' + index + '][cameraNum]']),
+        label: {
+          html: 'Camera number'
+        },
+        id: 'bodyWornCameraNumbers[' + index + '][cameraNum]',
+        name: 'bodyWornCameraNumbers[' + index + '][cameraNum]',
+        value: value,
+        attributes: {
+          'data-name': 'bodyWornCameraNumbers[%index%][cameraNum]',
+          'data-id': 'bodyWornCameraNumbers[%index%][cameraNum]'
+        }
+        })
+      }}
+      </div>
+      <div class="govuk-grid-column-one-third remove-button-container govuk-!-margin-top-6">
+        {% if showRemove %}
+          <button type="button" class="govuk-button govuk-button--secondary add-another__remove-button">
+          Remove
+          </button>
+        {% endif  %}
+      </div>
+  </div>  
+  {% endcall %}
+{% endmacro%}
 
 {% macro radiosWithNestedRadios(question) %}
 

--- a/server/views/formPages/incidentMacros.njk
+++ b/server/views/formPages/incidentMacros.njk
@@ -52,42 +52,56 @@
 {% endmacro %}
 
 
-{% macro radioWithNestedTextBox(question) %}
-    <div class="govuk-!-margin-bottom-9
-    {% if question.errors | findError('bodyWornCamera') %}
-      govuk-form-group--error
-      {% set cameraErrMsg =  question.errors | findError('bodyWornCamera') %}
-    {% endif %}">
+{% macro radioWithMultipleNestedTextBox(question) %}
+
+  {% if question.primaryQuestion.errorMessage %}
+    {% set govukFormGroupErrorOuter  =  'govuk-form-group--error' %}
+    {% set primaryErrorMessageText = question.primaryQuestion.errorMessage.text %}
+  {% endif %}
     
+  <div class="govuk-!-margin-bottom-9 {{govukFormGroupErrorOuter}}">
     <fieldset class="govuk-fieldset">
       <legend class="govuk-fieldset__legend ">
-        Was any part of the incident captured on a body-worn camera?
+        {{question.primaryQuestion.text}}
       </legend>
-      <span id="cameraErrMsg" class="govuk-error-message">
+      <span id="primaryQuestionErrMsg" class="govuk-error-message">
         <span class="govuk-visually-hidden">Error:</span>
-        {{ cameraErrMsg.text }}
+        {{ primaryErrorMessageText}}
       </span>
       
       <div class="govuk-radios" data-module="govuk-radios">
         <div class=" govuk-radios">
           <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="bodyWornCamera" name="bodyWornCamera" 
-            type="radio" value="YES" data-aria-controls="body-worn-camera-conditional" 
-            {% if question.value.bodyWornCamera === 'YES' %} checked="checked" {% endif %}>
-            <label class="govuk-label govuk-radios__label" for="bodyWornCamera">
+            <input class="govuk-radios__input" id="{{question.primaryQuestion.name}}" name="{{question.primaryQuestion.name}}"
+            type="radio" value="YES" data-aria-controls="conditional-inputs" 
+            {% if question.primaryQuestion.value === 'YES' %} checked="checked" {% endif %}>
+            <label class="govuk-label govuk-radios__label" for="{{question.primaryQuestion.name}}">
               Yes
             </label>
           </div>
           <!-- hidden panel starts here -->
-          <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="body-worn-camera-conditional">
+          <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-inputs">
 
             <!-- add another starts here -->
-            <div class="add-another-camera" id="bodyWornCameraNumbers">
-
-              {% for camera in question.value.bodyWornCameraNumbers %}
-                {{ addCameraNumber(question.errors, index = loop.index0, value = camera.cameraNum, showRemove = loop.length != 1) }}
+            <div class="add-another-input" id="{{question.followUpQuestion.name}}">
+              {% for item in question.followUpQuestion.value %}
+               
+                {{ addAnother(
+                question.followUpQuestion.otherIds, 
+                question.followUpQuestion.name, 
+                question.followUpQuestion.errorMessage, 
+                index = loop.index0, 
+                value = item[question.followUpQuestion.otherIds[0]], 
+                showRemove = loop.length != 1) 
+                }}
               {% else %}
-                {{ addCameraNumber(question.errors, index = 0, value = null, showRemove = false) }}
+                {{ addAnother(
+                question.followUpQuestion.otherIds, 
+                question.followUpQuestion.name, 
+                question.followUpQuestion.errorMessage, 
+                index = 0, 
+                value = null, 
+                showRemove = false) }}
               {% endfor %}
 
               <div class="button-action">
@@ -95,7 +109,7 @@
                 govukButton({
                   text: 'Add another',
                   classes: 'govuk-button--secondary  add-another__add-button govuk-!-margin-bottom-4',
-                  attributes: { 'data-qa-add-another-camera': true }
+                  attributes: { 'data-qa-add-another-input': true }
                 })
               }}
               </div>
@@ -105,14 +119,14 @@
           <!-- hidden panel end -->
 
           <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="body-worn-camera-no" name="bodyWornCamera" type="radio" value="NO" {% if question.value.bodyWornCamera === 'NO' %} checked="checked" {% endif %}>
-            <label class="govuk-label govuk-radios__label" for="body-worn-camera-no">
+            <input class="govuk-radios__input" id="primary-question-no" name="{{question.primaryQuestion.name}}" type="radio" value="NO" {% if question.primaryQuestion.value === 'NO' %} checked="checked" {% endif %}>
+            <label class="govuk-label govuk-radios__label" for="primary-question-no">
               No
             </label>
           </div>
           <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="body-worn-camera-notKnown" name="bodyWornCamera" type="radio" value="NOT_KNOWN" {% if question.value.bodyWornCamera === 'NOT_KNOWN' %} checked="checked" {% endif %}>
-            <label class="govuk-label govuk-radios__label" for="body-worn-camera-notKnown">
+            <input class="govuk-radios__input" id="primary-question-notKnown" name="{{question.primaryQuestion.name}}" type="radio" value="NOT_KNOWN" {% if question.primaryQuestion.value === 'NOT_KNOWN' %} checked="checked" {% endif %}>
+            <label class="govuk-label govuk-radios__label" for="primary-question-notKnown">
               Not known
             </label>
           </div>
@@ -123,22 +137,22 @@
   </div>
 {% endmacro %}
 
-{% macro addCameraNumber(errors, index, value, showRemove) %}
+{% macro addAnother(otherIds, name, errors, index, value, showRemove) %}
   {% call govukFieldset({ classes: 'add-another__item' }) %}
   <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-third" id="bodyWornCameraNumbers[{{index}}]">
+      <div class="govuk-grid-column-one-third" id={{name}}[{{index}}]>
       {{
       govukInput({
-        errorMessage: errors | findErrors(['bodyWornCameraNumbers[' + index + ']', 'bodyWornCameraNumbers[' + index + '][cameraNum]']),
+        errorMessage: errors | findErrors([name + '[' + index + ']', name + '[' + index + ']['+ otherIds[0] + ']']),
         label: {
-          html: 'Camera number'
+          html: otherIds[1]
         },
-        id: 'bodyWornCameraNumbers[' + index + '][cameraNum]',
-        name: 'bodyWornCameraNumbers[' + index + '][cameraNum]',
+        id: name + '[' + index + ']['+ otherIds[0] + ']',
+        name: name + '[' + index + ']['+ otherIds[0] + ']',
         value: value,
         attributes: {
-          'data-name': 'bodyWornCameraNumbers[%index%][cameraNum]',
-          'data-id': 'bodyWornCameraNumbers[%index%][cameraNum]'
+          'data-name': name + '[%index%]['+ otherIds[0] +']',
+          'data-id': name + '[%index%]['+ otherIds[0] +']'
         }
         })
       }}

--- a/server/views/pages/reportDetailMacro.njk
+++ b/server/views/pages/reportDetailMacro.njk
@@ -180,6 +180,16 @@
         print: print
       })
     }}
+
+    {{
+      reportDetailsMacros.tableRow({
+        label: 'Was any part of the incident captured on a body-worn camera?',
+        'data-qa': 'bodyCameras',
+        dataValue: data.useOfForceDetails.bodyCameras | capitalize,
+        print: print
+      })
+    }}
+
     {{
       reportDetailsMacros.tableRow({
         label: 'Were any personal protection techniques used?',
@@ -357,13 +367,4 @@
         print: print
       })
     }}
-    {{
-      reportDetailsMacros.tableRow({
-        label: 'Was any part of the incident captured on a body-worn camera?',
-        'data-qa': 'bodyCameras',
-        dataValue: data.evidence.bodyCameras | capitalize,
-        print: print
-      })
-    }}
-
 {% endmacro %}


### PR DESCRIPTION
[MAP-581](https://dsdmoj.atlassian.net/jira/software/c/projects/MAP/boards/1354?selectedIssue=MAP-581)
Move the body-camera question out of the 'Evidence' page and put in 'Use of force details' page.

The code in the PR will put the body-worn camera responses for any new reports in the correct place of the DB blob. However old reports will still have the data within Evidence section of blob. The long term goal is to run a DB migration to shift the data and [MAP-642](https://dsdmoj.atlassian.net/jira/software/c/projects/MAP/boards/1354?selectedIssue=MAP-642) has been raised to do that work. 
In the meantime I have implemented logic in the [4th commit ](https://github.com/ministryofjustice/use-of-force/pull/672/commits/ca059c6c62044e940c2f9cda9efc70e256b0ddae) of this PR to get the question response irrespective of which section it is in the blob. 
And while I have annotated the question as optional, it is mandatory, and was done just to accommodate the fact that it could be in either evidence or details sections. And once Map-642 has been done, we can rip out the changes in the 4th commit


[MAP-581]: https://dsdmoj.atlassian.net/browse/MAP-581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAP-642]: https://dsdmoj.atlassian.net/browse/MAP-642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ