### PR TITLE
Map 1745 UOF bug users unable to access incident details page

### DIFF
--- a/server/routes/creatingReports/changePrison.test.ts
+++ b/server/routes/creatingReports/changePrison.test.ts
@@ -34,10 +34,10 @@ afterEach(() => {
   jest.resetAllMocks()
 })
 
-describe('GET /change-prison', () => {
+describe('GET /prison-of-incident', () => {
   test('should render content', () => {
     return request(app)
-      .get(`/report/-19/change-prison`)
+      .get(`/report/-19/prison-of-incident`)
       .expect('Content-Type', /html/)
       .expect(res => {
         expect(res.text).toContain('What prison did the use of force take place in?')
@@ -45,10 +45,10 @@ describe('GET /change-prison', () => {
       })
   })
 })
-describe('POST /change-prison', () => {
+describe('POST /prison-of-incident', () => {
   it('should redirect to incident-details page', () => {
     return request(app)
-      .post('/report/-19/change-prison')
+      .post('/report/-19/prison-of-incident')
       .send({ agencyId: 'MDI', submit: 'save-and-continue' })
       .expect(302)
       .expect('Location', '/report/-19/incident-details')
@@ -56,15 +56,15 @@ describe('POST /change-prison', () => {
 
   it('Not selecting a prison but selecting Continue should redirect to current page', () => {
     return request(app)
-      .post('/report/-19/change-prison')
+      .post('/report/-19/prison-of-incident')
       .send({ submit: 'save-and-continue' })
       .expect(302)
-      .expect('Location', '/report/-19/change-prison')
+      .expect('Location', '/report/-19/prison-of-incident')
   })
 
   it('Selecting a prison followed by Continue should call the location service', () => {
     return request(app)
-      .post('/report/-19/change-prison')
+      .post('/report/-19/prison-of-incident')
       .send({ agencyId: 'MDI', submit: 'save-and-continue' })
       .expect(302)
       .expect(() => {
@@ -74,7 +74,7 @@ describe('POST /change-prison', () => {
 
   it('Cancel should not call the location service', () => {
     return request(app)
-      .post('/report/-19/change-prison')
+      .post('/report/-19/prison-of-incident')
       .send({ agencyId: 'MDI', submit: 'cancel' })
       .expect(302)
       .expect(() => {
@@ -86,7 +86,7 @@ describe('POST /change-prison', () => {
     flash.mockReturnValue([{ plannedUseOfForce: true, authorisedBy: 'the authoriser' }])
 
     return request(app)
-      .post('/report/-19/change-prison')
+      .post('/report/-19/prison-of-incident')
       .send({ agencyId: 'MDI', submit: 'save-and-continue' })
       .expect(302)
       .expect(() => {

--- a/server/routes/creatingReports/changePrison.ts
+++ b/server/routes/creatingReports/changePrison.ts
@@ -39,7 +39,7 @@ export default class ChangePrisonRoutes {
 
       const userInput = req.flash('userInputForIncidentDetails')
 
-      // this will create a new report record if it doesn't exist already (as will be the case for TRN and OUT)
+      // this will create a new report record if it doesn't exist already
       await this.draftReportService.process(
         res.locals.user,
         parseInt(bookingId, 10),

--- a/server/routes/creatingReports/changePrison.ts
+++ b/server/routes/creatingReports/changePrison.ts
@@ -37,6 +37,21 @@ export default class ChangePrisonRoutes {
         return res.redirect(req.originalUrl)
       }
 
+      const userInput = req.flash('userInputForIncidentDetails')
+
+      // this will create a new report record if it doesn't exist already (as will be the case for TRN and OUT)
+      await this.draftReportService.process(
+        res.locals.user,
+        parseInt(bookingId, 10),
+        'incidentDetails',
+        {
+          plannedUseOfForce: userInput[0]?.plannedUseOfForce,
+          authorisedBy: userInput[0]?.authorisedBy,
+          witnesses: userInput[0]?.witnesses,
+        },
+        null
+      )
+
       await this.draftReportService.updateAgencyId(agencyId, username, Number(bookingId))
     }
 

--- a/server/routes/creatingReports/incidentDetails.test.ts
+++ b/server/routes/creatingReports/incidentDetails.test.ts
@@ -125,6 +125,27 @@ describe('GET /section/form', () => {
         expect(locationService.getIncidentLocations).toBeCalledWith('user1-system-token', 'persisted-agency-id')
       })
   })
+  test('should redirect to /change-prison if agencyId is TRN', () => {
+    draftReportService.getCurrentDraft.mockResolvedValue({ id: '1', agencyId: 'TRN' })
+    return request(app)
+      .get(`/report/1/incident-details`)
+      .expect(302)
+      .expect('Location', '/report/1/change-prison')
+      .expect(() => {
+        expect(locationService.getIncidentLocations).not.toHaveBeenCalled()
+      })
+  })
+
+  test('should redirect to /change-prison if agencyId is OUT', () => {
+    draftReportService.getCurrentDraft.mockResolvedValue({ id: '1', agencyId: 'OUT' })
+    return request(app)
+      .get(`/report/1/incident-details`)
+      .expect(302)
+      .expect('Location', '/report/1/change-prison')
+      .expect(() => {
+        expect(locationService.getIncidentLocations).not.toHaveBeenCalled()
+      })
+  })
 })
 
 describe('POST save and continue /section/form', () => {
@@ -145,6 +166,7 @@ describe('POST save and continue /section/form', () => {
       .expect(302)
       .expect('Location', '/report/1/staff-involved')
       .expect(() => {
+        expect(flash).toHaveBeenCalledTimes(2)
         expect(draftReportService.process).toBeCalledTimes(1)
         expect(draftReportService.process).toBeCalledWith(
           user,
@@ -248,6 +270,7 @@ describe('POST save and return to tasklist', () => {
       .expect(302)
       .expect('Location', '/report/1/change-prison')
       .expect(() => {
+        expect(flash).toHaveBeenCalledTimes(1)
         expect(draftReportService.getPotentialDuplicates).not.toBeCalled()
         expect(draftReportService.process).toBeCalledTimes(1)
         expect(draftReportService.process).toBeCalledWith(

--- a/server/routes/creatingReports/incidentDetails.test.ts
+++ b/server/routes/creatingReports/incidentDetails.test.ts
@@ -125,23 +125,23 @@ describe('GET /section/form', () => {
         expect(locationService.getIncidentLocations).toBeCalledWith('user1-system-token', 'persisted-agency-id')
       })
   })
-  test('should redirect to /change-prison if agencyId is TRN', () => {
+  test('should redirect to /prison-of-incident if agencyId is TRN', () => {
     draftReportService.getCurrentDraft.mockResolvedValue({ id: '1', agencyId: 'TRN' })
     return request(app)
       .get(`/report/1/incident-details`)
       .expect(302)
-      .expect('Location', '/report/1/change-prison')
+      .expect('Location', '/report/1/prison-of-incident')
       .expect(() => {
         expect(locationService.getIncidentLocations).not.toHaveBeenCalled()
       })
   })
 
-  test('should redirect to /change-prison if agencyId is OUT', () => {
+  test('should redirect to /prison-of-incident if agencyId is OUT', () => {
     draftReportService.getCurrentDraft.mockResolvedValue({ id: '1', agencyId: 'OUT' })
     return request(app)
       .get(`/report/1/incident-details`)
       .expect(302)
-      .expect('Location', '/report/1/change-prison')
+      .expect('Location', '/report/1/prison-of-incident')
       .expect(() => {
         expect(locationService.getIncidentLocations).not.toHaveBeenCalled()
       })
@@ -268,7 +268,7 @@ describe('POST save and return to tasklist', () => {
         witnesses: [{ name: 'User bob' }, { name: '' }],
       })
       .expect(302)
-      .expect('Location', '/report/1/change-prison')
+      .expect('Location', '/report/1/prison-of-incident')
       .expect(() => {
         expect(flash).toHaveBeenCalledTimes(1)
         expect(draftReportService.getPotentialDuplicates).not.toBeCalled()

--- a/server/routes/creatingReports/incidentDetails.ts
+++ b/server/routes/creatingReports/incidentDetails.ts
@@ -40,7 +40,7 @@ export default class IncidentDetailsRoutes {
 
   private async getSubmitRedirectLocation(req: Request, bookingId: number, submitType) {
     if (submitType === SubmitType.SAVE_AND_CHANGE_PRISON) {
-      return `/report/${bookingId}/change-prison`
+      return `/report/${bookingId}/prison-of-incident`
     }
 
     if (await this.draftReportService.isDraftComplete(req.user.username, bookingId)) {
@@ -80,7 +80,7 @@ export default class IncidentDetailsRoutes {
 
     // if prisoner is currently being transferred or has left the prison, redirect user to select prison where the incident occured
     if (prisonId === 'TRN' || prisonId === 'OUT') {
-      return res.redirect(`/report/${bookingId}/change-prison`)
+      return res.redirect(`/report/${bookingId}/prison-of-incident`)
     }
 
     const locations = await this.locationService.getIncidentLocations(token, prisonId)

--- a/server/routes/creatingReports/index.ts
+++ b/server/routes/creatingReports/index.ts
@@ -64,8 +64,8 @@ export default function Index({
   get(reportPath('staff-member-not-found'), addInvolvedStaff.viewStaffMemberNotFound)
 
   const changePrison = new ChangePrisonRoutes(locationService, draftReportService, systemToken)
-  get(reportPath('change-prison'), changePrison.viewPrisons)
-  post(reportPath('change-prison'), changePrison.submit)
+  get(reportPath('prison-of-incident'), changePrison.viewPrisons)
+  post(reportPath('prison-of-incident'), changePrison.submit)
 
   const whyWasUoFApplied = new WhyWasUoFAppliedRoutes(draftReportService)
   get(reportPath('why-was-uof-applied'), whyWasUoFApplied.view())


### PR DESCRIPTION
[MAP-1745](https://dsdmoj.atlassian.net/jira/software/c/projects/MAP/boards/1354?assignee=5cd29c554326200dc971eab7&selectedIssue=MAP-1745)

This code change fixes the scenario where the /incident-details page will not load if an offender is currently in a transfer or has left prison. This is signified by the offenders agencyId being TRN or OUT. 
In such cases, loading of incident-details fails (and throws a 400 error) because TRN and OUT are not actual prisons and getting their internal locations, which are required by the select drop-down on the page, would return an error.

With the new code, when a user selects /incident-details, a check of the agencyId is done. If it's either TRN or OUT then we redirect to the change prison page. The /change-prison endpoint has been renamed to /prison-of-incident because the user isn't necessarily expecting to change prison of their own accord. 

In the previous code, selecting the 'Change' link in /incident-details page saves any user input and calls draftReportService.process which either updates an existing report or creates a new one. This is triggered via frontend javascript that acts on components with the 'js-submitLink' html class. Because the frontend javascript trigger is now being circumvented by the immediate redirect to /prison-of-incident, the draftReportService.process is called in the submit of /prison-of-incident.

Have used flash to pass any user inputs to /prison-of-incident


[MAP-1745]: https://dsdmoj.atlassian.net/browse/MAP-1745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ