### PR TITLE
Feature/map 2638 add pagination to not completed tab

### DIFF
--- a/server/routes/maintainingReports/reviewer.test.ts
+++ b/server/routes/maintainingReports/reviewer.test.ts
@@ -160,6 +160,25 @@ describe(`GET /not-completed-incidents`, () => {
       })
   })
 
+  it('should pass search query params through to page params', () => {
+    userSupplier.mockReturnValue(reviewerUser)
+    reviewService.getIncompleteReports.mockResolvedValue(
+      new PageResponse(
+        { min: 1, max: 20, totalCount: 200, totalPages: 10, page: 1, nextPage: 2, previousPage: null },
+        [],
+      ),
+    )
+    return request(app)
+      .get('/not-completed-incidents?page=1')
+      .expect(200)
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain(
+          '<a class="moj-pagination__link" href="?prisonNumber=A1234AA&amp;reporter=Bob&amp;dateFrom=9%20Jan%202020&amp;dateTo=15%20Jan%202020&amp;prisonerName=Jimmy%20Choo&amp;page=3',
+        )
+      })
+  })
+
   it('should not allow if not reviewer', () => {
     userSupplier.mockReturnValue(user)
     return request(app)

--- a/server/routes/maintainingReports/reviewer.test.ts
+++ b/server/routes/maintainingReports/reviewer.test.ts
@@ -5,7 +5,7 @@ import { parseDate } from '../../utils/utils'
 import { PageResponse } from '../../utils/page'
 import type { ReportDetail } from '../../services/reportDetailBuilder'
 import { Report } from '../../data/incidentClientTypes'
-import ReviewService, { ReviewerStatementWithComments } from '../../services/reviewService'
+import ReviewService, { IncidentSummary, ReviewerStatementWithComments } from '../../services/reviewService'
 import OffenderService from '../../services/offenderService'
 import AuthService from '../../services/authService'
 import ReportDetailBuilder from '../../services/reportDetailBuilder'
@@ -30,7 +30,10 @@ beforeEach(() => {
   reviewService.getReport.mockResolvedValue({} as Report)
   authService.getSystemClientToken.mockResolvedValue('user1-system-token')
   app = appWithAllRoutes({ offenderService, reviewService, reportDetailBuilder, authService }, userSupplier)
-  reviewService.getIncompleteReports.mockResolvedValue([])
+
+  reviewService.getIncompleteReports.mockResolvedValue(
+    new PageResponse({ min: 0, max: 0, page: 1, totalCount: 0, totalPages: 1 }, []),
+  )
   reviewService.getCompletedReports.mockResolvedValue(
     new PageResponse({ min: 0, max: 0, page: 1, totalCount: 0, totalPages: 1 }, []),
   )
@@ -167,9 +170,22 @@ describe(`GET /not-completed-incidents`, () => {
 
   it('should display the OVERDUE badge but not REMOVAL REQUEST badge', () => {
     userSupplier.mockReturnValue(coordinatorUser)
-    reviewService.getIncompleteReports.mockResolvedValue([
-      { ...commonReportData, isOverdue: true, isRemovalRequested: false },
-    ])
+    reviewService.getIncompleteReports.mockResolvedValue({
+      metaData: {
+        page: 1,
+        totalPages: 1,
+        totalCount: 1,
+        min: 0,
+        max: 0,
+      },
+      items: [{ ...commonReportData, isOverdue: true, isRemovalRequested: false }],
+      map: function (fn: (item: IncidentSummary) => any) {
+        return {
+          ...this,
+          items: this.items.map(fn),
+        }
+      },
+    })
 
     return request(app)
       .get('/not-completed-incidents')
@@ -177,11 +193,25 @@ describe(`GET /not-completed-incidents`, () => {
       .expect(res => expect(res.text).toContain('OVERDUE'))
       .expect(res => expect(res.text).not.toContain('REMOVAL REQUEST'))
   })
+
   it('should display the REMOVAL REQUEST badge but not OVERDUE badge', () => {
     userSupplier.mockReturnValue(coordinatorUser)
-    reviewService.getIncompleteReports.mockResolvedValue([
-      { ...commonReportData, isOverdue: false, isRemovalRequested: true },
-    ])
+    reviewService.getIncompleteReports.mockResolvedValue({
+      metaData: {
+        page: 1,
+        totalPages: 1,
+        totalCount: 1,
+        min: 0,
+        max: 0,
+      },
+      items: [{ ...commonReportData, isOverdue: false, isRemovalRequested: true }],
+      map: function (fn: (item: IncidentSummary) => any) {
+        return {
+          ...this,
+          items: this.items.map(fn),
+        }
+      },
+    })
 
     return request(app)
       .get('/not-completed-incidents')
@@ -189,11 +219,25 @@ describe(`GET /not-completed-incidents`, () => {
       .expect(res => expect(res.text).not.toContain('OVERDUE'))
       .expect(res => expect(res.text).toContain('REMOVAL REQUEST'))
   })
+
   it('should display both the REMOVAL REQUEST and OVERDUE badges', () => {
     userSupplier.mockReturnValue(coordinatorUser)
-    reviewService.getIncompleteReports.mockResolvedValue([
-      { ...commonReportData, isOverdue: true, isRemovalRequested: true },
-    ])
+    reviewService.getIncompleteReports.mockResolvedValue({
+      metaData: {
+        page: 1,
+        totalPages: 1,
+        totalCount: 1,
+        min: 0,
+        max: 0,
+      },
+      items: [{ ...commonReportData, isOverdue: true, isRemovalRequested: true }],
+      map: function (fn: (item: IncidentSummary) => any) {
+        return {
+          ...this,
+          items: this.items.map(fn),
+        }
+      },
+    })
 
     return request(app)
       .get('/not-completed-incidents')
@@ -288,7 +332,7 @@ describe('GET /view-statements', () => {
       isVerified: true,
       name: `User ${params.id}`,
       userId: `USER_${params.id}`,
-    }) as ReviewerStatementWithComments
+    } as ReviewerStatementWithComments)
 
   it('should only render submitted statements', async () => {
     userSupplier.mockReturnValue(coordinatorUser)

--- a/server/routes/maintainingReports/reviewer.test.ts
+++ b/server/routes/maintainingReports/reviewer.test.ts
@@ -173,9 +173,7 @@ describe(`GET /not-completed-incidents`, () => {
       .expect(200)
       .expect('Content-Type', /html/)
       .expect(res => {
-        expect(res.text).toContain(
-          '<a class="moj-pagination__link" href="?prisonNumber=A1234AA&amp;reporter=Bob&amp;dateFrom=9%20Jan%202020&amp;dateTo=15%20Jan%202020&amp;prisonerName=Jimmy%20Choo&amp;page=3',
-        )
+        expect(res.text).toContain('<a class="moj-pagination__link" href="?page=2">')
       })
   })
 

--- a/server/routes/maintainingReports/reviewer.test.ts
+++ b/server/routes/maintainingReports/reviewer.test.ts
@@ -156,7 +156,7 @@ describe(`GET /not-completed-incidents`, () => {
       .expect('Content-Type', /html/)
       .expect(res => {
         expect(res.text).toContain('Use of force incidents')
-        expect(reviewService.getIncompleteReports).toHaveBeenCalledWith('user1', 'LEI')
+        expect(reviewService.getIncompleteReports).toHaveBeenCalledWith('user1', 'LEI', 1)
       })
   })
 

--- a/server/routes/maintainingReports/reviewer.ts
+++ b/server/routes/maintainingReports/reviewer.ts
@@ -19,7 +19,8 @@ export default class ReviewerRoutes {
     const page = parseInt(req.query.page as string, 10) || 1
     const { items: reports, metaData: pageData } = await this.reviewService.getIncompleteReports(
       res.locals.user.username,
-      res.locals.user.activeCaseLoadId
+      res.locals.user.activeCaseLoadId,
+      page
     )
 
     return res.render('pages/not-completed-incidents', {

--- a/server/routes/maintainingReports/reviewer.ts
+++ b/server/routes/maintainingReports/reviewer.ts
@@ -16,12 +16,16 @@ export default class ReviewerRoutes {
   ) {}
 
   viewNotCompletedIncidents = async (req: Request, res: Response): Promise<void> => {
-    const reports = await this.reviewService.getIncompleteReports(
+    const page = parseInt(req.query.page as string, 10) || 1
+    const { items: reports, metaData: pageData } = await this.reviewService.getIncompleteReports(
       res.locals.user.username,
       res.locals.user.activeCaseLoadId
     )
+
     return res.render('pages/not-completed-incidents', {
       reports,
+      pageData,
+      rawQuery: req.query,
       selectedTab: 'not-completed',
     })
   }

--- a/server/services/reviewService.test.ts
+++ b/server/services/reviewService.test.ts
@@ -132,43 +132,6 @@ describe('reviewService', () => {
     })
   })
 
-  // describe('getIncompletedReports', () => {
-  //   const reportSummary = (id: number): ReportSummary => ({
-  //     id,
-  //     bookingId: id + 1,
-  //     reporterName: `reporter-${id}`,
-  //     offenderNo: `offender-${id}`,
-  //     incidentDate: new Date(id),
-  //   })
-
-  //   const incidentSummary = (id: number): IncidentSummary => ({
-  //     id,
-  //     bookingId: id + 1,
-  //     incidentdate: new Date(id),
-  //     staffMemberName: `reporter-${id}`,
-  //     isOverdue: false,
-  //     isRemovalRequested: false,
-  //     offenderName: `Prisoner prisoner-${id}`,
-  //     offenderNo: `offender-${id}`,
-  //   })
-
-  //   test('retrieve and include offender names', async () => {
-  //     incidentClient.getIncompleteReportsForReviewer.mockResolvedValue([reportSummary(1), reportSummary(2)])
-
-  //     offenderService.getOffenderNames.mockResolvedValue({
-  //       'offender-1': 'Prisoner prisoner-1',
-  //       'offender-2': 'Prisoner prisoner-2',
-  //     })
-
-  //     const result = await service.getIncompleteReports('userName', 'agency-1', 1)
-  //     expect(result).toEqual([incidentSummary(1), incidentSummary(2)])
-  //     expect(incidentClient.getIncompleteReportsForReviewer).toHaveBeenCalledWith('agency-1')
-  //     expect(offenderService.getOffenderNames).toHaveBeenCalledWith('userName-system-token', [
-  //       'offender-1',
-  //       'offender-2',
-  //     ])
-  //   })
-  // })
   describe('getIncompletedReports', () => {
     const reportSummary = (id: number): ReportSummary => ({
       id,
@@ -196,19 +159,6 @@ describe('reviewService', () => {
         'offender-1': 'Prisoner prisoner-1',
         'offender-2': 'Prisoner prisoner-2',
       })
-
-      // const expected = new PageResponse(
-      //   {
-      //     min: 1,
-      //     max: 2,
-      //     page: 1,
-      //     totalCount: 2,
-      //     totalPages: 1,
-      //     nextPage: null,
-      //     previousPage: null,
-      //   },
-      //   [incidentSummary(1), incidentSummary(2)]
-      // )
 
       const expected = new PageResponse(
         {

--- a/server/services/reviewService.test.ts
+++ b/server/services/reviewService.test.ts
@@ -160,7 +160,7 @@ describe('reviewService', () => {
         'offender-2': 'Prisoner prisoner-2',
       })
 
-      const result = await service.getIncompleteReports('userName', 'agency-1')
+      const result = await service.getIncompleteReports('userName', 'agency-1', 1)
       expect(result).toEqual([incidentSummary(1), incidentSummary(2)])
       expect(incidentClient.getIncompleteReportsForReviewer).toHaveBeenCalledWith('agency-1')
       expect(offenderService.getOffenderNames).toHaveBeenCalledWith('userName-system-token', [

--- a/server/services/reviewService.test.ts
+++ b/server/services/reviewService.test.ts
@@ -132,6 +132,43 @@ describe('reviewService', () => {
     })
   })
 
+  // describe('getIncompletedReports', () => {
+  //   const reportSummary = (id: number): ReportSummary => ({
+  //     id,
+  //     bookingId: id + 1,
+  //     reporterName: `reporter-${id}`,
+  //     offenderNo: `offender-${id}`,
+  //     incidentDate: new Date(id),
+  //   })
+
+  //   const incidentSummary = (id: number): IncidentSummary => ({
+  //     id,
+  //     bookingId: id + 1,
+  //     incidentdate: new Date(id),
+  //     staffMemberName: `reporter-${id}`,
+  //     isOverdue: false,
+  //     isRemovalRequested: false,
+  //     offenderName: `Prisoner prisoner-${id}`,
+  //     offenderNo: `offender-${id}`,
+  //   })
+
+  //   test('retrieve and include offender names', async () => {
+  //     incidentClient.getIncompleteReportsForReviewer.mockResolvedValue([reportSummary(1), reportSummary(2)])
+
+  //     offenderService.getOffenderNames.mockResolvedValue({
+  //       'offender-1': 'Prisoner prisoner-1',
+  //       'offender-2': 'Prisoner prisoner-2',
+  //     })
+
+  //     const result = await service.getIncompleteReports('userName', 'agency-1', 1)
+  //     expect(result).toEqual([incidentSummary(1), incidentSummary(2)])
+  //     expect(incidentClient.getIncompleteReportsForReviewer).toHaveBeenCalledWith('agency-1')
+  //     expect(offenderService.getOffenderNames).toHaveBeenCalledWith('userName-system-token', [
+  //       'offender-1',
+  //       'offender-2',
+  //     ])
+  //   })
+  // })
   describe('getIncompletedReports', () => {
     const reportSummary = (id: number): ReportSummary => ({
       id,
@@ -160,8 +197,34 @@ describe('reviewService', () => {
         'offender-2': 'Prisoner prisoner-2',
       })
 
+      // const expected = new PageResponse(
+      //   {
+      //     min: 1,
+      //     max: 2,
+      //     page: 1,
+      //     totalCount: 2,
+      //     totalPages: 1,
+      //     nextPage: null,
+      //     previousPage: null,
+      //   },
+      //   [incidentSummary(1), incidentSummary(2)]
+      // )
+
+      const expected = new PageResponse(
+        {
+          min: 1,
+          max: 2,
+          page: 1,
+          totalCount: 2,
+          totalPages: 1,
+          nextPage: null,
+          previousPage: null,
+        },
+        [incidentSummary(1), incidentSummary(2)]
+      )
+
       const result = await service.getIncompleteReports('userName', 'agency-1', 1)
-      expect(result).toEqual([incidentSummary(1), incidentSummary(2)])
+      expect(result).toEqual(expected)
       expect(incidentClient.getIncompleteReportsForReviewer).toHaveBeenCalledWith('agency-1')
       expect(offenderService.getOffenderNames).toHaveBeenCalledWith('userName-system-token', [
         'offender-1',

--- a/server/services/reviewService.ts
+++ b/server/services/reviewService.ts
@@ -104,10 +104,12 @@ export default class ReviewService {
     return reports.map(toIncidentSummary(namesByOffenderNumber))
   }
 
-  async getIncompleteReports(username: string, agencyId: AgencyId): Promise<IncidentSummary[]> {
+  // async getIncompleteReports(username: string, agencyId: AgencyId): Promise<IncidentSummary[]> {
+  async getIncompleteReports(username: string, agencyId: AgencyId): Promise<PageResponse<IncidentSummary>> {
     const incomplete = await this.incidentClient.getIncompleteReportsForReviewer(agencyId)
     const namesByOffenderNumber = await this.getOffenderNames(username, incomplete)
-    return incomplete.map(toIncidentSummary(namesByOffenderNumber))
+    // return incomplete.map(toIncidentSummary(namesByOffenderNumber))
+    return toPage(1, incomplete.map(toIncidentSummary(namesByOffenderNumber)))
   }
 
   async getStatements(token: string, reportId: number): Promise<ReviewerStatementWithComments[]> {

--- a/server/services/reviewService.ts
+++ b/server/services/reviewService.ts
@@ -104,12 +104,15 @@ export default class ReviewService {
     return reports.map(toIncidentSummary(namesByOffenderNumber))
   }
 
-  // async getIncompleteReports(username: string, agencyId: AgencyId): Promise<IncidentSummary[]> {
-  async getIncompleteReports(username: string, agencyId: AgencyId): Promise<PageResponse<IncidentSummary>> {
+  async getIncompleteReports(
+    username: string,
+    agencyId: AgencyId,
+    page: number
+  ): Promise<PageResponse<IncidentSummary>> {
     const incomplete = await this.incidentClient.getIncompleteReportsForReviewer(agencyId)
     const namesByOffenderNumber = await this.getOffenderNames(username, incomplete)
-    // return incomplete.map(toIncidentSummary(namesByOffenderNumber))
-    return toPage(1, incomplete.map(toIncidentSummary(namesByOffenderNumber)))
+
+    return toPage(page, incomplete.map(toIncidentSummary(namesByOffenderNumber)))
   }
 
   async getStatements(token: string, reportId: number): Promise<ReviewerStatementWithComments[]> {

--- a/server/views/pages/not-completed-incidents.html
+++ b/server/views/pages/not-completed-incidents.html
@@ -3,10 +3,15 @@
 {% from "govuk/components/table/macro.njk" import govukTable %} 
 {% from  "../macros.njk" import overdueBadge %}   
 {% from  "../macros.njk" import removalRequestedBadge %}    
+{% from "moj/components/pagination/macro.njk" import mojPagination %}
 
 {% block tabContent %}
 <section class="govuk-tabs__panel">
   
+  {% if pageData.totalPages > 1 %}
+    {{ mojPagination( pageData | toPagination(rawQuery) ) }}
+  {% endif %} 
+
   {% if reports.length %}
 <table class="govuk-table reviewer-incidents" data-qa="incidents-todo">
 
@@ -64,6 +69,10 @@
 {% else %}
 <p class="govuk-body" data-qa="no-incidents-todo">There are no incomplete incidents</p>
 {% endif %}
+
+{% if pageData.totalPages > 1 %}
+  {{ mojPagination( pageData | toPagination(rawQuery) ) }}
+{% endif %} 
 
 </section>
 {% endblock %}


### PR DESCRIPTION
This PR is related to [MAP-2638](https://dsdmoj.atlassian.net/jira/software/c/projects/MAP/boards/1354?selectedIssue=MAP-2638)

**Changes made in this PR:**
- Added the moj-pagination component to the 'Not Completed' tab view
- Updated reviewService logic to support the use of pagination in the view
- Refactored various pieces of code related to the ticket
- Added and updated unit tests that support the new functionality
- Added and updated integration tests that support the new functionality

[MAP-2638]: https://dsdmoj.atlassian.net/browse/MAP-2638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ