### PR TITLE
Map 1937 uof cron bug revert

### DIFF
--- a/helm_deploy/use-of-force/templates/job.yaml
+++ b/helm_deploy/use-of-force/templates/job.yaml
@@ -9,8 +9,8 @@ spec:
   startingDeadlineSeconds: 300
   successfulJobsHistoryLimit: 5
   jobTemplate:
+    ttlSecondsAfterFinished: 100
     spec:
-      ttlSecondsAfterFinished: 100
       template:
         spec:
           restartPolicy: Never

--- a/helm_deploy/use-of-force/templates/job.yaml
+++ b/helm_deploy/use-of-force/templates/job.yaml
@@ -3,18 +3,17 @@ kind: CronJob
 metadata:
   name: send-reminders
 spec:
-  schedule: "*/15 * * * *"
+  schedule: "*/5 * * * *"
   concurrencyPolicy: Replace
   failedJobsHistoryLimit: 5
   startingDeadlineSeconds: 300
   successfulJobsHistoryLimit: 5
   jobTemplate:
-    ttlSecondsAfterFinished: 100
     spec:
       template:
         spec:
           restartPolicy: Never
-          activeDeadlineSeconds: 600
+          activeDeadlineSeconds: 298
           containers:
           - name: use-of-force
             image: {{ with index .Values "generic-service" }}{{ .image.repository }}:{{ .image.tag }}{{ end }}


### PR DESCRIPTION
This reverts the changes in previous to commits because it has not made any changes to the cron job failing. 
Kubernetes is still killing the pod with reason _'Pod was active on the node longer than the specified deadline'_
Will investigate further but in meantime will revert ineffectual changes. 