### PR TITLE
MAP-1670 move getting fecomponents to after authorisationMiddleware

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -301,11 +301,10 @@ export default function createApp(services: Services): Express {
 
   app.use(populateCurrentUser(services.userService))
 
-  app.get('*', getFrontendComponents(services.feComponentsService))
-
   app.use(unauthenticatedRoutes(services))
   app.use(authorisationMiddleware)
 
+  app.get('*', getFrontendComponents(services.feComponentsService))
   app.use(createRouter(authenticationMiddleware, services))
 
   app.use((req, res, next) => {


### PR DESCRIPTION
to reduce the 'Cannot read properties of undefined (reading 'token')' error occurring in fecomponents