### PR TITLE
Map 2636 uof edit incident details persist edits to edits table

### DIFF
--- a/assets/sass/local.sass
+++ b/assets/sass/local.sass
@@ -406,3 +406,4 @@ dt.summary-list__key__wider
 // target the parent of dev having a class of negative-margin-top-7
 main:has(div.negative-margin-top-7)
   margin-top: -30px
+  

--- a/assets/sass/local.sass
+++ b/assets/sass/local.sass
@@ -406,4 +406,3 @@ dt.summary-list__key__wider
 // target the parent of dev having a class of negative-margin-top-7
 main:has(div.negative-margin-top-7)
   margin-top: -30px
-  

--- a/assets/sass/local.sass
+++ b/assets/sass/local.sass
@@ -387,6 +387,22 @@ dt.summary-list__key__wider
 .border-bottom-none
   border-bottom: none
 
+.edit-history-table
+  table-layout: fixed
+  width: 100%
+
+.edit-history-table-width-8
+  width: 8% !important
+
+.edit-history-table-width-12
+  width: 12% !important
+
+.edit-history-table .border-bottom-grey  tr:last-child
+  border-bottom: 1px solid govuk-colour("mid-grey")
+
+.edit-history-table .govuk-table__cell
+   border-bottom: none
+
 // target the parent of dev having a class of negative-margin-top-7
 main:has(div.negative-margin-top-7)
   margin-top: -30px

--- a/migrations/20250902000000_form_db.js
+++ b/migrations/20250902000000_form_db.js
@@ -1,0 +1,23 @@
+export async function up(knex) {
+  await knex.schema.alterTable('report_edit', table => {
+    table.dropColumn('change_to')
+    table.dropColumn('old_value_primary')
+    table.dropColumn('old_value_secondary')
+    table.dropColumn('new_value_primary')
+    table.dropColumn('new_value_secondary')
+    table.jsonb('changes').defaultTo('[]').notNullable()
+    table.text('reason_text')
+  })
+}
+
+export async function down(knex) {
+  await knex.schema.alterTable('report_edit', table => {
+    table.dropColumn('changes')
+    table.dropColumn('reason_text')
+    table.string('change_to')
+    table.string('old_value_primary')
+    table.string('old_value_secondary')
+    table.string('new_value_primary')
+    table.string('new_value_secondary')
+  })
+}

--- a/migrations/20250902000000_form_db.js
+++ b/migrations/20250902000000_form_db.js
@@ -1,17 +1,16 @@
-export async function up(knex) {
-  await knex.schema.alterTable('report_edit', table => {
+exports.up = knex =>
+  knex.schema.alterTable('report_edit', table => {
     table.dropColumn('change_to')
     table.dropColumn('old_value_primary')
     table.dropColumn('old_value_secondary')
     table.dropColumn('new_value_primary')
     table.dropColumn('new_value_secondary')
-    table.jsonb('changes').defaultTo('[]').notNullable()
+    table.jsonb('changes').defaultTo('{}').notNullable()
     table.text('reason_text')
   })
-}
 
-export async function down(knex) {
-  await knex.schema.alterTable('report_edit', table => {
+exports.down = knex =>
+  knex.schema.alterTable('report_edit', table => {
     table.dropColumn('changes')
     table.dropColumn('reason_text')
     table.string('change_to')
@@ -20,4 +19,3 @@ export async function down(knex) {
     table.string('new_value_primary')
     table.string('new_value_secondary')
   })
-}

--- a/server/config/edit/incidentDetailsConfig.ts
+++ b/server/config/edit/incidentDetailsConfig.ts
@@ -1,3 +1,38 @@
 export default {
-  section: 'incidentDetails',
+  SECTION: 'incidentDetails',
+}
+
+export const QUESTION_SET = {
+  PRISON: 'Prison',
+  INCIDENT_LOCATION: 'Incident location',
+  WITNESSES: 'Witnesses to the incident',
+  PLANNED_UOF: 'Was use of force planned',
+  AUTHORISED_BY: 'Who authorised use of force',
+  INCIDENT_DATE: 'Incident date',
+}
+
+export const QUESTION_ID = {
+  INCIDENT_LOCATION: 'incidentLocation',
+  WITNESSES: 'witnesses',
+  PLANNED_UOF: 'plannedUseOfForce',
+  AUTHORISED_BY: 'authorisedBy',
+  INCIDENT_DATE: 'incidentDate',
+  AGENCY_ID: 'agencyId',
+}
+
+export const REASON = {
+  ERROR_IN_REPORT: 'errorInReport',
+  ERROR_IN_REPORT_DESCRIPTION: 'Error in report',
+  SOMETHING_MISSING: 'somethingMissingFromReport',
+  SOMETHING_MISSING_DESCRIPTION: 'Something missing',
+  NEW_EVIDENCE: 'newEvidence',
+  NEW_EVIDENCE_DESCRIPTION: 'New evidence',
+  ANOTHER_REASON: 'anotherReasonForEdit',
+  ANOTHER_REASON_DESCRIPTION: 'Another reason',
+}
+
+export type DateTime = {
+  date: string
+  hour: string
+  minute: string
 }

--- a/server/config/edit/questionSequence.ts
+++ b/server/config/edit/questionSequence.ts
@@ -1,0 +1,6 @@
+// This is the order in which changes will be displayed in the 'what changed, changed from, changed to' columns of
+// /{incidentId}/view-incident?tab=edit-history page. Not setting this order will mean the view will follow the order in the DB which is very random.
+
+// just add more to the same list for the other pages. Don't create a new array.
+
+export default ['incidentDate', 'agencyId', 'incidentLocation', 'plannedUseOfForce', 'authorisedBy', 'witnesses']

--- a/server/config/edit/questionSets.ts
+++ b/server/config/edit/questionSets.ts
@@ -1,0 +1,14 @@
+import { QUESTION_SET } from './incidentDetailsConfig'
+
+// this will hold the questions every page. Keys to match those in db
+export default {
+  incidentDetails: {
+    agencyId: QUESTION_SET.PRISON,
+    incidentLocation: QUESTION_SET.INCIDENT_LOCATION,
+    witnesses: QUESTION_SET.WITNESSES,
+    plannedUseOfForce: QUESTION_SET.PLANNED_UOF,
+    authorisedBy: QUESTION_SET.AUTHORISED_BY,
+    incidentDate: QUESTION_SET.INCIDENT_DATE,
+  },
+  // Add mappings for the other sections/pages of the report here. Keys to be in the order to display in reasons page
+}

--- a/server/data/incidentClient.test.ts
+++ b/server/data/incidentClient.test.ts
@@ -52,17 +52,14 @@ test('getReportEdits', () => {
           , editor_user_id "editorUserId"
           , editor_name "editorName"
           , report_id "reportId"
-          , change_to "changeTo"
-          , old_value_primary "oldValuePrimary"
-          , old_value_secondary "oldValueSecondary"
-          , new_value_primary "newValuePrimary"
-          , new_value_secondary "newValueSecondary"
+          , changes "changes"
           , reason "reason"
+          , reason_text "reasonText"
           , additional_comments "additionalComments"
           , report_owner_changed "reportOwnerChanged"
           from report_edit r
           where r.report_id = $1
-          ORDER BY edit_date ASC`,
+          ORDER BY edit_date DESC`,
     values: [1],
   })
 })
@@ -350,13 +347,18 @@ test('update', () => {
   })
 })
 
-test('updateAgencyId', () => {
-  incidentClient.updateAgencyId(1, 'agencyId')
+test('updateWithEdits', () => {
+  const date = new Date()
+
+  incidentClient.updateWithEdits(1, date, 'WRI', {})
 
   expect(query).toHaveBeenCalledWith({
     text: `update v_report r
-              set agency_id = COALESCE($1,  r.agency_id)
-              where r.id = $2`,
-    values: ['agencyId', 1],
+            set form_response = COALESCE($1,   r.form_response)
+            ,   incident_date = COALESCE($2,   r.incident_date)
+            ,   agency_id = COALESCE($3,   r.agency_id)
+            ,   updated_date = now()
+            where r.id = $4`,
+    values: [{}, date, 'WRI', 1],
   })
 })

--- a/server/data/incidentClient.ts
+++ b/server/data/incidentClient.ts
@@ -1,5 +1,6 @@
+import { Change } from '../services/editReports/types/reportEditServiceTypes'
 import type { QueryPerformer, InTransaction } from './dataAccess/db'
-import { AgencyId, LoggedInUser } from '../types/uof'
+import { AgencyId } from '../types/uof'
 import { LabelledValue, ReportStatus, StatementStatus } from '../config/types'
 import {
   IncidentSearchQuery,
@@ -69,17 +70,14 @@ export default class IncidentClient {
           , editor_user_id "editorUserId"
           , editor_name "editorName"
           , report_id "reportId"
-          , change_to "changeTo"
-          , old_value_primary "oldValuePrimary"
-          , old_value_secondary "oldValueSecondary"
-          , new_value_primary "newValuePrimary"
-          , new_value_secondary "newValueSecondary"
+          , changes "changes"
           , reason "reason"
+          , reason_text "reasonText"
           , additional_comments "additionalComments"
           , report_owner_changed "reportOwnerChanged"
           from report_edit r
           where r.report_id = $1
-          ORDER BY edit_date ASC`,
+          ORDER BY edit_date DESC`,
       values: [reportId],
     })
     return results.rows
@@ -307,12 +305,46 @@ export default class IncidentClient {
     })
   }
 
-  async updateAgencyId(reportId: number, agencyId: AgencyId): Promise<void> {
-    await this.query({
+  async updateWithEdits(
+    reportId: number,
+    incidentDate: Date | null,
+    agencyId: string | null,
+    formResponse: unknown | null,
+    query: QueryPerformer = this.query
+  ): Promise<void> {
+    await query({
       text: `update v_report r
-              set agency_id = COALESCE($1,  r.agency_id)
-              where r.id = $2`,
-      values: [agencyId, reportId],
+            set form_response = COALESCE($1,   r.form_response)
+            ,   incident_date = COALESCE($2,   r.incident_date)
+            ,   agency_id = COALESCE($3,   r.agency_id)
+            ,   updated_date = now()
+            where r.id = $4`,
+      values: [formResponse, incidentDate, agencyId, reportId],
+    })
+  }
+
+  async insertReportEdit(
+    edits: {
+      username: string
+      displayName: string
+      reportId: number
+      changes: Change
+      reason: string
+      reasonText: string
+      reasonAdditionalInfo: string
+      reportOwnerChanged: boolean
+    },
+    query: QueryPerformer = this.query
+  ): Promise<void> {
+    const { username, displayName, reportId, changes, reason, reasonText, reasonAdditionalInfo, reportOwnerChanged } =
+      edits
+    await query({
+      text: `INSERT INTO report_edit
+      (editor_user_id, editor_name, report_id, changes, reason, reason_text, additional_comments, report_owner_changed)
+      VALUES($1, $2, $3, $4, $5, $6, $7, $8)
+      returning id;
+      `,
+      values: [username, displayName, reportId, changes, reason, reasonText, reasonAdditionalInfo, reportOwnerChanged],
     })
   }
 }

--- a/server/routes/__test/appSetup.ts
+++ b/server/routes/__test/appSetup.ts
@@ -22,6 +22,7 @@ import DraftReportService from '../../services/drafts/draftReportService'
 import FeComponentsService from '../../services/feComponentsService'
 import AuthService from '../../services/authService'
 import ReportDetailBuilder from '../../services/reportDetailBuilder'
+import EditIncidentDetailsService from '../../services/editIncidentDetailsService'
 import ReportEditService from '../../services/reportEditService'
 import { Services } from '../../services'
 import { PrisonClient } from '../../data'
@@ -128,6 +129,7 @@ export const appWithAllRoutes = (
     locationService: {} as LocationService,
     nomisMappingService: {} as NomisMappingService,
     reportDetailBuilder: {} as ReportDetailBuilder,
+    editIncidentDetailsService: {} as EditIncidentDetailsService,
     reportEditService: {} as ReportEditService,
     draftReportService: {} as DraftReportService,
     userService: {} as UserService,

--- a/server/routes/maintainingReports/coordinator.test.ts
+++ b/server/routes/maintainingReports/coordinator.test.ts
@@ -40,7 +40,7 @@ const statementService = new StatementService(null, null, null) as jest.Mocked<S
 const authService = new AuthService(null) as jest.Mocked<AuthService>
 const locationService = new LocationService(null, null) as jest.Mocked<LocationService>
 const reportDetailBuilder = new ReportDetailBuilder(null, null, null, null, null) as jest.Mocked<ReportDetailBuilder>
-const reportEditService = new ReportEditService(null, null, null) as jest.Mocked<ReportEditService>
+const reportEditService = new ReportEditService(null, null, null, null) as jest.Mocked<ReportEditService>
 const userSupplier = jest.fn()
 
 let app

--- a/server/routes/viewingIncidents/index.ts
+++ b/server/routes/viewingIncidents/index.ts
@@ -5,9 +5,15 @@ import type { Services } from '../../services'
 import config from '../../config'
 
 export default function viewingIncidentRoutes(services: Services): Router {
-  const { reportService, reportDetailBuilder, reviewService, authService } = services
+  const { reportService, reportEditService, reportDetailBuilder, reviewService, authService } = services
   const router = express.Router()
-  const incidents = new ViewIncidentRoutes(reportService, reportDetailBuilder, reviewService, authService)
+  const incidents = new ViewIncidentRoutes(
+    reportService,
+    reportEditService,
+    reportDetailBuilder,
+    reviewService,
+    authService
+  )
   const get = (path, handler) => router.get(path, asyncMiddleware(handler))
 
   if (config.featureFlagReportEditingEnabled) {

--- a/server/routes/viewingIncidents/viewIncidents.ts
+++ b/server/routes/viewingIncidents/viewIncidents.ts
@@ -1,5 +1,6 @@
 import { RequestHandler } from 'express'
 import type AuthService from 'server/services/authService'
+import ReportEditService from '../../services/reportEditService'
 import type ReportService from '../../services/reportService'
 import type ReportDataBuilder from '../../services/reportDetailBuilder'
 import type ReviewService from '../../services/reviewService'
@@ -8,6 +9,7 @@ import logger from '../../../log'
 export default class ViewIncidentsRoutes {
   constructor(
     private readonly reportService: ReportService,
+    private readonly reportEditService: ReportEditService,
     private readonly reportDetailBuilder: ReportDataBuilder,
     private readonly reviewService: ReviewService,
     private readonly authService: AuthService
@@ -19,6 +21,7 @@ export default class ViewIncidentsRoutes {
     const { isReviewer, isCoordinator, username } = res.locals.user
     const report = await this.reviewService.getReport(parseInt(incidentId, 10))
     const reportEdits = await this.reportService.getReportEdits(parseInt(incidentId, 10))
+    const reportEditViewData = await this.reportEditService.mapEditDataToViewOutput(reportEdits, req.user)
     const hasReportBeenEdited = reportEdits?.length > 0
     const reportData = await this.reportDetailBuilder.build(username, report)
     const { offenderDetail } = reportData
@@ -78,6 +81,7 @@ export default class ViewIncidentsRoutes {
         isReviewer,
         isCoordinator,
         offenderDetail,
+        reportEditViewData,
       }
       return res.render('pages/viewIncident/incident.njk', { data: dataForEditHistory })
     }

--- a/server/services/editIncidentDetailsService.test.ts
+++ b/server/services/editIncidentDetailsService.test.ts
@@ -1,0 +1,165 @@
+import moment from 'moment'
+
+import LocationService from './locationService'
+import AuthService from './authService'
+import EditIncidentDetailsService from './editIncidentDetailsService'
+import questionSets from '../config/edit/questionSets'
+
+jest.mock('./authService')
+jest.mock('./locationService')
+const locationService = new LocationService(null, null) as jest.Mocked<LocationService>
+const authService = new AuthService(null) as jest.Mocked<AuthService>
+
+locationService.getLocation = jest.fn()
+locationService.getPrisonById = jest.fn()
+
+let editIncidentDetailsService
+
+const changes = {
+  incidentDate: {
+    oldValue: moment('2025-07-26 15:30', 'YYYY-MM-DD HH:mm'),
+    newValue: moment('2025-07-27 14:30', 'YYYY-MM-DD HH:mm'),
+    hasChanged: true,
+  },
+  incidentLocation: {
+    oldValue: 'UUID-111',
+    newValue: 'UUID-222',
+    hasChanged: true,
+  },
+  agencyId: {
+    oldValue: 'WRI',
+    newValue: 'AYI',
+    hasChanged: true,
+  },
+  plannedUseOfForce: {
+    oldValue: true,
+    newValue: false,
+    hasChanged: true,
+  },
+  authorisedBy: {
+    oldValue: 'John',
+    newValue: undefined,
+    hasChanged: true,
+  },
+  witnesses: {
+    newValue: [
+      {
+        name: 'John Smith',
+      },
+    ],
+    oldValue: [
+      {
+        name: 'John Smith',
+      },
+      {
+        name: 'Tom',
+      },
+    ],
+    question: 'Witnesses to the incident',
+    hasChanged: true,
+  },
+}
+
+beforeEach(() => {
+  authService.getSystemClientToken.mockResolvedValue(`system-token-1`)
+  editIncidentDetailsService = new EditIncidentDetailsService(locationService, authService)
+
+  locationService.getPrisonById.mockResolvedValueOnce({
+    agencyId: 'WRI',
+    description: 'Whitemoor (HMP)',
+    agencyType: 'INST',
+    active: true,
+  })
+
+  locationService.getPrisonById.mockResolvedValueOnce({
+    agencyId: 'AYI',
+    description: 'Aylesbury (HMP)',
+    agencyType: 'INST',
+    active: true,
+  })
+})
+
+describe('buildIncidentDetails', () => {
+  it('calls upstream services with correct args', async () => {
+    locationService.getLocation.mockResolvedValueOnce('Cell one')
+    locationService.getLocation.mockResolvedValueOnce('Cell two')
+    const questionSet = questionSets.incidentDetails
+    await editIncidentDetailsService.buildIncidentDetails('user-1', questionSet, changes)
+
+    expect(locationService.getPrisonById).toHaveBeenCalledWith('system-token-1', 'WRI')
+    expect(locationService.getPrisonById).toHaveBeenCalledWith('system-token-1', 'AYI')
+    expect(locationService.getLocation).toHaveBeenCalledWith('system-token-1', 'UUID-111')
+    expect(locationService.getLocation).toHaveBeenCalledWith('system-token-1', 'UUID-222')
+  })
+
+  it('returns the correct response', async () => {
+    locationService.getLocation.mockResolvedValueOnce('Cell one')
+    locationService.getLocation.mockResolvedValueOnce('Cell two')
+    const questionSet = questionSets.incidentDetails
+
+    const result = await editIncidentDetailsService.buildIncidentDetails('user-1', questionSet, changes)
+    const expectedResult = [
+      { newValue: '27/07/2025 14:30', oldValue: '26/07/2025 15:30', question: 'Incident date' },
+      { newValue: 'Cell two', oldValue: 'Cell one', question: 'Incident location' },
+      { newValue: 'Aylesbury (HMP)', oldValue: 'Whitemoor (HMP)', question: 'Prison' },
+      { newValue: false, oldValue: true, question: 'Was use of force planned' },
+      { newValue: undefined, oldValue: 'John', question: 'Who authorised use of force' },
+      { newValue: 'John Smith', oldValue: 'John Smith, Tom', question: 'Witnesses to the incident' },
+    ]
+    expect(result).toEqual(expectedResult)
+  })
+
+  it('handles scenario when no witnesses in current report', async () => {
+    changes.witnesses = {
+      newValue: [
+        {
+          name: 'John Smith',
+        },
+      ],
+      oldValue: undefined,
+      question: 'Witnesses to the incident',
+      hasChanged: true,
+    }
+
+    const questionSet = questionSets.incidentDetails
+    locationService.getLocation.mockResolvedValueOnce('Cell one')
+    locationService.getLocation.mockResolvedValueOnce('Cell two')
+
+    const result = await editIncidentDetailsService.buildIncidentDetails('user-1', questionSet, changes)
+    const expectedResult = [
+      { newValue: '27/07/2025 14:30', oldValue: '26/07/2025 15:30', question: 'Incident date' },
+      { newValue: 'Cell two', oldValue: 'Cell one', question: 'Incident location' },
+      { newValue: 'Aylesbury (HMP)', oldValue: 'Whitemoor (HMP)', question: 'Prison' },
+      { newValue: false, oldValue: true, question: 'Was use of force planned' },
+      { newValue: undefined, oldValue: 'John', question: 'Who authorised use of force' },
+      { newValue: 'John Smith', oldValue: undefined, question: 'Witnesses to the incident' },
+    ]
+    expect(result).toEqual(expectedResult)
+  })
+  it('handles scenario when witnesses no longer present', async () => {
+    changes.witnesses = {
+      newValue: undefined,
+      oldValue: [
+        {
+          name: 'John Smith',
+        },
+      ],
+      question: 'Witnesses to the incident',
+      hasChanged: true,
+    }
+    const questionSet = questionSets.incidentDetails
+    locationService.getLocation.mockResolvedValueOnce('Cell one')
+    locationService.getLocation.mockResolvedValueOnce('Cell two')
+
+    const result = await editIncidentDetailsService.buildIncidentDetails('user-1', questionSet, changes)
+    const expectedResult = [
+      { newValue: '27/07/2025 14:30', oldValue: '26/07/2025 15:30', question: 'Incident date' },
+      { newValue: 'Cell two', oldValue: 'Cell one', question: 'Incident location' },
+      { newValue: 'Aylesbury (HMP)', oldValue: 'Whitemoor (HMP)', question: 'Prison' },
+      { newValue: false, oldValue: true, question: 'Was use of force planned' },
+      { newValue: undefined, oldValue: 'John', question: 'Who authorised use of force' },
+      { newValue: undefined, oldValue: 'John Smith', question: 'Witnesses to the incident' },
+    ]
+    expect(result).toEqual(expectedResult)
+  })
+})

--- a/server/services/editIncidentDetailsService.ts
+++ b/server/services/editIncidentDetailsService.ts
@@ -1,0 +1,66 @@
+/* eslint-disable no-restricted-syntax */
+/* eslint-disable no-await-in-loop */
+import moment from 'moment'
+import type LocationService from './locationService'
+import AuthService from './authService'
+
+export default class EditIncidentDetailsService {
+  constructor(
+    private readonly locationService: LocationService,
+    private readonly authService: AuthService
+  ) {}
+
+  async buildIncidentDetails(username, questionSet, changes) {
+    const result = []
+
+    for (const key of Object.keys(changes)) {
+      const { oldValue, newValue } = changes[key]
+      const question = questionSet[key]
+
+      let resolvedOldValue: string
+      let resolvedNewValue
+
+      switch (key) {
+        case 'incidentDate':
+          resolvedOldValue = moment(oldValue).format('DD/MM/YYYY HH:mm')
+          resolvedNewValue = moment(newValue).format('DD/MM/YYYY HH:mm')
+          break
+
+        case 'agencyId':
+          resolvedOldValue = await this.#getAgency(username, oldValue)
+          resolvedNewValue = await this.#getAgency(username, newValue)
+          break
+
+        case 'incidentLocation':
+          resolvedOldValue = await this.#getIncidentLocation(username, oldValue)
+          resolvedNewValue = await this.#getIncidentLocation(username, newValue)
+          break
+
+        case 'witnesses':
+          resolvedOldValue = oldValue ? oldValue.map(c => c.name).join(', ') : undefined
+          resolvedNewValue = newValue ? newValue.map(c => c.name).join(', ') : undefined
+          break
+
+        default:
+          resolvedOldValue = oldValue
+          resolvedNewValue = newValue
+      }
+
+      result.push({ question, oldValue: resolvedOldValue, newValue: resolvedNewValue })
+    }
+
+    return result
+  }
+
+  async #getAgency(username: string, agencyId: string): Promise<string> {
+    const token = await this.authService.getSystemClientToken(username)
+    const prison = await this.locationService.getPrisonById(token, agencyId)
+    return prison.description
+  }
+
+  async #getIncidentLocation(username: string, uuid: string) {
+    const token = await this.authService.getSystemClientToken(username)
+    const location = await this.locationService.getLocation(token, uuid)
+    return location
+  }
+}

--- a/server/services/editReports/incidentDetails.test.ts
+++ b/server/services/editReports/incidentDetails.test.ts
@@ -1,4 +1,4 @@
-import { compareIncidentDetailsEditWithReport } from './incidentDetails'
+import compareIncidentDetailsEditWithReport from './incidentDetails'
 
 describe('compareIncidentDetailsEditWithReport', () => {
   const report = {
@@ -16,7 +16,7 @@ describe('compareIncidentDetailsEditWithReport', () => {
   const valuesFromRequestBody = {
     incidentDate: new Date('2020-03-02T14:17:00Z'),
     newAgencyId: 'MDI',
-    incidentLocationId: '56789-ABC',
+    incidentLocationId: '12345-ABC',
     plannedUseOfForce: 'true',
     authorisedBy: 'Joe bloggs',
     witnesses: [
@@ -27,39 +27,31 @@ describe('compareIncidentDetailsEditWithReport', () => {
   }
 
   const expectedResult = {
-    agencyId: {
-      hasChanged: true,
-      newValue: 'MDI',
-      oldValue: 'WRI',
-    },
+    agencyId: { hasChanged: true, newValue: 'MDI', oldValue: 'WRI', question: 'Prison' },
     authorisedBy: {
       hasChanged: true,
       newValue: 'Joe bloggs',
       oldValue: undefined,
+      question: 'Who authorised use of force',
     },
     incidentDate: {
       hasChanged: false,
       newValue: new Date('2020-03-02T14:17:00Z'),
       oldValue: new Date('2020-03-02T14:17:00Z'),
+      question: 'Incident date',
     },
     incidentLocation: {
-      hasChanged: true,
-      newValue: '56789-ABC',
+      hasChanged: false,
+      newValue: '12345-ABC',
       oldValue: '12345-ABC',
+      question: 'Incident location',
     },
-    plannedUseOfForce: {
-      hasChanged: true,
-      newValue: 'true',
-      oldValue: false,
-    },
+    plannedUseOfForce: { hasChanged: true, newValue: 'true', oldValue: false, question: 'Was use of force planned' },
     witnesses: {
       hasChanged: true,
-      newValue: [
-        {
-          name: 'Tom Smith',
-        },
-      ],
+      newValue: [{ name: 'Tom Smith' }],
       oldValue: undefined,
+      question: 'Witnesses to the incident',
     },
   }
   it('Should calculate differences correctly', () => {

--- a/server/services/editReports/incidentDetails.ts
+++ b/server/services/editReports/incidentDetails.ts
@@ -1,49 +1,49 @@
 import R from 'ramda'
 
+import { QUESTION_SET } from '../../config/edit/incidentDetailsConfig'
 import { hasValueChanged, excludeEmptyValuesThenTrim } from '../../utils/utils'
 
-export const compareIncidentDetailsEditWithReport = (report, valuesFromRequestBody) => {
-  const witnessesOldValue = excludeEmptyValuesThenTrim(report.form.incidentDetails.witnesses) || undefined
+export default (report, valuesFromRequestBody) => {
+  const witnessesOldValue = excludeEmptyValuesThenTrim(report.form.incidentDetails?.witnesses) || undefined
   const witnessesNewValue =
     excludeEmptyValuesThenTrim(valuesFromRequestBody.witnesses?.filter(witness => witness.name !== '')) || undefined
 
   return {
     incidentDate: {
+      question: QUESTION_SET.INCIDENT_DATE,
       oldValue: report.incidentDate,
       newValue: valuesFromRequestBody.incidentDate,
       hasChanged: !R.equals(report.incidentDate, valuesFromRequestBody.incidentDate),
     },
     agencyId: {
+      question: QUESTION_SET.PRISON,
       oldValue: report.agencyId,
       newValue: valuesFromRequestBody.newAgencyId,
-      hasChanged: hasValueChanged(report.agencyId, valuesFromRequestBody.newAgencyId || report.agencyId),
+      hasChanged: !R.equals(report.agencyId, valuesFromRequestBody.newAgencyId || report.agencyId),
     },
     incidentLocation: {
+      question: QUESTION_SET.INCIDENT_LOCATION,
       oldValue: report.form.incidentDetails.incidentLocationId,
       newValue: valuesFromRequestBody.incidentLocationId,
-      hasChanged: hasValueChanged(
-        report.form.incidentDetails.incidentLocationId,
-        valuesFromRequestBody.incidentLocationId
-      ),
+      hasChanged: !R.equals(report.form.incidentDetails.incidentLocationId, valuesFromRequestBody.incidentLocationId),
     },
     plannedUseOfForce: {
+      question: QUESTION_SET.PLANNED_UOF,
       oldValue: report.form.incidentDetails.plannedUseOfForce,
       newValue: valuesFromRequestBody.plannedUseOfForce,
       hasChanged: !R.equals(report.form.incidentDetails.plannedUseOfForce, valuesFromRequestBody.plannedUseOfForce),
     },
     authorisedBy: {
+      question: QUESTION_SET.AUTHORISED_BY,
       oldValue: report.form.incidentDetails.authorisedBy,
       newValue: valuesFromRequestBody.authorisedBy,
       hasChanged: hasValueChanged(report.form.incidentDetails.authorisedBy, valuesFromRequestBody.authorisedBy),
     },
     witnesses: {
+      question: QUESTION_SET.WITNESSES,
       oldValue: witnessesOldValue,
       newValue: witnessesNewValue,
       hasChanged: !R.equals(witnessesOldValue, witnessesNewValue),
     },
   }
-}
-
-export const compareReportDetailsEditWithReport = () => {
-  return 0
 }

--- a/server/services/editReports/types/reportEditServiceTypes.ts
+++ b/server/services/editReports/types/reportEditServiceTypes.ts
@@ -1,9 +1,12 @@
+export type Change = { oldValue: unknown; newValue: unknown; question: string }
+
 export type PersistData = {
   reportId: string
   pageInput: unknown
   reportSection: { section: string }
-  changes: unknown
+  changes: Change[]
   reason: string
   reasonText: string
   reasonAdditionalInfo: string
+  reportOwnerChanged?: boolean
 }

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -25,6 +25,7 @@ import { notificationServiceFactory } from './notificationService'
 import { DraftInvolvedStaffService } from './drafts/draftInvolvedStaffService'
 import FeComponentsService from './feComponentsService'
 import AuthService from './authService'
+import EditIncidentDetailsService from './editIncidentDetailsService'
 
 export const services = () => {
   const {
@@ -116,7 +117,14 @@ export const services = () => {
   )
   const feComponentsService = new FeComponentsService(feComponentsClient)
 
-  const reportEditService = new ReportEditService(locationService, authService, reportService)
+  const editIncidentDetailsService = new EditIncidentDetailsService(locationService, authService)
+
+  const reportEditService = new ReportEditService(
+    reportService,
+    editIncidentDetailsService,
+    locationService,
+    authService
+  )
 
   return {
     involvedStaffService,
@@ -133,6 +141,7 @@ export const services = () => {
     draftReportService,
     feComponentsService,
     authService,
+    editIncidentDetailsService,
     reportEditService,
   }
 }

--- a/server/services/reportEditService.test.ts
+++ b/server/services/reportEditService.test.ts
@@ -1,13 +1,18 @@
+import moment from 'moment'
 import ReportEditService from './reportEditService'
 import LocationService from './locationService'
 import AuthService from './authService'
 import ReportService from './reportService'
+import EditIncidentDetailsService from './editIncidentDetailsService'
+import questionSets from '../config/edit/questionSets'
 
 jest.mock('./authService')
 jest.mock('./locationService')
 const locationService = new LocationService(null, null) as jest.Mocked<LocationService>
 const authService = new AuthService(null) as jest.Mocked<AuthService>
 const reportService = new ReportService(null, null, null, null, null, null) as jest.Mocked<ReportService>
+const editIncidentDetailsService = new EditIncidentDetailsService(null, null) as jest.Mocked<EditIncidentDetailsService>
+
 locationService.getLocation = jest.fn()
 locationService.getPrisonById = jest.fn()
 
@@ -15,137 +20,125 @@ let reportEditService
 
 beforeEach(() => {
   authService.getSystemClientToken.mockResolvedValue(`system-token-1`)
-  reportEditService = new ReportEditService(locationService, authService, reportService)
+  reportEditService = new ReportEditService(reportService, editIncidentDetailsService, locationService, authService)
 })
 
 describe('constructChangesToView', () => {
-  it('constructs response correctly when planned use of force, incident date and witneeses have changed', async () => {
+  editIncidentDetailsService.buildIncidentDetails = jest.fn()
+  it('call upstream services with correct args', async () => {
     const reportSection = {
       text: 'the incident details',
       section: 'incidentDetails',
     }
-    const changes = {
-      plannedUseOfForce: {
-        oldValue: true,
-        newValue: 'false',
-        hasChanged: true,
-      },
-      incidentDate: {
-        oldValue: '2020-03-02T13:00:00.000Z',
-        newValue: '2020-03-05T14:17:00.000Z',
-        hasChanged: true,
-      },
-      witnesses: {
-        oldValue: [],
-        newValue: [
-          {
-            name: 'someone else',
-          },
-          {
-            name: 'tom',
-          },
-        ],
-        hasChanged: true,
-      },
-    }
-
-    const result = await reportEditService.constructChangesToView('user-1', reportSection, changes)
-
-    expect(result).toEqual([
-      {
-        question: 'Was use of force planned',
-        oldValue: true,
-        newValue: 'false',
-      },
-      {
-        question: 'Incident date',
-        oldValue: '02/03/2020 13:00',
-        newValue: '05/03/2020 14:17',
-      },
-      {
-        question: 'Witnesses to the incident',
-        oldValue: '',
-        newValue: 'someone else, tom',
-      },
-    ])
-  })
-
-  it('handles scenario where witnesses changed from some to none', async () => {
-    const reportSection = {
-      text: 'the incident details',
-      section: 'incidentDetails',
-    }
-    const changes = {
-      witnesses: {
-        oldValue: [
-          {
-            name: 'tom',
-          },
-          {
-            name: 'another person',
-          },
-        ],
-        newValue: [],
-        hasChanged: true,
-      },
-    }
-
-    const result = await reportEditService.constructChangesToView('user-1', reportSection, changes)
-
-    expect(result).toEqual([
-      {
-        question: 'Witnesses to the incident',
-        oldValue: 'tom, another person',
-        newValue: '',
-      },
-    ])
-  })
-
-  it('calls upstream services with correct args', async () => {
-    const reportSection = {
-      text: 'the incident details',
-      section: 'incidentDetails',
-    }
-    const changes = {
-      incidentLocation: {
-        oldValue: 'UUID-111',
-        newValue: 'UUID-222',
-        hasChanged: true,
-      },
-      agencyId: {
-        oldValue: 'WRI',
-        newValue: 'AYI',
-        hasChanged: true,
-      },
-    }
-
-    locationService.getPrisonById.mockResolvedValueOnce({
-      agencyId: 'WRI',
-      description: 'Whitemoor (HMP)',
-      agencyType: 'INST',
-      active: true,
-    })
-
-    locationService.getPrisonById.mockResolvedValueOnce({
-      agencyId: 'AYI',
-      description: 'Aylesbury (HMP)',
-      agencyType: 'INST',
-      active: true,
-    })
-
-    locationService.getLocation.mockResolvedValueOnce('A Wing Exercise')
-    locationService.getLocation.mockResolvedValueOnce('Gym')
+    const changes = {}
 
     await reportEditService.constructChangesToView('user-1', reportSection, changes)
 
-    expect(locationService.getPrisonById).toHaveBeenCalledWith('system-token-1', 'WRI')
-    expect(locationService.getPrisonById).toHaveBeenCalledWith('system-token-1', 'AYI')
-
-    expect(locationService.getLocation).toHaveBeenCalledWith('system-token-1', 'UUID-111')
-    expect(locationService.getLocation).toHaveBeenCalledWith('system-token-1', 'UUID-222')
+    expect(editIncidentDetailsService.buildIncidentDetails).toHaveBeenCalledWith(
+      'user-1',
+      questionSets.incidentDetails,
+      changes
+    )
   })
 })
 
+describe('compareEditsWithReport', () => {
+  it('returns the correct result', () => {
+    const reportSection = 'incidentDetails'
+    const report = {
+      id: 1,
+      incidentDate: new Date('2020-03-02T14:17:00Z'),
+      agencyId: 'WRI',
+      form: {
+        incidentDetails: {
+          locationId: 12345,
+          plannedUseOfForce: false,
+          incidentLocationId: '12345-ABC',
+        },
+      },
+    }
+    const valuesToCompareWithReport = {
+      incidentDate: new Date('2020-03-02T14:17:00Z'),
+      newAgencyId: 'MDI',
+      incidentLocationId: '56789-ABC',
+      plannedUseOfForce: 'true',
+      authorisedBy: 'Joe bloggs',
+      witnesses: [
+        {
+          name: 'Tom Smith',
+        },
+      ],
+    }
+
+    const actualResult = reportEditService.compareEditsWithReport({
+      report,
+      valuesToCompareWithReport,
+      reportSection,
+    })
+
+    const expectedResult = {
+      agencyId: {
+        hasChanged: true,
+        newValue: 'MDI',
+        oldValue: 'WRI',
+        question: 'Prison',
+      },
+      authorisedBy: {
+        hasChanged: true,
+        newValue: 'Joe bloggs',
+        oldValue: undefined,
+        question: 'Who authorised use of force',
+      },
+      incidentDate: {
+        hasChanged: false,
+        newValue: new Date('2020-03-02T14:17:00Z'),
+        oldValue: new Date('2020-03-02T14:17:00Z'),
+        question: 'Incident date',
+      },
+      incidentLocation: {
+        hasChanged: true,
+        newValue: '56789-ABC',
+        oldValue: '12345-ABC',
+        question: 'Incident location',
+      },
+      plannedUseOfForce: {
+        hasChanged: true,
+        newValue: 'true',
+        oldValue: false,
+        question: 'Was use of force planned',
+      },
+      witnesses: {
+        hasChanged: true,
+        newValue: [
+          {
+            name: 'Tom Smith',
+          },
+        ],
+        oldValue: undefined,
+        question: 'Witnesses to the incident',
+      },
+    }
+    expect(actualResult).toEqual(expectedResult)
+  })
+})
+
+describe('removeHasChangedKey', () => {
+  it('should remove the hasChanged key', () => {
+    const input = {
+      agencyId: { newValue: 'BCI', oldValue: 'WRI', hasChanged: true },
+      witnesses: { newValue: [{ name: 'jimmy' }], hasChanged: true },
+      incidentDate: { newValue: '2020-03-10', oldValue: '2020-03-23', hasChanged: true },
+    }
+
+    const output = {
+      agencyId: { newValue: 'BCI', oldValue: 'WRI' },
+      witnesses: { newValue: [{ name: 'jimmy' }] },
+      incidentDate: { newValue: '2020-03-10', oldValue: '2020-03-23' },
+    }
+
+    expect(reportEditService.removeHasChangedKey(input)).toEqual(output)
+  })
+})
 describe('validateReasonForChangeInput', () => {
   it('Should return error when no reason provided', () => {
     const input = { reportSection: { text: 'the incident details' } }
@@ -177,5 +170,127 @@ describe('validateReasonForChangeInput', () => {
     }
     const result = reportEditService.validateReasonForChangeInput(input)
     expect(result).toEqual([])
+  })
+})
+
+describe('reorderKeysInChangesArrayWithinEditsToSpecificSequence', () => {
+  it('should order the response object key-value pairs correctly', () => {
+    const incidentDate = moment('2025-07-28 10:37:00')
+    const now = moment()
+    const reportEditData = [
+      {
+        id: 1,
+        edit_date: now,
+        editor_user_id: 'USER-1',
+        editor_name: 'Joe Bloggs',
+        report_id: 1,
+        reason: 'errorInReport',
+        additional_comments: '',
+        report_owner_changed: false,
+        changes: [
+          {
+            witnesses: {
+              newValue: [{ name: 'jimmy' }, { name: 'another person' }, { name: 'tom' }],
+              oldValue: [{ name: 'jimmy' }, { name: 'another person' }],
+              question: 'Witnesses to the incident',
+            },
+            authorisedBy: { newValue: 'Joe Bloggs', question: 'Who authorised use of force' },
+            incidentDate: {
+              newValue: incidentDate,
+              oldValue: incidentDate,
+              question: 'Incident date',
+            },
+            incidentLocation: {
+              newValue: 'UUID-1',
+              oldValue: 'UUID-2',
+              question: 'Incident location',
+            },
+            plannedUseOfForce: { newValue: true, oldValue: false, question: 'Was use of force planned' },
+          },
+        ],
+        reason_text: '',
+      },
+    ]
+
+    const expectedOrderOfKeysInChangesObj = [
+      'incidentDate',
+      'incidentLocation',
+      'plannedUseOfForce',
+      'authorisedBy',
+      'witnesses',
+    ]
+
+    const response = reportEditService.reorderKeysInChangesArrayWithinEditsToSpecificSequence(reportEditData)
+    const actualOderOfKeysinChangesObj = Object.keys(response[0].changes[0])
+    expect(actualOderOfKeysinChangesObj).toEqual(expectedOrderOfKeysInChangesObj)
+  })
+})
+
+describe('applyCorrectFormat', () => {
+  it('should return the correct format of incident date', async () => {
+    const key = 'incidentDate'
+    const val = moment('2025-07-27 14:30', 'YYYY-MM-DD HH:mm')
+    const result = await reportEditService.applyCorrectFormat(key, val, 'user-1')
+    expect(result).toEqual('27/07/2025 14:30')
+  })
+
+  it('should return prison name', async () => {
+    locationService.getPrisonById.mockResolvedValue({
+      agencyId: 'LEI',
+      description: 'HMP Leicester',
+      active: true,
+      agencyType: 'HMP',
+    })
+
+    const key = 'agencyId'
+    const val = 'LEI'
+    const result = await reportEditService.applyCorrectFormat(key, val, 'user-1')
+    expect(result).toEqual('HMP Leicester')
+  })
+
+  it('should return location name', async () => {
+    locationService.getLocation.mockResolvedValue('Cell-1')
+
+    const key = 'incidentLocation'
+    const val = 'UUID-1'
+    const result = await reportEditService.applyCorrectFormat(key, val, 'user-1')
+    expect(result).toEqual('Cell-1')
+  })
+
+  it('should return location name', async () => {
+    locationService.getLocation.mockResolvedValue('Cell-1')
+
+    const key = 'incidentLocation'
+    const val = 'UUID-1'
+    const result = await reportEditService.applyCorrectFormat(key, val, 'user-1')
+    expect(result).toEqual('Cell-1')
+  })
+
+  it('should return authorisedby without modification', async () => {
+    const key = 'authorisedBy'
+    const val = 'Harry'
+    const result = await reportEditService.applyCorrectFormat(key, val, 'user-1')
+    expect(result).toEqual('Harry')
+  })
+
+  it('should convert boolean to Yes', async () => {
+    const key = 'plannedUseOfForce'
+    const val = true
+    const result = await reportEditService.applyCorrectFormat(key, val, 'user-1')
+    expect(result).toEqual('Yes')
+  })
+
+  it('should return witnesses array as a single string', async () => {
+    const key = 'witnesses'
+    const val = [
+      {
+        name: 'jimmy',
+      },
+      {
+        name: 'tom',
+      },
+    ]
+    const result = await reportEditService.applyCorrectFormat(key, val, 'user-1')
+    expect(result).toEqual('jimmy, tom')
   })
 })

--- a/server/utils/getIncidentDate.ts
+++ b/server/utils/getIncidentDate.ts
@@ -1,6 +1,7 @@
 import moment from 'moment'
+import { DateTime } from '../config/edit/incidentDetailsConfig'
 
-export default function getIncidentDate(savedValue: Date, userProvidedValue) {
+export default function getIncidentDate(savedValue: Date, userProvidedValue): DateTime | null {
   if (userProvidedValue) {
     const {
       date,

--- a/server/utils/nunjucksSetup.test.ts
+++ b/server/utils/nunjucksSetup.test.ts
@@ -50,9 +50,9 @@ describe('nunjucksSetup', () => {
   })
 
   describe('toYesNoIfTrueFalse', () => {
-    it('returns dash (-) for no value', () => {
+    it('returns undefined nothing for no value', () => {
       const result = njk.getFilter('toYesNoIfTrueFalse')()
-      expect(result).toEqual('\u2013')
+      expect(result).toEqual(undefined)
     })
     it('returns yes for string true', () => {
       const result = njk.getFilter('toYesNoIfTrueFalse')('true')

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -89,6 +89,14 @@ export default function configureNunjucks(app: Express.Application): nunjucks.En
     return value ? moment(value).format(format) : null
   })
 
+  njkEnv.addFilter('extractDate', value => {
+    return value ? moment(value).format('DD/MM/YYYY') : null
+  })
+
+  njkEnv.addFilter('extractTime', value => {
+    return value ? moment(value).format('HH:mm') : null
+  })
+
   njkEnv.addFilter('toSelect', (array, valueKey, textKey, value) => {
     const emptyOption = {
       value: '',
@@ -211,7 +219,6 @@ export default function configureNunjucks(app: Express.Application): nunjucks.En
   })
 
   njkEnv.addFilter('toYesNoIfTrueFalse', value => {
-    if (value == null) return '\u2013'
     if (value === 'true' || value === true) return 'Yes'
     if (value === 'false' || value === false) return 'No'
     return value

--- a/server/views/pages/viewIncident/edit-history.njk
+++ b/server/views/pages/viewIncident/edit-history.njk
@@ -1,3 +1,90 @@
-<h1 class="govuk-heading-xl">Use of force incident {{ data.incidentId }}</h1>
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+
+{% block content %}
+<div class="govuk-grid-column-full">
+  <div class = 'govuk-!-display-none-print'>
+    <div class="flex-container-space-between">
+      <h1 class="govuk-heading-xl govuk-!-margin-bottom-4 govuk-!-margin-top-4">Use of force incident {{ data.incidentId }} </h1>
+
+      {% if data.isCoordinator %}
+        <div class="govuk-button-group govuk-!-margin-top-6">
+            {{ govukButton({
+              text: "Edit report",
+              href: "edit-report",
+              attributes: {'data-qa':'button-edit-report'}
+            }) }}
+
+            {{ govukButton({
+              classes: "govuk-button--warning",
+              text: "Delete incident",
+              href: "delete-incident",
+              attributes: {'data-qa':'button-delete-incident'}
+            }) }}
+        </div>
+      {% endif %}
+    </div>
 
   {{ navigationTabMacro.navigation(data, {editHistory:true}) }}
+</div>
+<div class="govuk-grid-column-full">
+
+<div class="govuk-grid-row govuk-body negative-margin-top-7">
+  <table class="govuk-table edit-history-table">
+    <caption class="govuk-table__caption govuk-table__caption--m">Edit history</caption>
+
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header edit-history-table-width-8">Date</th>
+        <th scope="col" class="govuk-table__header edit-history-table-width-8">Time</th>
+        <th scope="col" class="govuk-table__header edit-history-table-width-8">Changed by</th>
+        <th scope="col" class="govuk-table__header edit-history-table-width-12">What changed</th>
+        <th scope="col" class="govuk-table__header ">Changed from</th>
+        <th scope="col" class="govuk-table__header ">Changed to</th>
+        <th scope="col" class="govuk-table__header">Reason for change</th>
+      </tr>
+    </thead>
+    {% for item in data.reportEditViewData %}
+      <tbody class="govuk-table__body border-bottom-grey">
+        <tr class="govuk-table__row">
+          <td class="govuk-table__cell edit-history-table-width-8">{{item.editDate | extractDate}}</td>
+          <td class="govuk-table__cell edit-history-table-width-8">{{item.editDate | extractTime}}</td>
+          <td class="govuk-table__cell edit-history-table-width-8">{{item.editorName}}</td>
+          <td class="govuk-table__cell edit-history-table-width-12">{{item.whatChanged[0]}}</td>
+          <td class="govuk-table__cell">{{item.changedFrom[0]}}</td>
+          <td class="govuk-table__cell">{{item.changedTo[0]}}</td>
+          <td class="govuk-table__cell">{{item.reason}}</td>
+        </tr>
+        {% set len = item.whatChanged.length %}
+        {% for i in range(1, len) %}
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell"></td>
+            <td class="govuk-table__cell"></td>
+            <td class="govuk-table__cell"></td>
+            <td class="govuk-table__cell">{{item.whatChanged[i]}}</td>
+            <td class="govuk-table__cell">{{item.changedFrom[i]}}</td>
+            <td class="govuk-table__cell">{{item.changedTo[i]}}</td>
+            <td class="govuk-table__cell"></td>        
+          </tr>
+        {% endfor %}
+          <tr>
+            <td colspan="6"></td>
+            <td>
+              <!-- If additional comments added -->
+              {% if item.additionalComments %}
+                {% set additionalComponentHtml %}
+                  {{ item.additionalComments }}
+                {% endset %}
+                {{ govukDetails({
+                  summaryText: "Additional comments",
+                  classes: "govuk-!-margin-top-2",
+                  html: additionalComponentHtml
+                }) }}
+              {% endif %}
+            </td>
+          </tr>
+      </tbody>
+    {% endfor %}
+  </table>
+</div>
+{% endblock %}


### PR DESCRIPTION
This PR is to enable edits to the incident-details page
Have added a DB migration so that changes will now be stored in a jsonb blob rather than individual columns (old_value_primary, old_value_secondary etc)
Use of the bob follows the pattern in the actual original report