### PR TITLE
Map 2316 uof incident page tabs and navigation part 1

### DIFF
--- a/assets/sass/local.sass
+++ b/assets/sass/local.sass
@@ -155,6 +155,15 @@ i[class^="arrow-"]
   font-size: 1.1875rem
   line-height: 2.31579
 
+.flex-container-space-between 
+  padding: 10px 0px 10px 0px
+  margin: 0 auto
+  width: 100%
+  height: 60%
+  display: flex
+  align-items: center
+  justify-content: space-between
+
 .flex-container 
   display: flex
 

--- a/assets/sass/local.sass
+++ b/assets/sass/local.sass
@@ -380,3 +380,7 @@ dt.summary-list__key__wider
 
 .border-bottom-none
   border-bottom: none
+
+// target the parent of dev having a class of negative-margin-top-7
+main:has(div.negative-margin-top-7)
+  margin-top: -30px

--- a/server/routes/maintainingReports/reviewer.test.ts
+++ b/server/routes/maintainingReports/reviewer.test.ts
@@ -3,7 +3,7 @@ import { appWithAllRoutes, user, reviewerUser, coordinatorUser } from '../__test
 import { parseDate } from '../../utils/utils'
 import { PageResponse } from '../../utils/page'
 import type { ReportDetail } from '../../services/reportDetailBuilder'
-import { Report } from '../../data/incidentClientTypes'
+import { Report, ReportEdit } from '../../data/incidentClientTypes'
 import ReviewService, { ReviewerStatementWithComments } from '../../services/reviewService'
 import OffenderService from '../../services/offenderService'
 import AuthService from '../../services/authService'
@@ -234,6 +234,24 @@ describe('GET /view-report', () => {
         expect(res.text).toContain('Use of force incident')
         expect(res.text).toContain('Delete incident')
         expect(res.text).toContain('Edit report')
+        expect(res.text).not.toContain('Edit history')
+      })
+  })
+
+  it('should show report edit rows', () => {
+    config.featureFlagReportEditingEnabled = true
+    reviewService.getReportEdits.mockResolvedValue([{ reportOwnerChanged: true }] as unknown as ReportEdit[])
+    reviewService.getReport.mockResolvedValue(report)
+    app = appWithAllRoutes({ offenderService, reviewService, reportDetailBuilder, authService }, userSupplier)
+    userSupplier.mockReturnValue(coordinatorUser)
+    return request(app)
+      .get('/1/view-report')
+      .expect(200)
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain('Edit history')
+        expect(res.text).toContain('Report last edited')
+        expect(res.text).toContain('Current report owner')
       })
   })
 })

--- a/server/routes/maintainingReports/reviewer.test.ts
+++ b/server/routes/maintainingReports/reviewer.test.ts
@@ -8,6 +8,7 @@ import ReviewService, { ReviewerStatementWithComments } from '../../services/rev
 import OffenderService from '../../services/offenderService'
 import AuthService from '../../services/authService'
 import ReportDetailBuilder from '../../services/reportDetailBuilder'
+import config from '../../config'
 
 const userSupplier = jest.fn()
 
@@ -204,6 +205,8 @@ describe(`GET /not-completed-incidents`, () => {
 
 describe('GET /view-report', () => {
   it('should render page for reviewer', () => {
+    config.featureFlagReportEditingEnabled = true
+    app = appWithAllRoutes({ offenderService, reviewService, reportDetailBuilder, authService }, userSupplier)
     userSupplier.mockReturnValue(reviewerUser)
     reviewService.getReport.mockResolvedValue(report)
     return request(app)
@@ -211,8 +214,26 @@ describe('GET /view-report', () => {
       .expect(200)
       .expect('Content-Type', /html/)
       .expect(res => {
-        expect(res.text).toContain('Use of force report')
-        expect(res.text).not.toContain('Delete report')
+        expect(res.text).toContain('Use of force incident')
+        expect(res.text).not.toContain('Delete incident')
+        expect(res.text).not.toContain('Edit report')
+      })
+  })
+
+  it('should render page for coordinator', () => {
+    config.featureFlagReportEditingEnabled = true
+    app = appWithAllRoutes({ offenderService, reviewService, reportDetailBuilder, authService }, userSupplier)
+
+    userSupplier.mockReturnValue(coordinatorUser)
+    reviewService.getReport.mockResolvedValue(report)
+    return request(app)
+      .get('/1/view-report')
+      .expect(200)
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain('Use of force incident')
+        expect(res.text).toContain('Delete incident')
+        expect(res.text).toContain('Edit report')
       })
   })
 })

--- a/server/routes/maintainingReports/reviewer.ts
+++ b/server/routes/maintainingReports/reviewer.ts
@@ -74,7 +74,9 @@ export default class ReviewerRoutes {
 
     const dataWithEdits = { ...data, hasReportBeenEdited, lastEdit, hasReportOwnerChanged, reportOwner }
 
-    return res.render('pages/reviewer/view-report', { data: dataWithEdits })
+    const user = { isCoordinator: res.locals.user.isCoordinator, isReviewer: res.locals.user.isReviewer }
+
+    return res.render('pages/reviewer/view-report', { data: dataWithEdits, user })
   }
 
   reviewStatements = async (req: Request, res: Response): Promise<void> => {

--- a/server/views/pages/reportDetailSectionsMacros.njk
+++ b/server/views/pages/reportDetailSectionsMacros.njk
@@ -64,8 +64,8 @@
       {{dataItem.dataValue}}
     </dd>
    <dd class= "govuk-summary-list__actions">
-    <a class="govuk-link govuk-link--no-visited-state" data-qa='history-link' href='/{{dataItem.incidentId}}/view-history'>History
-    <span class="govuk-visually-hidden"> History</span></a>
+    <a class="govuk-link govuk-link--no-visited-state" data-qa='history-link' href='/{{dataItem.incidentId}}/view-history'>Edit history
+    <span class="govuk-visually-hidden"> Edit history</span></a>
    </dd>
   </div>
 </dl> 

--- a/server/views/pages/reviewer/view-report.html
+++ b/server/views/pages/reviewer/view-report.html
@@ -9,10 +9,11 @@
 
 {% block beforeContent %}
   {% include "../../partials/breadcrumbs.njk" %}
+  {{ super() }}
 {% endblock %}
 
 {% block content %}
-<div class="govuk-grid-row govuk-body">
+<div class="govuk-grid-row govuk-body negative-margin-top-7">
   {% if featureFlagReportEditingEnabled %}
     {% set renderReportView = true %}
     {% set print = false %}

--- a/server/views/pages/reviewer/view-report.html
+++ b/server/views/pages/reviewer/view-report.html
@@ -14,41 +14,65 @@
 {% block content %}
 <div class="govuk-grid-row govuk-body">
   {% if featureFlagReportEditingEnabled %}
-  {% set renderReportView = true %}
-  {% set print = false %}
-  
-  <div class="{% if renderReportView %} govuk-grid-column-full {% else %} govuk-grid-column-three-quarters {% endif %} govuk-!-margin-bottom-9">
-    <h1 class="govuk-heading-xl">Use of force incident {{ data.incidentId }}</h1>
+    {% set renderReportView = true %}
+    {% set print = false %}
 
-    {{ mojSubNavigation({
-        label: "Sub navigation",
-        items: [{
-          text: "Report",
-          href: '/' + data.incidentId + '/view-report',
-          active: true,
-          attributes: {'data-qa':'report-tab'}
-        }]
-      }) }}
+    <div class="{% if renderReportView %} govuk-grid-column-full {% else %} govuk-grid-column-three-quarters {% endif %} govuk-!-margin-bottom-9">
+      
+      {% if user.isCoordinator %}
+        <div class="flex-container-space-between">
+          <div>
+            <h1 class="govuk-heading-xl govuk-!-margin-bottom-0">Use of force incident {{ data.incidentId }} </h1>
+          </div>
 
-    {{
-      reportDetail.detail(data, null, data.incidentId, user, print, renderReportView)
-    }}
+          <div class="govuk-button-group govuk-!-margin-top-4">
+              {{ govukButton({
+                text: "Edit report",
+                href: "edit-report",
+                attributes: {'data-qa':'button-edit-report'}
+              }) }}
+
+              {{ govukButton({
+                classes: "govuk-button--warning",
+                text: "Delete incident",
+                href: "delete-incident",
+                attributes: {'data-qa':'button-delete-incident'}
+              }) }}
+          </div>
+      </div>
+      {% else %}
+          <h1 class="govuk-heading-xl">Use of force incident {{ data.incidentId }}</h1>
+      {% endif %}
+
+      {{ mojSubNavigation({
+          label: "Sub navigation",
+          items: [{
+            text: "Report",
+            href: '/' + data.incidentId + '/view-report',
+            active: true,
+            attributes: {'data-qa':'report-tab'}
+          }]
+        }) }}
+
+      {{
+        reportDetail.detail(data, null, data.incidentId, user, print, renderReportView)
+      }}
 
     {% else %}
 
-    <div class="govuk-grid-column-full govuk-!-margin-bottom-9 ">
-      <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-          {{
-            reportDetail.reportHeading(data, print=false)
-          }}
+      <div class="govuk-grid-column-full govuk-!-margin-bottom-9 ">
+        <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-full">
+            {{
+              reportDetail.reportHeading(data, print=false)
+            }}
+          </div>
         </div>
-      </div>
-  
-      {{
-        reportDetail.detail(data, null, data.incidentId, user)
-      }}
+
+        {{
+          reportDetail.detail(data, null, data.incidentId, user)
+        }}
 
     {% endif %}
 

--- a/server/views/pages/your-report.html
+++ b/server/views/pages/your-report.html
@@ -19,7 +19,7 @@
   {% set print = false %}
   
   <div class="{% if renderReportView %} govuk-grid-column-full {% else %} govuk-grid-column-three-quarters {% endif %} govuk-!-margin-bottom-9 no-print">
-    <h1 class="govuk-heading-xl">Use of force incident {{ data.incidentId }}</h1>
+    <h1 class="govuk-heading-xl govuk-!-margin-bottom-6">Use of force incident {{ data.incidentId }}</h1>
     
     {{ mojSubNavigation({
       label: "Sub navigation",


### PR DESCRIPTION
[MAP-2316](https://dsdmoj.atlassian.net/jira/software/c/projects/MAP/boards/1354?isEligibleForUserSurvey=true&issueParent=391911&selectedIssue=MAP-2316)
1. display the Edit and delete buttons in /view-report to coordinators only
2. include the prisoner profile in /view-report
3. change link text from history to Edit history
4. tests to check existence of rows related to edited reports

[MAP-2316]: https://dsdmoj.atlassian.net/browse/MAP-2316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ