### PR TITLE
MAP-1874 increase time for which a job will be live

### DIFF
--- a/helm_deploy/use-of-force/templates/job.yaml
+++ b/helm_deploy/use-of-force/templates/job.yaml
@@ -13,7 +13,7 @@ spec:
       template:
         spec:
           restartPolicy: Never
-          activeDeadlineSeconds: 240
+          activeDeadlineSeconds: 298
           containers:
           - name: use-of-force
             image: {{ with index .Values "generic-service" }}{{ .image.repository }}:{{ .image.tag }}{{ end }}


### PR DESCRIPTION
the send-reminders cron jobs are intermittently failing. 
Increasing the 'live' time of the job as it may enable the job to complete before it fails
Note a new job is started every 300 seconds