### PR TITLE
MAP-2388 migration for new history table

### DIFF
--- a/migrations/20250501000000_form-db.js
+++ b/migrations/20250501000000_form-db.js
@@ -1,0 +1,17 @@
+exports.up = knex =>
+  knex.schema.createTable('report_edit', table => {
+    table.increments('id').primary('pk_edit')
+    table.timestamp('timestamp').notNullable().defaultTo(knex.fn.now())
+    table.string('user_id', 32).notNullable()
+    table.string('user_name', 128).notNullable()
+    table.bigInteger('report_id').notNullable()
+    table.string('question', 128).notNullable()
+    table.string('old_value_primary', 1000).notNullable()
+    table.string('old_value_secondary', 1000).nullable()
+    table.string('new_value_primary', 1000).notNullable()
+    table.string('new_value_secondary', 1000).nullable()
+    table.string('reason', 128).notNullable()
+    table.string('additional_comments', 1000).nullable()
+  })
+
+exports.down = knex => knex.schema.dropTable('report_edit')


### PR DESCRIPTION
New DB table added to hold edit history for reports already submitted. 
In addition to when and by whom the edit was made, it will record the main question, the main answer (eg Yes/No)and potentially secondary answers (example list of check boxes or camera numbers) plus reason for the edit and any additional comments. Note some question sets and answers can be really long, hence the use of 1000 char limit. 