### PR TITLE
Revert "MAP-1937 update helm chart for data extractor (#740)"

### DIFF
--- a/helm_deploy/use-of-force/Chart.yaml
+++ b/helm_deploy/use-of-force/Chart.yaml
@@ -12,5 +12,5 @@ dependencies:
     version: 1.10
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-data-analytics-extractor
-    version: 1.2.0
+    version: 1.1.1
     repository: https://ministryofjustice.github.io/hmpps-helm-charts


### PR DESCRIPTION
This reverts commit 4d9bc7e916b9da55c3232ad213f62af5c41f0779.