### PR TITLE
MAP-1625 get report using db query that doesn't require user

### DIFF
--- a/server/routes/adhocReportActions/addhocActionController.ts
+++ b/server/routes/adhocReportActions/addhocActionController.ts
@@ -19,7 +19,7 @@ export default class AddhocActionController {
 
     for (let reportId = fromId; reportId <= toId; reportId += 1) {
       try {
-        const report = await this.reportService.getReport(req.user.username, reportId)
+        const report = await this.reportService.getReportUsingReportIdOnly(reportId)
 
         const { locationId } = report.form.incidentDetails
 

--- a/server/routes/adhocReportActions/adhocActionController.test.ts
+++ b/server/routes/adhocReportActions/adhocActionController.test.ts
@@ -60,9 +60,9 @@ describe('Adhoc actions', () => {
     it('calls the report service to get reports correctly', async () => {
       await controller.updateReport(req, res)
 
-      expect(reportService.getReport).toHaveBeenCalledTimes(2)
-      expect(reportService.getReport).toHaveBeenCalledWith('user_name', 1)
-      expect(reportService.getReport).toHaveBeenCalledWith('user_name', 2)
+      expect(reportService.getReportUsingReportIdOnly).toHaveBeenCalledTimes(2)
+      expect(reportService.getReportUsingReportIdOnly).toHaveBeenCalledWith(1)
+      expect(reportService.getReportUsingReportIdOnly).toHaveBeenCalledWith(2)
     })
 
     it('does not do update if incidentLocationId already exists', async () => {
@@ -75,7 +75,7 @@ describe('Adhoc actions', () => {
         },
       }
 
-      reportService.getReport.mockResolvedValue(report as any)
+      reportService.getReportUsingReportIdOnly.mockResolvedValue(report as any)
       await controller.updateReport(req, res)
 
       expect(reportService.update).not.toHaveBeenCalled()
@@ -95,8 +95,8 @@ describe('Adhoc actions', () => {
         },
       }
 
-      reportService.getReport.mockResolvedValueOnce(report as any)
-      reportService.getReport.mockRejectedValueOnce(Error(`Report does not exist: 2`))
+      reportService.getReportUsingReportIdOnly.mockResolvedValueOnce(report as any)
+      reportService.getReportUsingReportIdOnly.mockRejectedValueOnce(Error(`Report does not exist: 2`))
 
       nomisMappingService.getDpsLocationDetailsHavingCorrespondingNomisLocationId.mockResolvedValue({
         dpsLocationId: 'some-uuid',
@@ -143,7 +143,7 @@ describe('Adhoc actions', () => {
         },
       }
 
-      reportService.getReport.mockResolvedValue(report as any)
+      reportService.getReportUsingReportIdOnly.mockResolvedValue(report as any)
 
       nomisMappingService.getDpsLocationDetailsHavingCorrespondingNomisLocationId.mockResolvedValue({
         dpsLocationId: 'some-uuid',

--- a/server/services/reportService.ts
+++ b/server/services/reportService.ts
@@ -64,6 +64,15 @@ export default class ReportService {
     return report
   }
 
+  async getReportUsingReportIdOnly(reportId: number): Promise<Report> {
+    const report = await this.incidentClient.getReportForReviewer(reportId)
+
+    if (!report) {
+      throw new Error(`Report does not exist: ${reportId}`)
+    }
+    return report
+  }
+
   async getAnonReportSummary(token: string, statementId: number): Promise<AnonReportSummaryWithPrison | undefined> {
     const report = await this.incidentClient.getAnonReportSummary(statementId)
     if (!report) {


### PR DESCRIPTION
Use a different DB query to get reports  - a query that does not require the report's submitter as an argument