### PR TITLE
Map 2501 update pagination

### DIFF
--- a/integration-tests/integration/createIncident/view-your-reports.cy.js
+++ b/integration-tests/integration/createIncident/view-your-reports.cy.js
@@ -80,7 +80,7 @@ context('A reporter views their report list', () => {
 
     cy.task(
       'seedReports',
-      Array.from(Array(62)).map((_, i) => ({
+      Array.from(Array(60)).map((_, i) => ({
         status: ReportStatus.SUBMITTED,
         bookingId: i,
         involvedStaff: [
@@ -97,14 +97,13 @@ context('A reporter views their report list', () => {
     yourReportsPage.selectedTab().contains('Your reports')
     yourReportsPage.pagination().should('be.visible')
 
-    yourReportsPage.pageResults().should(results => expect(results.text()).to.contain('Showing 1 to 20 of 62 results'))
+    yourReportsPage.pageResults().should(results => expect(results.text()).to.contain('Showing 1 to 20 of 60 results'))
 
     yourReportsPage.pageLinks().then(pageLinks =>
       expect(pageLinks).to.deep.equal([
         { href: undefined, text: '1', selected: true },
         { href: '?page=2', text: '2', selected: false },
         { href: '?page=3', text: '3', selected: false },
-        { href: '?page=4', text: '4', selected: false },
         { href: '?page=2', text: 'Next page', selected: false },
       ])
     )
@@ -115,31 +114,101 @@ context('A reporter views their report list', () => {
         { href: '?page=1', text: '1', selected: false },
         { href: undefined, text: '2', selected: true },
         { href: '?page=3', text: '3', selected: false },
-        { href: '?page=4', text: '4', selected: false },
         { href: '?page=3', text: 'Next page', selected: false },
       ])
     )
 
-    yourReportsPage.clickLinkWithText('4')
-    yourReportsPage.pageLinks().then(pageLinks =>
-      expect(pageLinks).to.deep.equal([
-        { href: '?page=3', text: 'Previous page', selected: false },
-        { href: '?page=1', text: '1', selected: false },
-        { href: '?page=2', text: '2', selected: false },
-        { href: '?page=3', text: '3', selected: false },
-        { href: undefined, text: '4', selected: true },
-      ])
-    )
-
-    yourReportsPage.clickLinkWithText('Previous page')
+    yourReportsPage.clickLinkWithText('3')
     yourReportsPage.pageLinks().then(pageLinks =>
       expect(pageLinks).to.deep.equal([
         { href: '?page=2', text: 'Previous page', selected: false },
         { href: '?page=1', text: '1', selected: false },
         { href: '?page=2', text: '2', selected: false },
         { href: undefined, text: '3', selected: true },
-        { href: '?page=4', text: '4', selected: false },
-        { href: '?page=4', text: 'Next page', selected: false },
+      ])
+    )
+
+    yourReportsPage.clickLinkWithText('Previous page')
+    yourReportsPage.pageLinks().then(pageLinks =>
+      expect(pageLinks).to.deep.equal([
+        { href: '?page=1', text: 'Previous page', selected: false },
+        { href: '?page=1', text: '1', selected: false },
+        { href: undefined, text: '2', selected: true },
+        { href: '?page=3', text: '3', selected: false },
+        { href: '?page=3', text: 'Next page', selected: false },
+      ])
+    )
+  })
+
+  it('A user can view extended pagination when more than 3 pages of results', () => {
+    cy.task('stubOffenders', [offender])
+    cy.login()
+
+    cy.task(
+      'seedReports',
+      Array.from(Array(220)).map((_, i) => ({
+        status: ReportStatus.SUBMITTED,
+        bookingId: i,
+        involvedStaff: [
+          {
+            username: 'TEST_USER',
+            name: 'TEST_USER name',
+            email: 'TEST_USER@gov.uk',
+          },
+        ],
+      }))
+    )
+
+    const yourReportsPage = YourReportsPage.goTo()
+    yourReportsPage.selectedTab().contains('Your reports')
+    yourReportsPage.pagination().should('be.visible')
+
+    yourReportsPage.pageResults().should(results => expect(results.text()).to.contain('Showing 1 to 20 of 220 results'))
+
+    // [1] 2 3 ... 11 Next >
+    yourReportsPage.pageLinks().then(pageLinks =>
+      expect(pageLinks).to.deep.equal([
+        { href: undefined, text: '1', selected: true },
+        { href: '?page=2', text: '2', selected: false },
+        { href: '?page=3', text: '3', selected: false },
+        { href: '', text: '…', selected: false },
+        { href: '?page=11', text: '11', selected: false },
+        { href: '?page=2', text: 'Next page', selected: false },
+      ])
+    )
+
+    // < Previous 1 … 3 [4] 5 Next >
+    yourReportsPage.clickLinkWithText('3')
+    yourReportsPage.clickLinkWithText('Next page')
+    yourReportsPage.pageLinks().then(pageLinks =>
+      expect(pageLinks).to.deep.equal([
+        { href: '?page=3', text: 'Previous page', selected: false },
+        { href: '?page=1', text: '1', selected: false },
+        { href: '', text: '…', selected: false },
+        { href: '?page=3', text: '3', selected: false },
+        { href: undefined, text: '4', selected: true },
+        { href: '?page=5', text: '5', selected: false },
+        { href: '', text: '…', selected: false },
+        { href: '?page=11', text: '11', selected: false },
+        { href: '?page=5', text: 'Next page', selected: false },
+      ])
+    )
+
+    // < Previous 1 … [9] 10 11 Next >
+    yourReportsPage.clickLinkWithText('5')
+    yourReportsPage.clickLinkWithText('Next page') // 6
+    yourReportsPage.clickLinkWithText('Next page') // 7
+    yourReportsPage.clickLinkWithText('Next page') // 8
+    yourReportsPage.clickLinkWithText('Next page') // 9
+    yourReportsPage.pageLinks().then(pageLinks =>
+      expect(pageLinks).to.deep.equal([
+        { href: '?page=8', text: 'Previous page', selected: false },
+        { href: '?page=1', text: '1', selected: false },
+        { href: '', text: '…', selected: false },
+        { href: undefined, text: '9', selected: true },
+        { href: '?page=10', text: '10', selected: false },
+        { href: '?page=11', text: '11', selected: false },
+        { href: '?page=10', text: 'Next page', selected: false },
       ])
     )
   })

--- a/integration-tests/integration/statements/view-your-statements.cy.js
+++ b/integration-tests/integration/statements/view-your-statements.cy.js
@@ -118,7 +118,7 @@ context('A user views their statements list', () => {
 
     cy.task(
       'seedReports',
-      Array.from(Array(62)).map((_, i) => ({
+      Array.from(Array(60)).map((_, i) => ({
         status: ReportStatus.SUBMITTED,
         bookingId: i,
         involvedStaff: [
@@ -137,14 +137,13 @@ context('A user views their statements list', () => {
 
     yourStatementsPage
       .pageResults()
-      .should(results => expect(results.text()).to.contain('Showing 1 to 20 of 62 results'))
+      .should(results => expect(results.text()).to.contain('Showing 1 to 20 of 60 results'))
 
     yourStatementsPage.pageLinks().then(pageLinks =>
       expect(pageLinks).to.deep.equal([
         { href: undefined, text: '1', selected: true },
         { href: '?page=2', text: '2', selected: false },
         { href: '?page=3', text: '3', selected: false },
-        { href: '?page=4', text: '4', selected: false },
         { href: '?page=2', text: 'Next page', selected: false },
       ])
     )
@@ -155,31 +154,103 @@ context('A user views their statements list', () => {
         { href: '?page=1', text: '1', selected: false },
         { href: undefined, text: '2', selected: true },
         { href: '?page=3', text: '3', selected: false },
-        { href: '?page=4', text: '4', selected: false },
         { href: '?page=3', text: 'Next page', selected: false },
       ])
     )
 
-    yourStatementsPage.clickLinkWithText('4')
-    yourStatementsPage.pageLinks().then(pageLinks =>
-      expect(pageLinks).to.deep.equal([
-        { href: '?page=3', text: 'Previous page', selected: false },
-        { href: '?page=1', text: '1', selected: false },
-        { href: '?page=2', text: '2', selected: false },
-        { href: '?page=3', text: '3', selected: false },
-        { href: undefined, text: '4', selected: true },
-      ])
-    )
-
-    yourStatementsPage.clickLinkWithText('Previous page')
+    yourStatementsPage.clickLinkWithText('3')
     yourStatementsPage.pageLinks().then(pageLinks =>
       expect(pageLinks).to.deep.equal([
         { href: '?page=2', text: 'Previous page', selected: false },
         { href: '?page=1', text: '1', selected: false },
         { href: '?page=2', text: '2', selected: false },
         { href: undefined, text: '3', selected: true },
-        { href: '?page=4', text: '4', selected: false },
-        { href: '?page=4', text: 'Next page', selected: false },
+      ])
+    )
+
+    yourStatementsPage.clickLinkWithText('Previous page')
+    yourStatementsPage.pageLinks().then(pageLinks =>
+      expect(pageLinks).to.deep.equal([
+        { href: '?page=1', text: 'Previous page', selected: false },
+        { href: '?page=1', text: '1', selected: false },
+        { href: undefined, text: '2', selected: true },
+        { href: '?page=3', text: '3', selected: false },
+        { href: '?page=3', text: 'Next page', selected: false },
+      ])
+    )
+  })
+
+  it('A user can view expected pagination elements when there are more than 3 pages of results', () => {
+    cy.task('stubOffenders', [offender])
+    cy.login()
+
+    cy.task(
+      'seedReports',
+      Array.from(Array(220)).map((_, i) => ({
+        status: ReportStatus.SUBMITTED,
+        bookingId: i,
+        involvedStaff: [
+          {
+            username: 'TEST_USER',
+            name: 'TEST_USER name',
+            email: 'TEST_USER@gov.uk',
+          },
+        ],
+      }))
+    )
+
+    const yourStatementsPage = YourStatementsPage.goTo()
+    yourStatementsPage.selectedTab().contains('Your statements')
+    yourStatementsPage.pagination().should('be.visible')
+
+    yourStatementsPage
+      .pageResults()
+      .should(results => expect(results.text()).to.contain('Showing 1 to 20 of 220 results'))
+
+    // [1] 2 3 ... 11 Next >
+    yourStatementsPage.pageLinks().then(pageLinks =>
+      expect(pageLinks).to.deep.equal([
+        { href: undefined, text: '1', selected: true },
+        { href: '?page=2', text: '2', selected: false },
+        { href: '?page=3', text: '3', selected: false },
+        { href: '', text: '…', selected: false },
+        { href: '?page=11', text: '11', selected: false },
+        { href: '?page=2', text: 'Next page', selected: false },
+      ])
+    )
+
+    // < Previous 1 … 3 [4] 5 Next >
+    yourStatementsPage.clickLinkWithText('3')
+    yourStatementsPage.clickLinkWithText('Next page')
+    yourStatementsPage.pageLinks().then(pageLinks =>
+      expect(pageLinks).to.deep.equal([
+        { href: '?page=3', text: 'Previous page', selected: false },
+        { href: '?page=1', text: '1', selected: false },
+        { href: '', text: '…', selected: false },
+        { href: '?page=3', text: '3', selected: false },
+        { href: undefined, text: '4', selected: true },
+        { href: '?page=5', text: '5', selected: false },
+        { href: '', text: '…', selected: false },
+        { href: '?page=11', text: '11', selected: false },
+        { href: '?page=5', text: 'Next page', selected: false },
+      ])
+    )
+
+    // < Previous 1 … [9] 10 11 Next >
+    yourStatementsPage.clickLinkWithText('5')
+    yourStatementsPage.clickLinkWithText('Next page') // 6
+    yourStatementsPage.clickLinkWithText('Next page') // 7
+    yourStatementsPage.clickLinkWithText('Next page') // 8
+    yourStatementsPage.clickLinkWithText('Next page') // 9
+    yourStatementsPage.pageLinks().then(pageLinks =>
+      expect(pageLinks).to.deep.equal([
+        { href: '?page=8', text: 'Previous page', selected: false },
+        { href: '?page=1', text: '1', selected: false },
+        { href: '', text: '…', selected: false },
+        { href: undefined, text: '9', selected: true },
+        { href: '?page=10', text: '10', selected: false },
+        { href: '?page=11', text: '11', selected: false },
+        { href: '?page=10', text: 'Next page', selected: false },
       ])
     )
   })

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -136,25 +136,69 @@ export default function configureNunjucks(app: Express.Application): nunjucks.En
 
   njkEnv.addFilter('toPagination', (pageData: PageMetaData, query: Record<string, unknown> = {}) => {
     const urlForPage = n => `?${querystring.stringify({ ...query, page: n })}`
-    const items = [...Array(pageData.totalPages).keys()].map(n => ({
-      text: n + 1,
-      href: urlForPage(n + 1),
-      selected: n + 1 === pageData.page,
-    }))
+
+    const { page, totalPages, previousPage, nextPage, totalCount, min, max } = pageData
+    const items: { text: string; href?: string; selected?: boolean }[] = []
+
+    const addPage = (n: number) => {
+      items.push({
+        text: `${n}`,
+        href: urlForPage(n),
+        selected: n === page,
+      })
+    }
+
+    const addEllipsis = () => {
+      items.push({
+        text: '…',
+      })
+    }
+
+    if (totalPages <= 3) {
+      for (let i = 1; i <= totalPages; i += 1) {
+        addPage(i)
+      }
+    } else {
+      const isNearStart = page <= 3
+      const isNearEnd = page >= totalPages - 2
+
+      if (isNearStart) {
+        // e.g. [1] 2 3 … 10
+        for (let i = 1; i <= 3; i += 1) addPage(i)
+        addEllipsis()
+        addPage(totalPages)
+      } else if (isNearEnd) {
+        // e.g. 1 … 8 9 [10]
+        addPage(1)
+        addEllipsis()
+        for (let i = totalPages - 2; i <= totalPages; i += 1) addPage(i)
+      } else {
+        // e.g. 1 … 4 [5] 6 … 10
+        addPage(1)
+        addEllipsis()
+        addPage(page - 1)
+        addPage(page)
+        addPage(page + 1)
+        addEllipsis()
+        addPage(totalPages)
+      }
+    }
+
     return {
       results: {
-        from: pageData.min,
-        to: pageData.max,
-        count: pageData.totalCount,
+        from: min,
+        to: max,
+        count: totalCount,
       },
-      previous: pageData.previousPage && {
+      previous: previousPage && {
         text: 'Previous',
-        href: urlForPage(pageData.previousPage),
+        href: urlForPage(previousPage),
       },
-      next: pageData.nextPage && {
-        text: 'Next',
-        href: urlForPage(pageData.nextPage),
-      },
+      next: nextPage &&
+        !(totalPages <= 3 && page === totalPages) && {
+          text: 'Next',
+          href: urlForPage(nextPage),
+        },
       items,
     }
   })


### PR DESCRIPTION
The changes in this PR are related to [MAP-2501](https://dsdmoj.atlassian.net/jira/software/c/projects/MAP/boards/1354?assignee=625e8c18fd06270069bf7ddd&selectedIssue=MAP-2501)

**The changes made include:**

- Updated the toPagination nunjucks filter which handles the logic for the pagination component
- Updated failing integration test, that were failing due to the logic changes in the toPagination filter
- Add additional integration tests focusing on the pagination component

[MAP-2501]: https://dsdmoj.atlassian.net/browse/MAP-2501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ