### PR TITLE
Map 2319 uof add history link and css to hide bottom borders

### DIFF
--- a/assets/sass/local.sass
+++ b/assets/sass/local.sass
@@ -368,3 +368,6 @@ dt.summary-list__key__wider
 .summary-card__content .govuk-summary-list:last-child dd,
 .summary-card__content tr:last-child td
   border-bottom: none
+
+.border-bottom-none
+  border-bottom: none

--- a/integration-tests/pages/reviewer/viewReportPage.js
+++ b/integration-tests/pages/reviewer/viewReportPage.js
@@ -23,6 +23,8 @@ const viewReportPage = () =>
 
     location: () => cy.get('[data-qa="location"]'),
 
+    historyLink: () => cy.get('[data-qa="history-link"]'),
+
     getReportId: () => {
       return cy.url().then(url => {
         const match = url.match(/.*\/(.*)\/view-report/)

--- a/server/views/pages/reportDetailMacro.njk
+++ b/server/views/pages/reportDetailMacro.njk
@@ -93,10 +93,11 @@
             {% endif %}
 
             {% if data.hasReportBeenEdited %}
-              {{reportDetailsMacros.tableRow({
+              {{reportDetailsMacros.tableRowWithEditHistoryLink({
                   label: 'Report last edited',  
                   'data-qa': 'last-edited-date-time',    
-                  dataValue: data.lastEdit.editDate | formatDate("D MMMM YYYY [at] HH:mm") + ' by ' + data.lastEdit.editorName
+                  dataValue: data.lastEdit.editDate | formatDate("D MMMM YYYY [at] HH:mm") + ' by ' + data.lastEdit.editorName,
+                  incidentId: data.incidentId
                 })
               }}
             {% endif %}  

--- a/server/views/pages/reportDetailMacro.njk
+++ b/server/views/pages/reportDetailMacro.njk
@@ -198,14 +198,14 @@
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">        
             <th scope="col" class="govuk-table__header" aria-sort="ascending"><button type="button" data-index="0">Name</button></th>        
-            <th scope="col" class="govuk-table__header" aria-sort="none"><button type="button" data-index="1">Email address</button></th>        
+            <th scope="col" class="govuk-table__header width-half govuk-!-padding-left-4" aria-sort="none"><button type="button" data-index="1">Email address</button></th>        
           </tr>
         </thead>
         <tbody class="govuk-table__body">
           {%for item in data.incidentDetails.staffInvolved|sort(true, true, 'isReporter') %}
               <tr class="govuk-table__row" data-qa="staff-involved" >     
                 <td class="govuk-table__cell">{{item.name}} </td>
-                <td class="govuk-table__cell">{{item.email}}</td>
+                <td class="govuk-table__cell width-half govuk-!-padding-left-4">{{item.email}}</td>
               </tr>
           {% endfor %} 
         </tbody>

--- a/server/views/pages/reportDetailMacro.njk
+++ b/server/views/pages/reportDetailMacro.njk
@@ -54,6 +54,7 @@
 
 {% macro detail(data, bookingId, incidentId, user, print, renderReportView) %}
     {% if renderReportView %}
+    {% set addedClasses = 'border-bottom-none' %}
       <div class="summary-card">
           <div class="summary-card__title-wrapper">
             {{
@@ -105,7 +106,8 @@
             {{reportDetailsMacros.tableRowWithBadge({
                 label: 'Report status',  
                 'data-qa': 'report-status',    
-                dataValue: data.reportStatus
+                dataValue: data.reportStatus,
+                addedClasses: addedClasses
               })
             }}
         </div>
@@ -123,16 +125,16 @@
   </div>
   <div class="{% if renderReportView %} summary-card__content {% endif %}">
     {{reportDetailsMacros.tableRow({
-              label: 'Date of incident',  
-              'data-qa': 'incidentDate',    
-              dataValue: data.incidentDetails.incidentDate | formatDate('D MMMM YYYY'),
+        label: 'Date of incident',  
+        'data-qa': 'incidentDate',    
+        dataValue: data.incidentDetails.incidentDate | formatDate('D MMMM YYYY'),
         print: print
       })
     }}
     {{reportDetailsMacros.tableRow({
-              label: 'Time of incident',  
-              'data-qa': 'incidentTime',    
-              dataValue: data.incidentDetails.incidentDate | formatDate('HH:mm'),
+        label: 'Time of incident',  
+        'data-qa': 'incidentTime',    
+        dataValue: data.incidentDetails.incidentDate | formatDate('HH:mm'),
         print: print 
       })
     }}
@@ -176,7 +178,8 @@
         'data-qa': 'witnesses',
         dataValue: data.incidentDetails.witnesses,
         type: 'itemPerLine',
-        print: print
+        print: print,
+        addedClasses:addedClasses
       })
     }}
   </div>
@@ -197,7 +200,7 @@
     {% if renderReportView %}
       <table class="govuk-table" data-module="moj-sortable-table">
         <thead class="govuk-table__head">
-          <tr class="govuk-table__row">        
+          <tr class="govuk-table__row  {{addedClasses}}">        
             <th scope="col" class="govuk-table__header" aria-sort="ascending"><button type="button" data-index="0">Name</button></th>        
             <th scope="col" class="govuk-table__header width-half govuk-!-padding-left-4" aria-sort="none"><button type="button" data-index="1">Email address</button></th>        
           </tr>
@@ -387,7 +390,8 @@
         label: 'Were handcuffs applied against this prisoner?',
         'data-qa': 'handcuffsApplied',
         dataValue: data.useOfForceDetails.handcuffsApplied | toYesNo,
-        print: print
+        print: print,
+        addedClasses: addedClasses
       })
     }}
   </div>
@@ -468,7 +472,8 @@
         'data-qa': 'staffHospitalisation',
         dataValue: data.relocationAndInjuries.staffHospitalisation,
         type: 'itemPerLine',
-        print: print
+        print: print,
+        addedClasses: addedClasses
       })
     }}
   </div>
@@ -507,7 +512,8 @@
         label: 'Was any part of the incident captured on CCTV?',
         'data-qa': 'cctv',
         dataValue: data.evidence.cctv | capitalize,
-        print: print
+        print: print,
+        addedClasses: addedClasses
       })
     }}
   </div>

--- a/server/views/pages/reportDetailSectionsMacros.njk
+++ b/server/views/pages/reportDetailSectionsMacros.njk
@@ -56,6 +56,21 @@
 </dl> 
 {% endmacro %}
 
+{% macro tableRowWithEditHistoryLink(dataItem) %}
+<dl class="govuk-summary-list  govuk-!-margin-bottom-0">  
+  <div class="govuk-summary-list__row {% if dataItem.print %} govuk-!-margin-right-4 {% endif %}">
+    <dt class="govuk-summary-list__key summary-list__key__wider {% if dataItem.print %} govuk-!-margin-right-4 {% endif %}"> {{dataItem.label}} </dt>
+    <dd class="govuk-summary-list__value {% if dataItem.print %} govuk-!-margin-right-4 {% endif %}" data-qa="{{dataItem['data-qa']}}">
+      {{dataItem.dataValue}}
+    </dd>
+   <dd class= "govuk-summary-list__actions">
+    <a class="govuk-link govuk-link--no-visited-state" data-qa='history-link' href='/{{dataItem.incidentId}}/view-history'>History
+    <span class="govuk-visually-hidden"> History</span></a>
+   </dd>
+  </div>
+</dl> 
+{% endmacro %}
+
 {% macro tableRowWithContent(dataItem) %}
 <dl class="govuk-summary-list govuk-!-margin-0">  
   <div class="govuk-summary-list__row {% if dataItem.print %} flex-container {% endif %}">

--- a/server/views/pages/reportDetailSectionsMacros.njk
+++ b/server/views/pages/reportDetailSectionsMacros.njk
@@ -14,7 +14,7 @@
 
 {% macro tableRowWithBadge(dataItem) %}
 <dl class="govuk-summary-list govuk-!-margin-0 ">  
-  <div class="govuk-summary-list__row">
+  <div class="govuk-summary-list__row {{dataItem.addedClasses}}">
     <dt class="govuk-summary-list__key summary-list__key__wider flex-basis-50"> {{dataItem.label}} </dt>
     <dd class="govuk-summary-list__value" data-qa="{{dataItem['data-qa']}}">
       <span class="moj-badge moj-badge-blue moj-badge-large"> {{dataItem.dataValue}}</span>
@@ -26,7 +26,7 @@
 
 {% macro tableRow(dataItem) %}
 <dl class="govuk-summary-list govuk-!-margin-0">  
-  <div class="govuk-summary-list__row {% if dataItem.print %} flex-container {% endif %}">
+  <div class="govuk-summary-list__row {{dataItem.addedClasses}}{% if dataItem.print %} flex-container {% endif %}">
     <dt class="govuk-summary-list__key summary-list__key__wider {% if dataItem.print %} govuk-!-margin-right-4 {% endif %} flex-basis-50"> {{dataItem.label}} </dt>
     <dd class="govuk-summary-list__value  {% if dataItem.print %} govuk-!-margin-right-4 {% endif %}" data-qa="{{dataItem['data-qa']}}">
       {% if dataItem.dataValue.length === 0 or dataItem.dataValue == null %}


### PR DESCRIPTION
1. adding history link to /view-report and /your-report
2. 2. remove border under last rows of each section of /view-report and /your-report in but not in check-your-answers
3. tidy up alignment email in staff involved row of /view-report and /your-report