### PR TITLE
MAP-1044 revert cypress to last good docker image build state

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,6 +142,15 @@ workflows:
             branches:
               only:
                 - main
+      - hmpps/build_docker:
+          name: test_build_docker
+          publish: false
+          requires:
+            - build
+          filters:
+            branches:
+              ignore:
+                - main
       - hmpps/deploy_env:
           name: deploy_dev
           env: "dev"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,13 @@ ARG BUILD_NUMBER
 ARG GIT_REF
 
 RUN apt-get update && \
-        apt-get upgrade -y
+        apt-get upgrade -y \
+RUN apt-get -y install g++ make python3 curl && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
-RUN apt-get install -y curl
-
 RUN curl https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem \
         > /app/root.cert
-
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG BUILD_NUMBER
 ARG GIT_REF
 
 RUN apt-get update && \
-        apt-get upgrade -y \
+        apt-get upgrade -y
 RUN apt-get -y install g++ make python3 curl && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "@typescript-eslint/parser": "^5.59.6",
         "audit-ci": "^6.6.1",
         "concurrently": "^7.6.0",
-        "cypress": "^13.8.1",
+        "cypress": "^13.1.0",
         "cypress-multi-reporters": "^1.6.3",
         "dotenv": "^16.4.5",
         "eslint": "^8.40.0",

--- a/package.json
+++ b/package.json
@@ -152,8 +152,8 @@
     "@typescript-eslint/parser": "^5.59.6",
     "audit-ci": "^6.6.1",
     "concurrently": "^7.6.0",
-    "cypress": "^13.1.0",
-    "cypress-multi-reporters": "^1.6.3",
+    "cypress": "^13.8.1",
+    "cypress-multi-reporters": "^1.6.4",
     "dotenv": "^16.4.5",
     "eslint": "^8.40.0",
     "eslint-config-airbnb-base": "^15.0.0",
@@ -179,9 +179,6 @@
     "typescript": "^4.9.5"
   },
   "overrides": {
-    "cypress": {
-      "tough-cookie": "4.1.3"
-    },
     "jest-html-reporter": {
       "@babel/traverse": "7.23.2"
     },

--- a/package.json
+++ b/package.json
@@ -152,8 +152,8 @@
     "@typescript-eslint/parser": "^5.59.6",
     "audit-ci": "^6.6.1",
     "concurrently": "^7.6.0",
-    "cypress": "^13.8.1",
-    "cypress-multi-reporters": "^1.6.4",
+    "cypress": "^13.1.0",
+    "cypress-multi-reporters": "^1.6.3",
     "dotenv": "^16.4.5",
     "eslint": "^8.40.0",
     "eslint-config-airbnb-base": "^15.0.0",
@@ -179,6 +179,9 @@
     "typescript": "^4.9.5"
   },
   "overrides": {
+    "cypress": {
+      "tough-cookie": "4.1.3"
+    },
     "jest-html-reporter": {
       "@babel/traverse": "7.23.2"
     },


### PR DESCRIPTION
docker build failing after dependency updates.
error:

` => ERROR [builder 7/8] RUN CYPRESS_INSTALL_BINARY=0 npm ci --no-audit &  24.1s`

Reverting cypress updates to determine the issue

====

Actual problem was not with the cypress version, rather the bookworm-slim not including python. 
Dockerfile updated to install python
