### PR TITLE
MAP-1937 give jobs longer time to complete. 

### DIFF
--- a/helm_deploy/use-of-force/templates/job.yaml
+++ b/helm_deploy/use-of-force/templates/job.yaml
@@ -3,17 +3,18 @@ kind: CronJob
 metadata:
   name: send-reminders
 spec:
-  schedule: "*/5 * * * *"
+  schedule: "*/10 * * * *"
   concurrencyPolicy: Replace
   failedJobsHistoryLimit: 5
   startingDeadlineSeconds: 300
   successfulJobsHistoryLimit: 5
   jobTemplate:
+    ttlSecondsAfterFinished: 100
     spec:
       template:
         spec:
           restartPolicy: Never
-          activeDeadlineSeconds: 298
+          activeDeadlineSeconds: 600
           containers:
           - name: use-of-force
             image: {{ with index .Values "generic-service" }}{{ .image.repository }}:{{ .image.tag }}{{ end }}

--- a/helm_deploy/use-of-force/templates/job.yaml
+++ b/helm_deploy/use-of-force/templates/job.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: send-reminders
 spec:
-  schedule: "*/10 * * * *"
+  schedule: "*/15 * * * *"
   concurrencyPolicy: Replace
   failedJobsHistoryLimit: 5
   startingDeadlineSeconds: 300


### PR DESCRIPTION
The Email reminder cron job fails intermittently. Not sure of the exact cause but have noticed that jobs sometimes run very close to their 300 second 'active' time. 

This code change: 
Gives Jobs a longer time, 600 seconds, before they are treated as failed, see [activeDeadlineSeconds](https://kubernetes.io/docs/concepts/workloads/controllers/job/)

Cleans up completed job at 100 seconds, see [ttlSecondsAfterFinished](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/Cronjobs.html#kubernetes-cronjobs)

We currently run jobs every 5 mins. Have increased that to 15 mins just so that they don't overlap with any currently running jobs
