### PR TITLE
MAP-1670: Restore the correct liveness and readiness probes

### DIFF
--- a/helm_deploy/use-of-force/values.yaml
+++ b/helm_deploy/use-of-force/values.yaml
@@ -13,6 +13,14 @@ generic-service:
     enabled: true
     tlsSecretName: use-of-force-cert
     path: /
+  
+  livenessProbe:
+    httpGet:
+      path: /ping
+
+  readinessProbe:
+    httpGet:
+      path: /ping
 
   env:
     TOKENVERIFICATION_API_ENABLED: true


### PR DESCRIPTION
When we updated the Helm chart it brought some default liveness and readiness probe config that is incompatible with this project. We need to override the probe config in the same way that the TypeScript template project does.

MAP-1670