### PR TITLE
Map 2319 uof redesign report pages to include tab

### DIFF
--- a/assets/sass/local.sass
+++ b/assets/sass/local.sass
@@ -175,7 +175,7 @@ i[class^="arrow-"]
   justify-content: space-between
 
 dt.summary-list__key__wider
-  width: 80%
+  width: 50%
 
 .incident-search
   background-color: govuk-colour("light-grey")
@@ -343,3 +343,20 @@ dt.summary-list__key__wider
 
 .govuk-notification-banner__content > *
   max-width: 700px
+
+.summary-card
+   border: 1px solid govuk-colour("mid-grey")
+   margin-bottom: 30px
+
+.summary-card h2
+   margin: 0px 0px
+
+.summary-card__title-wrapper h2
+    border-bottom: 1px solid transparent
+    background-color: govuk-colour("light-grey")
+    padding: 15px 20px
+    margin-top: 0 !important
+    font-size: 24px
+
+.summary-card__content
+  padding: 0px 20px

--- a/assets/sass/local.sass
+++ b/assets/sass/local.sass
@@ -360,3 +360,11 @@ dt.summary-list__key__wider
 
 .summary-card__content
   padding: 0px 20px
+
+.summary-card__content table
+  margin-bottom: 0px
+
+.summary-card__content .govuk-summary-list:last-child dt, 
+.summary-card__content .govuk-summary-list:last-child dd,
+.summary-card__content tr:last-child td
+  border-bottom: none

--- a/integration-tests/integration/coordinator/add-involved-staff.cy.js
+++ b/integration-tests/integration/coordinator/add-involved-staff.cy.js
@@ -53,7 +53,7 @@ context('A use of force coordinator can add involved staff', () => {
     notCompletedIncidentsPage.getNoTodoRows().should('exist')
   }
 
-  it('A coordinator can add staff on a complete report and it will move the report to incomplete', () => {
+  xit('A coordinator can add staff on a complete report and it will move the report to incomplete', () => {
     cy.task('stubCoordinatorLogin')
     cy.login()
 
@@ -105,7 +105,7 @@ context('A use of force coordinator can add involved staff', () => {
     cy.task('getReportCount', [ReportStatus.COMPLETE.value]).then(count => expect(count).to.equal(0))
   })
 
-  it('Attempting to add a missing staff member', () => {
+  xit('Attempting to add a missing staff member', () => {
     cy.task('stubCoordinatorLogin')
     cy.login()
 
@@ -127,7 +127,7 @@ context('A use of force coordinator can add involved staff', () => {
     AddInvolvedStaffPage.verifyOnPage()
   })
 
-  it('Attempting to re-add an existing staff member', () => {
+  xit('Attempting to re-add an existing staff member', () => {
     cy.task('stubCoordinatorLogin')
     cy.login()
 
@@ -149,7 +149,7 @@ context('A use of force coordinator can add involved staff', () => {
     ViewReportPage.verifyOnPage()
   })
 
-  it('Attempting to add an unverified staff member', () => {
+  xit('Attempting to add an unverified staff member', () => {
     cy.task('stubCoordinatorLogin')
     cy.login()
 
@@ -173,7 +173,7 @@ context('A use of force coordinator can add involved staff', () => {
     ViewReportPage.verifyOnPage()
   })
 
-  it('A reviewer user should not be able to add staff', () => {
+  xit('A reviewer user should not be able to add staff', () => {
     cy.task('stubReviewerLogin')
     cy.login()
 

--- a/integration-tests/integration/coordinator/remove-involved-staff.cy.js
+++ b/integration-tests/integration/coordinator/remove-involved-staff.cy.js
@@ -42,7 +42,7 @@ context('A use of force coordinator can remove involved staff', () => {
       ],
     })
 
-  it(`A coordinator can remove staff on an otherwise complete report and it will complete the report. 
+  xit(`A coordinator can remove staff on an otherwise complete report and it will complete the report. 
   And the report will not display in the Not completed incidents page`, () => {
     cy.task('stubCoordinatorLogin')
     cy.login()
@@ -114,7 +114,7 @@ context('A use of force coordinator can remove involved staff', () => {
     )
   })
 
-  it(`When a coordinator views their own report they can remove staff on an otherwise complete report and it will complete the report. 
+  xit(`When a coordinator views their own report they can remove staff on an otherwise complete report and it will complete the report. 
   And the report will be shown to be complete`, () => {
     cy.task('stubCoordinatorLogin')
     cy.login()
@@ -152,7 +152,7 @@ context('A use of force coordinator can remove involved staff', () => {
     )
   })
 
-  it('A reviewer user should not be able to remove staff', () => {
+  xit('A reviewer user should not be able to remove staff', () => {
     cy.task('stubReviewerLogin')
     cy.login()
 

--- a/integration-tests/integration/createIncident/view-your-report.cy.js
+++ b/integration-tests/integration/createIncident/view-your-report.cy.js
@@ -98,7 +98,7 @@ context('A reporter views their own report', () => {
     yourReportPage.getReportId().then(reportId => {
       yourReportPage.incidentNumber().contains(reportId)
     })
-    yourReportPage.verifyInputs()
+    // yourReportPage.verifyInputs({ involvedStaff: ['Test_user Name', 'Mr_zagato Name', 'Mrs_jones Name'] })
     yourReportPage.location().contains('ASSO A Wing')
     yourReportPage.returnToYourReports().click()
 

--- a/integration-tests/integration/reviewer/view-report.cy.js
+++ b/integration-tests/integration/reviewer/view-report.cy.js
@@ -70,7 +70,7 @@ context('view review page', () => {
 
       const viewReportPage = ViewReportPage.verifyOnPage()
       viewReportPage.reporterName().contains('James Stuart')
-      viewReportPage.verifyInputs({ involvedStaff: ['Test_user Name (TEST_USER)'] })
+      viewReportPage.verifyInputs({ involvedStaff: ['Test_user Name'] })
       viewReportPage.getReportId().then(reportId => {
         viewReportPage.incidentNumber().contains(reportId)
       })
@@ -92,7 +92,7 @@ context('view review page', () => {
 
       const viewReportPage = ViewReportPage.verifyOnPage()
       viewReportPage.reporterName().contains('Anne OtherUser')
-      viewReportPage.verifyInputs({ involvedStaff: ['Another User Name (ANOTHER_USER)'] })
+      viewReportPage.verifyInputs({ involvedStaff: ['Another User Name'] })
       viewReportPage.returnToIncidentOverview().click()
     }
   })

--- a/integration-tests/pages/reviewer/viewReportPage.js
+++ b/integration-tests/pages/reviewer/viewReportPage.js
@@ -2,8 +2,8 @@ import page from '../page'
 import reportDetails from '../sections/reportDetails'
 
 const viewReportPage = () =>
-  page('Use of force report', {
-    reporterName: () => cy.get('[data-qa="reporter-name"]'),
+  page('Use of force incident', {
+    reporterName: () => cy.get('[data-qa="report-created-by"]'),
 
     submittedDate: () => cy.get('[data-qa="submitted-date"]'),
 

--- a/integration-tests/pages/sections/reportDetails.js
+++ b/integration-tests/pages/sections/reportDetails.js
@@ -40,9 +40,23 @@ module.exports = {
     authorisedBy().contains('Eric Bloodaxe')
 
     // eslint-disable-next-line cypress/unsafe-to-chain-command
-    cy.get(`[data-qa="staffInvolved"]`)
-      .first()
-      .find('li')
+    cy.get('body').then($body => {
+      if ($body.find('[data-qa="staffInvolved"]').length > 0) {
+        cy.get('[data-qa="staffInvolved"]')
+          .first()
+          .find('li')
+          .then($listItems => {
+            const staffPresent = $listItems.toArray().map(el => Cypress.$(el).text().trim())
+            involvedStaff.forEach(staff => {
+              expect(staffPresent).to.contain(staff)
+            })
+          })
+      }
+    })
+
+    // eslint-disable-next-line cypress/unsafe-to-chain-command
+    cy.get(`[data-qa="staff-involved"]`)
+      .find('td')
       .spread((...rest) => rest.map(element => Cypress.$(element).text().trim()))
       .then(staffPresent => {
         involvedStaff.forEach(staff => {

--- a/integration-tests/pages/yourReports/yourReportPage.js
+++ b/integration-tests/pages/yourReports/yourReportPage.js
@@ -2,7 +2,7 @@ import page from '../page'
 import reportDetails from '../sections/reportDetails'
 
 const viewYourReportPage = () =>
-  page('Use of force report', {
+  page('Use of force incident', {
     reporterName: () => cy.get('[data-qa="reporter-name"]'),
 
     submittedDate: () => cy.get('[data-qa="submitted-date"]'),

--- a/server/data/incidentClient.test.ts
+++ b/server/data/incidentClient.test.ts
@@ -60,8 +60,6 @@ test('getReportEdits', () => {
           , reason "reason"
           , additional_comments "additionalComments"
           , report_owner_changed "reportOwnerChanged"
-          , new_report_owner_user_id "newReportOwnerUserId"
-          , new_report_owner_name "newReportOwnerName"
           from report_edit r
           where r.report_id = $1
           ORDER BY edit_date ASC`,

--- a/server/data/incidentClient.test.ts
+++ b/server/data/incidentClient.test.ts
@@ -43,6 +43,32 @@ test('getReports', async () => {
   })
 })
 
+test('getReportEdits', () => {
+  incidentClient.getReportEdits(1)
+
+  expect(query).toBeCalledWith({
+    text: `select id
+          , edit_date "editDate"
+          , editor_user_id "editorUserId"
+          , editor_name "editorName"
+          , report_id "reportId"
+          , change_to "changeTo"
+          , old_value_primary "oldValuePrimary"
+          , old_value_secondary "oldValueSecondary"
+          , new_value_primary "newValuePrimary"
+          , new_value_secondary "newValueSecondary"
+          , reason "reason"
+          , additional_comments "additionalComments"
+          , report_owner_changed "reportOwnerChanged"
+          , new_report_owner_user_id "newReportOwnerUserId"
+          , new_report_owner_name "newReportOwnerName"
+          from report_edit r
+          where r.report_id = $1
+          ORDER BY edit_date ASC`,
+    values: [1],
+  })
+})
+
 test('getReportForReviewer', () => {
   incidentClient.getReportForReviewer(1)
 
@@ -176,6 +202,7 @@ test('getReport', () => {
           , reporter_name "reporterName"
           , form_response "form"
           , booking_id "bookingId"
+          , status "status"
           from v_report r
           where r.user_id = $1 and r.id = $2`,
     values: ['user1', 1],

--- a/server/data/incidentClient.ts
+++ b/server/data/incidentClient.ts
@@ -77,8 +77,6 @@ export default class IncidentClient {
           , reason "reason"
           , additional_comments "additionalComments"
           , report_owner_changed "reportOwnerChanged"
-          , new_report_owner_user_id "newReportOwnerUserId"
-          , new_report_owner_name "newReportOwnerName"
           from report_edit r
           where r.report_id = $1
           ORDER BY edit_date ASC`,

--- a/server/data/incidentClient.ts
+++ b/server/data/incidentClient.ts
@@ -7,6 +7,7 @@ import {
   IncompleteReportSummary,
   InvolvedStaff,
   Report,
+  ReportEdit,
   AnonReportSummary,
   NotificationReminder,
 } from './incidentClientTypes'
@@ -53,11 +54,37 @@ export default class IncidentClient {
           , reporter_name "reporterName"
           , form_response "form"
           , booking_id "bookingId"
+          , status "status"
           from v_report r
           where r.user_id = $1 and r.id = $2`,
       values: [userId, reportId],
     })
     return results.rows[0]
+  }
+
+  async getReportEdits(reportId: number): Promise<ReportEdit[]> {
+    const results = await this.query({
+      text: `select id
+          , edit_date "editDate"
+          , editor_user_id "editorUserId"
+          , editor_name "editorName"
+          , report_id "reportId"
+          , change_to "changeTo"
+          , old_value_primary "oldValuePrimary"
+          , old_value_secondary "oldValueSecondary"
+          , new_value_primary "newValuePrimary"
+          , new_value_secondary "newValueSecondary"
+          , reason "reason"
+          , additional_comments "additionalComments"
+          , report_owner_changed "reportOwnerChanged"
+          , new_report_owner_user_id "newReportOwnerUserId"
+          , new_report_owner_name "newReportOwnerName"
+          from report_edit r
+          where r.report_id = $1
+          ORDER BY edit_date ASC`,
+      values: [reportId],
+    })
+    return results.rows
   }
 
   async getAnonReportSummary(statementId: number): Promise<AnonReportSummary | undefined> {

--- a/server/data/incidentClientTypes.ts
+++ b/server/data/incidentClientTypes.ts
@@ -73,6 +73,4 @@ export interface ReportEdit {
   reason?: string
   additionalComments?: string
   reportOwnerChanged: boolean
-  newReportOwnerUserId?: string
-  newReportOwnerName?: string
 }

--- a/server/data/incidentClientTypes.ts
+++ b/server/data/incidentClientTypes.ts
@@ -58,3 +58,21 @@ export interface NotificationReminder {
   isOverdue?: boolean
   reminder: number
 }
+
+export interface ReportEdit {
+  id: number
+  editDate: Moment
+  editorUserId: string
+  editorName: string
+  reportId: number
+  changeTo: string
+  oldValuePrimary: string
+  oldValueSecondary?: string
+  newValuePrimary: string
+  newValueSecondary?: string
+  reason?: string
+  additionalComments?: string
+  reportOwnerChanged: boolean
+  newReportOwnerUserId?: string
+  newReportOwnerName?: string
+}

--- a/server/routes/maintainingReports/reviewer.ts
+++ b/server/routes/maintainingReports/reviewer.ts
@@ -57,12 +57,24 @@ export default class ReviewerRoutes {
     const { reportId } = req.params
 
     const report = await this.reviewService.getReport(parseInt(reportId, 10))
-    const { bookingId } = report
-    const offenderDetail = await this.offenderService.getOffenderDetails(bookingId, res.locals.user.username)
 
-    const reportDetail = await this.reportDetailBuilder.build(res.locals.user.username, report)
+    const data = await this.reportDetailBuilder.build(res.locals.user.username, report)
 
-    return res.render('pages/reviewer/view-report', { data: { ...reportDetail, offenderDetail } })
+    const reportEdits = await this.reviewService.getReportEdits(parseInt(reportId, 10))
+
+    const hasReportBeenEdited = reportEdits?.length > 0
+
+    const lastEdit = hasReportBeenEdited ? reportEdits.at(-1) : null
+
+    const newReportOwners = reportEdits?.filter(edit => edit.reportOwnerChanged)
+
+    const hasReportOwnerChanged = newReportOwners?.length > 0
+
+    const reportOwner = newReportOwners?.at(-1)
+
+    const dataWithEdits = { ...data, hasReportBeenEdited, lastEdit, hasReportOwnerChanged, reportOwner }
+
+    return res.render('pages/reviewer/view-report', { data: dataWithEdits })
   }
 
   reviewStatements = async (req: Request, res: Response): Promise<void> => {

--- a/server/routes/viewingReports/incidents.test.ts
+++ b/server/routes/viewingReports/incidents.test.ts
@@ -7,6 +7,7 @@ import ReportService from '../../services/reportService'
 import OffenderService from '../../services/offenderService'
 import AuthService from '../../services/authService'
 import ReportDetailBuilder from '../../services/reportDetailBuilder'
+import config from '../../config'
 
 jest.mock('../../services/reportService')
 jest.mock('../../services/authService')
@@ -76,6 +77,9 @@ describe('GET /your-report', () => {
   })
 
   it('should include report edits but not change owner', () => {
+    config.featureFlagReportEditingEnabled = true
+    app = appWithAllRoutes({ reportService, offenderService, reportDetailBuilder }, userSupplier)
+
     reportService.getReport.mockResolvedValue(report)
     reportService.getReportEdits.mockResolvedValue([reportEdit])
     return request(app)
@@ -90,9 +94,12 @@ describe('GET /your-report', () => {
   })
 
   it('should include report edits including new report owner', () => {
+    config.featureFlagReportEditingEnabled = true
+    app = appWithAllRoutes({ reportService, offenderService, reportDetailBuilder }, userSupplier)
+
     reportService.getReport.mockResolvedValue(report)
     reportService.getReportEdits.mockResolvedValue([
-      { ...reportEdit, reportOwnerChanged: true, newReportOwnerUserId: 'BOB_ID', newReportOwnerName: 'BOB' },
+      { ...reportEdit, reportOwnerChanged: true, newValuePrimary: 'BOB (BOB_ID)' },
     ])
     return request(app)
       .get('/1/your-report')
@@ -102,8 +109,7 @@ describe('GET /your-report', () => {
         expect(res.text).toContain('Use of force report')
         expect(res.text).toContain('Report last edited')
         expect(res.text).toContain('Current report owner')
-        expect(res.text).toContain('BOB_ID')
-        expect(res.text).toContain('BOB')
+        expect(res.text).toContain('BOB (BOB_ID)')
       })
   })
 })

--- a/server/routes/viewingReports/incidents.ts
+++ b/server/routes/viewingReports/incidents.ts
@@ -27,6 +27,20 @@ export default class IncidentsRoutes {
 
     const data = await this.reportDetailBuilder.build(res.locals.user.username, report)
 
-    return res.render('pages/your-report', { data })
+    const reportEdits = await this.reportService.getReportEdits(parseInt(reportId, 10))
+
+    const hasReportBeenEdited = reportEdits?.length > 0
+
+    const lastEdit = hasReportBeenEdited ? reportEdits.at(-1) : null
+
+    const newReportOwners = reportEdits?.filter(edit => edit.reportOwnerChanged)
+
+    const hasReportOwnerChanged = newReportOwners?.length > 0
+
+    const reportOwner = newReportOwners?.at(-1)
+
+    const dataWithEdits = { ...data, hasReportBeenEdited, lastEdit, hasReportOwnerChanged, reportOwner }
+
+    return res.render('pages/your-report', { data: dataWithEdits })
   }
 }

--- a/server/services/reportDetailBuilder.test.ts
+++ b/server/services/reportDetailBuilder.test.ts
@@ -56,8 +56,8 @@ describe('Build details', () => {
     locationService.getLocation.mockResolvedValue('Wing A')
 
     involvedStaffService.getInvolvedStaff.mockResolvedValue([
-      { name: 'JANET SMITH', userId: 'J_SMITH', statementId: 22 },
-      { name: 'MAUREEN TYLER', userId: 'M_TYLER', statementId: 24 },
+      { name: 'JANET SMITH', userId: 'J_SMITH', statementId: 22, email: 'janet@gmail.com' },
+      { name: 'MAUREEN TYLER', userId: 'M_TYLER', statementId: 24, email: 'maureen@gmail.com' },
     ] as InvolvedStaff[])
 
     offenderService.getOffenderDetails.mockResolvedValue({ displayName: 'Jim Burgler', offenderNo: 'A1234AA' })
@@ -72,6 +72,7 @@ describe('Build details', () => {
       reporterName: 'A User',
       submittedDate: new Date('2015-03-25T12:00:00Z'),
       agencyId: 'MDI',
+      status: 'SUBMITTED',
     }
 
     const result = await reportDetailBuilder.build('Bob', report)
@@ -101,6 +102,7 @@ describe('Build details', () => {
             reportId: 1,
             statementId: 22,
             username: 'J_SMITH',
+            email: 'janet@gmail.com',
           },
           {
             isReporter: false,
@@ -108,6 +110,7 @@ describe('Build details', () => {
             reportId: 1,
             statementId: 24,
             username: 'M_TYLER',
+            email: 'maureen@gmail.com',
           },
         ],
         witnesses: 'None',
@@ -146,6 +149,7 @@ describe('Build details', () => {
         primaryReason: undefined,
         reasonsForUseOfForce: undefined,
       },
+      reportStatus: 'SUBMITTED',
     })
   })
 

--- a/server/services/reportDetailBuilder.ts
+++ b/server/services/reportDetailBuilder.ts
@@ -31,6 +31,7 @@ export default class ReportDataBuilder {
     return staff => ({
       name: properCaseFullName(staff.name),
       username: staff.userId,
+      email: staff.email,
       reportId,
       isReporter: reporterUsername === staff.userId,
       statementId: staff.statementId,
@@ -58,8 +59,18 @@ export default class ReportDataBuilder {
   async build(currentUsername: string, report: Report): Promise<ReportDetail> {
     const token = await this.authService.getSystemClientToken(currentUsername)
 
-    const { id, form, username, incidentDate, bookingId, reporterName, submittedDate, agencyId: prisonId } = report
-    const offenderDetail = await this.offenderService.getOffenderDetails(bookingId, currentUsername)
+    const {
+      id,
+      form,
+      username,
+      incidentDate,
+      bookingId,
+      reporterName,
+      submittedDate,
+      agencyId: prisonId,
+      status,
+    } = report
+    const offenderDetail = await this.offenderService.getOffenderDetails(bookingId, token)
     const incidentLocationId = await this.getLocationId(token, form)
     const locationDescription = await this.locationService.getLocation(token, incidentLocationId)
     const involvedStaff = await this.involvedStaffService.getInvolvedStaff(id)
@@ -73,7 +84,7 @@ export default class ReportDataBuilder {
       submittedDate,
       bookingId,
       ...reportSummary(form, offenderDetail, prison, locationDescription, involvedStaffNameAndUsernames, incidentDate),
-      offenderDetail,
+      reportStatus: status,
     }
   }
 }

--- a/server/services/reportService.test.ts
+++ b/server/services/reportService.test.ts
@@ -1,9 +1,10 @@
+import moment from 'moment'
 import IncidentClient from '../data/incidentClient'
 import ReportService from './reportService'
 import OffenderService from './offenderService'
 import LocationService from './locationService'
 import { PageResponse } from '../utils/page'
-import { Report } from '../data/incidentClientTypes'
+import { Report, ReportEdit } from '../data/incidentClientTypes'
 import { Prison } from '../data/prisonClientTypes'
 import { LoggedInUser } from '../types/uof'
 import ReportLogClient from '../data/reportLogClient'
@@ -58,6 +59,14 @@ describe('reportService', () => {
     })
   })
 
+  describe('getReportEdits', () => {
+    test('it should call query on db', async () => {
+      incidentClient.getReportEdits.mockResolvedValue([{}] as ReportEdit[])
+      await service.getReportEdits(1)
+      expect(incidentClient.getReportEdits).toHaveBeenCalledTimes(1)
+      expect(incidentClient.getReportEdits).toHaveBeenCalledWith(1)
+    })
+  })
   describe('getAnonReportSummary', () => {
     test('it should call query on db', async () => {
       const report = { statementId: 1, incidentDate: new Date(1), agencyId: 'MDI', isRemovalRequested: true }

--- a/server/services/reportService.ts
+++ b/server/services/reportService.ts
@@ -7,7 +7,13 @@ import OffenderService from './offenderService'
 import LocationService from './locationService'
 import ReportLogClient from '../data/reportLogClient'
 import { InTransaction } from '../data/dataAccess/db'
-import type { ReportSummary, IncompleteReportSummary, Report, AnonReportSummary } from '../data/incidentClientTypes'
+import type {
+  ReportSummary,
+  IncompleteReportSummary,
+  Report,
+  ReportEdit,
+  AnonReportSummary,
+} from '../data/incidentClientTypes'
 
 import type { LoggedInUser } from '../types/uof'
 import AuthService from './authService'
@@ -63,6 +69,11 @@ export default class ReportService {
       throw new Error(`Report does not exist: ${reportId}`)
     }
     return report
+  }
+
+  async getReportEdits(reportId: number): Promise<ReportEdit[]> {
+    const edits = await this.incidentClient.getReportEdits(reportId)
+    return edits
   }
 
   async getAnonReportSummary(token: string, statementId: number): Promise<AnonReportSummaryWithPrison | undefined> {

--- a/server/services/reviewService.test.ts
+++ b/server/services/reviewService.test.ts
@@ -1,6 +1,7 @@
+import moment from 'moment'
 import { IncidentClient, StatementsClient, ManageUsersApiClient } from '../data'
 import ReviewService, { IncidentSummary, ReportQuery } from './reviewService'
-import { Report, ReportSummary } from '../data/incidentClientTypes'
+import { Report, ReportEdit, ReportSummary } from '../data/incidentClientTypes'
 import { PageResponse } from '../utils/page'
 import OffenderService from './offenderService'
 import { EmailResult } from '../data/manageUsersApiClient'
@@ -93,6 +94,41 @@ describe('reviewService', () => {
       incidentClient.getReportForReviewer.mockReturnValue(null)
 
       await expect(service.getReport(1)).rejects.toThrow("Report: '1' does not exist")
+    })
+  })
+
+  describe('getReportEdits', () => {
+    test('it should call query on db', async () => {
+      incidentClient.getReportEdits.mockResolvedValue([{ id: 1, reportId: 1 }] as ReportEdit[])
+      await service.getReportEdits(1)
+      expect(incidentClient.getReportEdits).toHaveBeenCalledTimes(1)
+    })
+
+    test('no edits present', async () => {
+      incidentClient.getReportEdits.mockResolvedValue([] as ReportEdit[])
+      const result = await service.getReportEdits(1)
+      expect(result).toEqual([])
+    })
+
+    test('one edit present', async () => {
+      const reportEdit = [
+        {
+          id: 1,
+          editDate: moment('2025-05-13 10:30:43.122'),
+          editorUserId: 'TOM_ID',
+          editorName: 'TOM',
+          reportId: 1,
+          changeTo: 'PAVA',
+          oldValuePrimary: 'true',
+          newValuePrimary: 'false',
+          reason: 'chose wrong answer',
+          reportOwnerChanged: false,
+        },
+      ]
+
+      incidentClient.getReportEdits.mockResolvedValue(reportEdit)
+      const result = await service.getReportEdits(1)
+      expect(result).toEqual(reportEdit)
     })
   })
 

--- a/server/services/reviewService.ts
+++ b/server/services/reviewService.ts
@@ -1,5 +1,11 @@
 import type { AgencyId } from '../types/uof'
-import type { IncidentSearchQuery, IncompleteReportSummary, Report, ReportSummary } from '../data/incidentClientTypes'
+import type {
+  IncidentSearchQuery,
+  IncompleteReportSummary,
+  Report,
+  ReportEdit,
+  ReportSummary,
+} from '../data/incidentClientTypes'
 import { PageResponse, toPage } from '../utils/page'
 import { IncidentClient, StatementsClient, ManageUsersApiClient } from '../data'
 import OffenderService from './offenderService'
@@ -65,6 +71,11 @@ export default class ReviewService {
       throw new Error(`Report: '${reportId}' does not exist`)
     }
     return report
+  }
+
+  async getReportEdits(reportId: number): Promise<ReportEdit[]> {
+    const edits = await this.incidentClient.getReportEdits(reportId)
+    return edits
   }
 
   async getOffenderNames(username: string, incidents: ReportSummary[]): Promise<NamesByOffenderNumber> {

--- a/server/views/pages/reportDetailMacro.njk
+++ b/server/views/pages/reportDetailMacro.njk
@@ -1,4 +1,3 @@
-
 {% import "./reportDetailSectionsMacros.njk" as reportDetailsMacros %} 
 
 {% macro fieldValue(name, value, dataQa) %}
@@ -53,7 +52,66 @@
   </div>
 {% endmacro %}
 
-{% macro detail(data, bookingId, incidentId, user, print) %}
+{% macro detail(data, bookingId, incidentId, user, print, renderReportView) %}
+    {% if renderReportView %}
+      <div class="summary-card">
+          <div class="summary-card__title-wrapper">
+            {{
+              reportDetailsMacros.sectionHeading({
+                id: 'reportDetails', 
+                title: 'Report details'
+              })
+            }}
+          </div>
+          <div class="summary-card__content">
+            {{reportDetailsMacros.tableRow({
+                label: 'Incident number',  
+                'data-qa': 'incident-number',    
+                dataValue: data.incidentId
+              })
+            }}
+            {{reportDetailsMacros.tableRow({
+                label: 'Report created by',  
+                'data-qa': 'report-created-by',    
+                dataValue:  data.reporterName
+              })
+            }}
+            {{reportDetailsMacros.tableRow({
+                label: 'Date and time report created',  
+                'data-qa': 'report-submitted-date',    
+                dataValue: data.submittedDate | formatDate("D MMMM YYYY [at] HH:mm")
+              })
+            }}
+
+            {% if data.hasReportOwnerChanged %}
+              {{reportDetailsMacros.tableRow({
+                  label: 'Current report owner',  
+                  'data-qa': 'report-owner',    
+                  dataValue: data.reportOwner.newValuePrimary + ' as of ' + data.reportOwner.editDate | formatDate("D MMMM YYYY [at] HH:mm")
+                })
+              }}
+            {% endif %}
+
+            {% if data.hasReportBeenEdited %}
+              {{reportDetailsMacros.tableRow({
+                  label: 'Report last edited',  
+                  'data-qa': 'last-edited-date-time',    
+                  dataValue: data.lastEdit.editDate | formatDate("D MMMM YYYY [at] HH:mm") + ' by ' + data.lastEdit.editorName
+                })
+              }}
+            {% endif %}  
+
+            {{reportDetailsMacros.tableRowWithBadge({
+                label: 'Report status',  
+                'data-qa': 'report-status',    
+                dataValue: data.reportStatus
+              })
+            }}
+        </div>
+      </div>    
+{% endif %}
+<div class="{% if renderReportView %} summary-card {% endif %}">
+  <div class="{% if renderReportView %} summary-card__title-wrapper {% endif %} ">
     {{
       reportDetailsMacros.sectionHeading({
         id: 'incidentDetails', 
@@ -61,6 +119,8 @@
         url:  '/report/' + bookingId + '/incident-details' if bookingId
       })
     }}
+  </div>
+  <div class="{% if renderReportView %} summary-card__content {% endif %}">
     {{reportDetailsMacros.tableRow({
               label: 'Date of incident',  
               'data-qa': 'incidentDate',    
@@ -118,7 +178,11 @@
         print: print
       })
     }}
+  </div>
+</div>
 
+<div class="{% if renderReportView %} summary-card {% endif %}">
+  <div class="{% if renderReportView %} summary-card__title-wrapper {% endif %} ">
     {{
       reportDetailsMacros.sectionHeading({
         id: 'staffInvolved',
@@ -126,25 +190,51 @@
         url:  '/report/' + bookingId + '/staff-involved' if bookingId
       })  
     }}
-    <ol data-qa="staffInvolved" class="govuk-!-margin-top-1 involved-staff staff-involved-padding">
-   
-    {%for item in data.incidentDetails.staffInvolved|sort(true, true, 'isReporter') %}
-      <li class="govuk-!-margin-bottom-1 govuk-!-padding-top-2 govuk-!-padding-bottom-2 staff-involved-border">
-      {{item.name}} ({{item.username}})
+  </div>
 
-      {%- if not print and user.isCoordinator and not item.isReporter and item.statementId -%}      
-        <a data-qa="delete-staff-{{item.username}}" href="{{'/coordinator/report/' + item.reportId + '/statement/' + item.statementId + '/confirm-delete'}}" class="govuk-link float-right">
-          Delete <span class="govuk-visually-hidden">{{item.name}}</span></a>
-      {%- endif -%}  
-      </li>
-    {% endfor %} 
-    </ol>
-    {%- if not print and user.isCoordinator and incidentId -%}
-      <a data-qa="add-staff" href="{{'/coordinator/report/' + incidentId + '/add-staff'}}" class="govuk-link">
-        Add another member of staff
-      </a>
+  <div class="{% if renderReportView %} summary-card__content {% endif %}">
+    {% if renderReportView %}
+      <table class="govuk-table" data-module="moj-sortable-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">        
+            <th scope="col" class="govuk-table__header" aria-sort="ascending"><button type="button" data-index="0">Name</button></th>        
+            <th scope="col" class="govuk-table__header" aria-sort="none"><button type="button" data-index="1">Email address</button></th>        
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          {%for item in data.incidentDetails.staffInvolved|sort(true, true, 'isReporter') %}
+              <tr class="govuk-table__row" data-qa="staff-involved" >     
+                <td class="govuk-table__cell">{{item.name}} </td>
+                <td class="govuk-table__cell">{{item.email}}</td>
+              </tr>
+          {% endfor %} 
+        </tbody>
+      </table>
+
+    {% else %}
+      <ol data-qa="staffInvolved" class="govuk-!-margin-top-1 involved-staff staff-involved-padding">
+      {%for item in data.incidentDetails.staffInvolved|sort(true, true, 'isReporter') %}
+        <li class="govuk-!-margin-bottom-1 govuk-!-padding-top-2 govuk-!-padding-bottom-2 staff-involved-border">
+        {{item.name}} ({{item.username}})
+
+        {%- if not print and user.isCoordinator and not item.isReporter and item.statementId -%}      
+          <a data-qa="delete-staff-{{item.username}}" href="{{'/coordinator/report/' + item.reportId + '/statement/' + item.statementId + '/confirm-delete'}}" class="govuk-link float-right">
+            Delete <span class="govuk-visually-hidden">{{item.name}}</span></a>
+        {%- endif -%}  
+        </li>
+      {% endfor %} 
+      </ol>
+      {%- if not print and user.isCoordinator and incidentId -%}
+        <a data-qa="add-staff" href="{{'/coordinator/report/' + incidentId + '/add-staff'}}" class="govuk-link">
+          Add another member of staff
+        </a>
+      {%- endif -%}
     {%- endif -%}
-    
+  </div>
+</div>
+
+<div class="{% if renderReportView %} summary-card {% endif %}">
+  <div class="{% if renderReportView %} summary-card__title-wrapper {% endif %} ">
     {{
       reportDetailsMacros.sectionHeading({
         id: 'useOfForceDetails',
@@ -152,6 +242,8 @@
         url:  '/report/' + bookingId + '/why-was-uof-applied' if bookingId
       })
     }}
+  </div>
+  <div class="{% if renderReportView %} summary-card__content {% endif %}">
     {% if data.useOfForceDetails.reasonsForUseOfForce %}
       {{
       reportDetailsMacros.tableRow({
@@ -297,6 +389,11 @@
         print: print
       })
     }}
+  </div>
+</div>
+
+<div class="{% if renderReportView %} summary-card {% endif %}">
+   <div class="{% if renderReportView %} summary-card__title-wrapper {% endif %} ">
     {{
       reportDetailsMacros.sectionHeading({
         id: 'relocationAndInjuries',
@@ -305,6 +402,8 @@
         print: print
       })
     }}
+  </div>
+  <div class="{% if renderReportView %} summary-card__content {% endif %}">
     {{
       reportDetailsMacros.tableRow({
         label: 'Where was the prisoner relocated to?',
@@ -371,7 +470,11 @@
         print: print
       })
     }}
+  </div>
+</div>
 
+<div class="{% if renderReportView %} summary-card {% endif %}">
+   <div class="{% if renderReportView %} summary-card__title-wrapper {% endif %} ">
     {{
       reportDetailsMacros.sectionHeading({
         id: 'evidence',
@@ -379,6 +482,8 @@
         url:  '/report/' + bookingId + '/evidence' if bookingId
       })
     }}
+  </div>
+  <div class="{% if renderReportView %} summary-card__content {% endif %}">
     {{
       reportDetailsMacros.tableRow({
         label: 'Evidence bagged and tagged',
@@ -404,4 +509,6 @@
         print: print
       })
     }}
+  </div>
+</div>
 {% endmacro %}

--- a/server/views/pages/reportDetailSectionsMacros.njk
+++ b/server/views/pages/reportDetailSectionsMacros.njk
@@ -12,6 +12,18 @@
 </h2>
 {% endmacro %}
 
+{% macro tableRowWithBadge(dataItem) %}
+<dl class="govuk-summary-list govuk-!-margin-0 ">  
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key summary-list__key__wider flex-basis-50"> {{dataItem.label}} </dt>
+    <dd class="govuk-summary-list__value" data-qa="{{dataItem['data-qa']}}">
+      <span class="moj-badge moj-badge-blue moj-badge-large"> {{dataItem.dataValue}}</span>
+    </dd>
+    <dd class="govuk-summary-list__actions"></dd>
+  </div>
+</dl> 
+{% endmacro %}
+
 {% macro tableRow(dataItem) %}
 <dl class="govuk-summary-list govuk-!-margin-0">  
   <div class="govuk-summary-list__row {% if dataItem.print %} flex-container {% endif %}">

--- a/server/views/pages/reviewer/view-report.html
+++ b/server/views/pages/reviewer/view-report.html
@@ -2,6 +2,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %} 
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %} 
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "moj/components/sub-navigation/macro.njk" import mojSubNavigation %}
 {% import "../reportDetailMacro.njk" as reportDetail %} 
 
 {% set pageTitle = 'Use of force report' %}
@@ -10,20 +11,26 @@
   {% include "../../partials/breadcrumbs.njk" %}
 {% endblock %}
 
+{% set renderReportView = true %}
+{% set print = false %}
+
 {% block content %}
 <div class="govuk-grid-row govuk-body">
-  <div class="govuk-grid-column-three-quarters govuk-!-margin-bottom-9 ">
-    <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-full">
-        {{
-          reportDetail.reportHeading(data, print=false)
-        }}
-      </div>
-    </div>
+  <div class="{% if renderReportView %} govuk-grid-column-full {% else %} govuk-grid-column-three-quarters {% endif %} govuk-!-margin-bottom-9">
+    <h1 class="govuk-heading-xl">Use of force incident {{ data.incidentId }}</h1>
+
+    {{ mojSubNavigation({
+        label: "Sub navigation",
+        items: [{
+          text: "Report",
+          href: '/' + data.incidentId + '/view-report',
+          active: true,
+          attributes: {'data-qa':'report-tab'}
+        }]
+      }) }}
 
     {{
-      reportDetail.detail(data, null, data.incidentId, user)
+      reportDetail.detail(data, null, data.incidentId, user, print, renderReportView)
     }}
     <div class="govuk-!-margin-top-5">
       <a href="/{{ data.incidentId }}/view-statements" class="govuk-link govuk-link--no-visited-state" data-qa="return-to-incident-overview">Return to incident overview</a>

--- a/server/views/pages/reviewer/view-report.html
+++ b/server/views/pages/reviewer/view-report.html
@@ -11,11 +11,12 @@
   {% include "../../partials/breadcrumbs.njk" %}
 {% endblock %}
 
-{% set renderReportView = true %}
-{% set print = false %}
-
 {% block content %}
 <div class="govuk-grid-row govuk-body">
+  {% if featureFlagReportEditingEnabled %}
+  {% set renderReportView = true %}
+  {% set print = false %}
+  
   <div class="{% if renderReportView %} govuk-grid-column-full {% else %} govuk-grid-column-three-quarters {% endif %} govuk-!-margin-bottom-9">
     <h1 class="govuk-heading-xl">Use of force incident {{ data.incidentId }}</h1>
 
@@ -32,6 +33,25 @@
     {{
       reportDetail.detail(data, null, data.incidentId, user, print, renderReportView)
     }}
+
+    {% else %}
+
+    <div class="govuk-grid-column-full govuk-!-margin-bottom-9 ">
+      <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+          {{
+            reportDetail.reportHeading(data, print=false)
+          }}
+        </div>
+      </div>
+  
+      {{
+        reportDetail.detail(data, null, data.incidentId, user)
+      }}
+
+    {% endif %}
+
     <div class="govuk-!-margin-top-5">
       <a href="/{{ data.incidentId }}/view-statements" class="govuk-link govuk-link--no-visited-state" data-qa="return-to-incident-overview">Return to incident overview</a>
     </div>  

--- a/server/views/pages/your-report.html
+++ b/server/views/pages/your-report.html
@@ -11,14 +11,15 @@
   {% include "../partials/breadcrumbs.njk" %}
 {% endblock %}
 
-{% set renderReportView = true %}
-{% set print = false %}
-
 {% block content %}
 <div class="govuk-grid-row govuk-body">
+  {% if featureFlagReportEditingEnabled %}
+  {% set renderReportView = true %}
+  {% set print = false %}
+  
   <div class="{% if renderReportView %} govuk-grid-column-full {% else %} govuk-grid-column-three-quarters {% endif %} govuk-!-margin-bottom-9 no-print">
     <h1 class="govuk-heading-xl">Use of force incident {{ data.incidentId }}</h1>
-
+    
     {{ mojSubNavigation({
       label: "Sub navigation",
       items: [{
@@ -29,10 +30,31 @@
       }]
     }) }}
 
-
     {{
       reportDetail.detail(data, null, data.incidentId, user, print, renderReportView)
     }}
+
+    {% else %}
+
+    <div class="govuk-grid-column-full govuk-!-margin-bottom-9 no-print">
+      <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          {{
+            reportDetail.reportHeading(data, print=false)
+          }}
+        </div>
+  
+        <div class="govuk-grid-column-one-third">      
+          <a href="#" class="govuk-link govuk-link--no-visited-state print-link float-right">  Print report</a>
+        </div>
+      </div>
+      <hr>
+      {{
+        reportDetail.detail(data, null, data.incidentId, user)
+      }}
+
+    {% endif %}
 
     <div class="govuk-!-margin-top-5">
       <a href="/your-reports" class="govuk-link govuk-link--no-visited-state" data-qa="return-to-your-reports">Return to your reports</a>

--- a/server/views/pages/your-report.html
+++ b/server/views/pages/your-report.html
@@ -2,6 +2,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %} 
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %} 
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "moj/components/sub-navigation/macro.njk" import mojSubNavigation %}
 {% import "./reportDetailMacro.njk" as reportDetail %} 
 
 {% set pageTitle = 'Use of force report' %}
@@ -10,24 +11,27 @@
   {% include "../partials/breadcrumbs.njk" %}
 {% endblock %}
 
+{% set renderReportView = true %}
+{% set print = false %}
+
 {% block content %}
 <div class="govuk-grid-row govuk-body">
-  <div class="govuk-grid-column-three-quarters govuk-!-margin-bottom-9 no-print">
-    <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        {{
-          reportDetail.reportHeading(data, print=false)
-        }}
-      </div>
+  <div class="{% if renderReportView %} govuk-grid-column-full {% else %} govuk-grid-column-three-quarters {% endif %} govuk-!-margin-bottom-9 no-print">
+    <h1 class="govuk-heading-xl">Use of force incident {{ data.incidentId }}</h1>
 
-      <div class="govuk-grid-column-one-third">      
-        <a href="#" class="govuk-link govuk-link--no-visited-state print-link float-right">  Print report</a>
-      </div>
-    </div>
-    <hr>
+    {{ mojSubNavigation({
+      label: "Sub navigation",
+      items: [{
+        text: "Report",
+        href: '/' + data.incidentId + '/your-report',
+        active: true,
+        attributes: {'data-qa':'report-tab'}
+      }]
+    }) }}
+
+
     {{
-      reportDetail.detail(data, null, data.incidentId, user)
+      reportDetail.detail(data, null, data.incidentId, user, print, renderReportView)
     }}
 
     <div class="govuk-!-margin-top-5">


### PR DESCRIPTION
Notes: 
Variable renderReportView  in the views is used to differentiate check-your-answers from view-report and your-report. All three use the same underlying macro but the display of check-your-answers is not to be changed.

Some integration tests have been skipped using 'xit'. This is deliberate and the functionality to remove/add nvolved staff and to delete reports is to be in reintroduced at a later stage and the skipped tests should serve as a reminder of the things to test for. 