### PR TITLE
MAP-2646 - Update pagination for single page of results

### DIFF
--- a/assets/sass/components/_pagination.scss
+++ b/assets/sass/components/_pagination.scss
@@ -83,7 +83,7 @@
 
 // Displays only the 'Showing x to x of x results section of the pagination if only 1 page of results
 // Ensures the content is displayed on the right hand side of its parent container
-.displayPageCountOnly {
+.displayResultsCountOnly {
   .moj-pagination__list {
     display: none;
   }

--- a/assets/sass/components/_pagination.scss
+++ b/assets/sass/components/_pagination.scss
@@ -81,7 +81,7 @@
     }
 }
 
-// Displays only the 'Showing x to x of x results section of the pagination if only 1 page of results
+// Displays only the 'Showing x to x of x results' section of the pagination if only 1 page of results
 // Ensures the content is displayed on the right hand side of its parent container
 .displayResultsCountOnly {
   .moj-pagination__list {

--- a/assets/sass/components/_pagination.scss
+++ b/assets/sass/components/_pagination.scss
@@ -80,3 +80,22 @@
         padding: 10px 15px;
     }
 }
+
+// Displays only the 'Showing x to x of x results section of the pagination if only 1 page of results
+// Ensures the content is displayed on the right hand side of its parent container
+.displayPageCountOnly {
+  .moj-pagination__list {
+    display: none;
+  }
+
+  .moj-pagination__results {
+    margin-left: auto;
+    display: block; 
+    text-align: right; 
+  }
+
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+}
+

--- a/integration-tests/integration/statements/view-your-statements.cy.js
+++ b/integration-tests/integration/statements/view-your-statements.cy.js
@@ -82,7 +82,7 @@ context('A user views their statements list', () => {
 
     const yourStatementsPage = YourStatementsPage.goTo()
     yourStatementsPage.selectedTab().contains('Your statements')
-    yourStatementsPage.pagination().should('not.exist')
+    yourStatementsPage.pagination().should('exist')
 
     {
       const { date, prisoner, overdue, removalRequested, action } = yourStatementsPage.statements(0)

--- a/server/views/pages/completed-incidents.html
+++ b/server/views/pages/completed-incidents.html
@@ -7,7 +7,11 @@
 <section class="govuk-tabs__panel">
   {% include "../partials/incidentSearchPanel.html" %}
 
-  {% if pageData.totalPages > 1 %}
+  {% if pageData.totalPages == 1 %}
+    <div class="displayPageCountOnly">
+      {{ mojPagination( pageData | toPagination(rawQuery) ) }}
+    </div>
+  {% elif pageData.totalPages > 1 %}
     {{ mojPagination( pageData | toPagination(rawQuery) ) }}
   {% endif %} 
 

--- a/server/views/pages/completed-incidents.html
+++ b/server/views/pages/completed-incidents.html
@@ -8,7 +8,7 @@
   {% include "../partials/incidentSearchPanel.html" %}
 
   {% if pageData.totalPages == 1 %}
-    <div class="displayPageCountOnly">
+    <div class="displayResultsCountOnly">
       {{ mojPagination( pageData | toPagination(rawQuery) ) }}
     </div>
   {% elif pageData.totalPages > 1 %}

--- a/server/views/pages/not-completed-incidents.html
+++ b/server/views/pages/not-completed-incidents.html
@@ -9,7 +9,7 @@
 {% block tabContent %}
 <section class="govuk-tabs__panel">
   {% if pageData.totalPages == 1 %}
-    <div class="displayPageCountOnly">
+    <div class="displayResultsCountOnly">
       {{ mojPagination( pageData | toPagination(rawQuery) ) }}
     </div>
   {% elif pageData.totalPages > 1 %}

--- a/server/views/pages/not-completed-incidents.html
+++ b/server/views/pages/not-completed-incidents.html
@@ -8,7 +8,11 @@
 
 {% block tabContent %}
 <section class="govuk-tabs__panel">
-  {% if pageData.totalPages > 1 %}
+  {% if pageData.totalPages == 1 %}
+    <div class="displayPageCountOnly">
+      {{ mojPagination( pageData | toPagination(rawQuery) ) }}
+    </div>
+  {% elif pageData.totalPages > 1 %}
     {{ mojPagination( pageData | toPagination(rawQuery) ) }}
   {% endif %} 
 

--- a/server/views/pages/your-reports.html
+++ b/server/views/pages/your-reports.html
@@ -7,7 +7,7 @@
 <section class="govuk-tabs__panel">
 
   {% if pageData.totalPages == 1 %}
-    <div class="displayPageCountOnly">
+    <div class="displayResultsCountOnly">
       {{ mojPagination( pageData | toPagination(rawQuery) ) }}
     </div>
   {% elif pageData.totalPages > 1 %}

--- a/server/views/pages/your-reports.html
+++ b/server/views/pages/your-reports.html
@@ -6,7 +6,11 @@
 {% block tabContent %}
 <section class="govuk-tabs__panel">
 
-  {% if pageData.totalPages > 1 %}
+  {% if pageData.totalPages == 1 %}
+    <div class="displayPageCountOnly">
+      {{ mojPagination( pageData | toPagination(rawQuery) ) }}
+    </div>
+  {% elif pageData.totalPages > 1 %}
     {{ mojPagination( pageData | toPagination ) }}
   {% endif %} 
   

--- a/server/views/pages/your-statements.html
+++ b/server/views/pages/your-statements.html
@@ -8,7 +8,7 @@
 <section class="govuk-tabs__panel">
 
 {% if pageData.totalPages == 1 %}
-  <div class="displayPageCountOnly">
+  <div class="displayResultsCountOnly">
     {{ mojPagination( pageData | toPagination(rawQuery) ) }}
   </div>
 {% elif pageData.totalPages > 1 %}

--- a/server/views/pages/your-statements.html
+++ b/server/views/pages/your-statements.html
@@ -7,7 +7,11 @@
 {% block tabContent %}
 <section class="govuk-tabs__panel">
 
-{% if pageData.totalPages > 1 %}
+{% if pageData.totalPages == 1 %}
+  <div class="displayPageCountOnly">
+    {{ mojPagination( pageData | toPagination(rawQuery) ) }}
+  </div>
+{% elif pageData.totalPages > 1 %}
   {{ mojPagination( pageData | toPagination ) }}
 {% endif %} 
   


### PR DESCRIPTION
Small update to display only the 'Showing x to x of x results' part of the pagination component when there is only 1 page of results. 

- Added new style to hide the additional unneeded part of the pagination component in this case
- Updated the appropriate views
- Updated integration test