### PR TITLE
Fix breaking docker build

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "audit-ci": "^6.6.1",
     "concurrently": "^7.6.0",
     "cypress": "^13.8.1",
-    "cypress-multi-reporters": "^1.6.3",
+    "cypress-multi-reporters": "^1.6.4",
     "dotenv": "^16.4.5",
     "eslint": "^8.40.0",
     "eslint-config-airbnb-base": "^15.0.0",
@@ -179,9 +179,6 @@
     "typescript": "^4.9.5"
   },
   "overrides": {
-    "cypress": {
-      "tough-cookie": "4.1.3"
-    },
     "jest-html-reporter": {
       "@babel/traverse": "7.23.2"
     },


### PR DESCRIPTION
Base node image updated from bullseye to bookworm  and also cypress from 13.1.0 to 13.8.1 (to match typescript template project) in previous commit.  
This has caused docker build to fail with _ERROR [builder 7/8] RUN CYPRESS_INSTALL_BINARY=0 npm ci --no-audit_

Updating cypress-multi-reporters and removing dependency override to see if that resolves error