### PR TITLE
MAP-2068 increase memory resource for data extractor

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -48,3 +48,8 @@ generic-prometheus-alerts:
 
 generic-data-analytics-extractor:
   serviceAccountName: use-of-force-prod-to-ap-s3
+  resources:
+    requests:
+      memory: 2G
+    limits:
+      memory: 4G


### PR DESCRIPTION
MAP-2068

Getting following prometheus alert ‘Alert: CronJob use-of-force-prod/use-of-force-data-analytics-extractor is failing.’

Traced back to OOM-Killed in pod logs.

 Implement increase in memory