### PR TITLE
Remove location from statements table

### DIFF
--- a/server/views/pages/viewIncident/statements.njk
+++ b/server/views/pages/viewIncident/statements.njk
@@ -34,7 +34,6 @@
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">
         <th class="govuk-table__header" scope="col" aria-sort="none">Name</th>
-        <th class="govuk-table__header" scope="col" aria-sort="none">Location</th>
         <th class="govuk-table__header" scope="col" aria-sort="none">Email</th>
         <th class="govuk-table__header" scope="col" aria-sort="none">Status</th>
         <th class="govuk-table__header" scope="col">Action</th>
@@ -45,7 +44,6 @@
       {% for statement in data.allStatements %}
         <tr class="govuk-table__row">
           <td class="govuk-table__cell" data-qa="name">{{statement.name}} ({{statement.userId}})</td>
-          <td class="govuk-table__cell" data-qa="location"></td>
           <td class="govuk-table__cell" data-qa="email">
             {{statement.email}}
             


### PR DESCRIPTION
Related to [MAP-2326.](https://dsdmoj.atlassian.net/jira/software/c/projects/MAP/boards/1354?assignee=625e8c18fd06270069bf7ddd&selectedIssue=MAP-2326)

**Changes made:**
- remove reference to location within the statements tab, involved staff table. 