### PR TITLE
MAP-1670: Got the health endpoint wrong in the last commit

### DIFF
--- a/helm_deploy/use-of-force/values.yaml
+++ b/helm_deploy/use-of-force/values.yaml
@@ -16,11 +16,11 @@ generic-service:
   
   livenessProbe:
     httpGet:
-      path: /ping
+      path: /health
 
   readinessProbe:
     httpGet:
-      path: /ping
+      path: /health
 
   env:
     TOKENVERIFICATION_API_ENABLED: true


### PR DESCRIPTION
This project actually uses `/health` not `/ping` for health check.

MAP-1670