### PR TITLE
MAP-1937 move ttlSecondsAfterFinished to correct nest

### DIFF
--- a/helm_deploy/use-of-force/templates/job.yaml
+++ b/helm_deploy/use-of-force/templates/job.yaml
@@ -9,8 +9,8 @@ spec:
   startingDeadlineSeconds: 300
   successfulJobsHistoryLimit: 5
   jobTemplate:
-    ttlSecondsAfterFinished: 100
     spec:
+      ttlSecondsAfterFinished: 100
       template:
         spec:
           restartPolicy: Never


### PR DESCRIPTION
helm file format incorrect in last PR. Move `ttlSecondsAfterFinished` to pod spec section