### PR TITLE
MAP-2798 handle report edits where reasonsForUseOfForce does not exist

### DIFF
--- a/server/routes/maintainingReports/coordinator.test.ts
+++ b/server/routes/maintainingReports/coordinator.test.ts
@@ -511,6 +511,28 @@ describe('coordinator', () => {
         })
     })
 
+    it('should render page even if no reasonsForUseOfForce exist (old reports)', async () => {
+      basicPersistedReport.form.reasonsForUseOfForce = undefined
+      await request(app)
+        .get('/1/edit-report/why-was-uof-applied')
+        .expect(200)
+        .expect('Content-Type', 'text/html; charset=utf-8')
+        .expect(res => {
+          expect(res.text).toContain('Back')
+          expect(res.text).toContain('Status')
+          expect(res.text).toContain('Why was use of force applied against this prisoner')
+          expect(res.text).toContain('Continue')
+          expect(res.text).toContain('Cancel')
+          expect(res.text).toContain('/1/edit-report')
+          expect(res.text).not.toContain('Save and return to report use of force')
+          expect(res.text).not.toContain('check-your-answers')
+          expect(res.text).not.toContain('Print report and statements')
+          expect(reviewService.getReport).toHaveBeenCalledWith(1)
+          expect(flash).toHaveBeenCalledWith('errors')
+          expect(offenderService.getOffenderDetails).toHaveBeenCalledWith(123456, 'user1')
+        })
+    })
+
     it('should render error messages when no data submitted', async () => {
       flash.mockReturnValueOnce([
         {
@@ -566,6 +588,28 @@ describe('coordinator', () => {
 
   describe('viewEditPrimaryReasonForUof', () => {
     it('should render page', async () => {
+      await request(app)
+        .get('/1/edit-report/what-was-the-primary-reason-of-uof')
+        .expect(200)
+        .expect('Content-Type', 'text/html; charset=utf-8')
+        .expect(res => {
+          expect(res.text).toContain('Back')
+          expect(res.text).toContain('Status')
+          expect(res.text).toContain('primary reason use of force was applied against this prisoner')
+          expect(res.text).toContain('Continue')
+          expect(res.text).toContain('Cancel')
+          expect(res.text).toContain('/1/edit-report')
+          expect(res.text).not.toContain('Save and return to report use of force')
+          expect(res.text).not.toContain('check-your-answers')
+          expect(res.text).not.toContain('Print report and statements')
+          expect(reviewService.getReport).toHaveBeenCalledWith(1)
+          expect(flash).toHaveBeenCalledWith('errors')
+          expect(offenderService.getOffenderDetails).toHaveBeenCalledWith(123456, 'user1')
+        })
+    })
+
+    it('should render page even if no reasonsForUseOfForce exist (old reports)', async () => {
+      basicPersistedReport.form.reasonsForUseOfForce = undefined
       await request(app)
         .get('/1/edit-report/what-was-the-primary-reason-of-uof')
         .expect(200)

--- a/server/routes/maintainingReports/coordinator.ts
+++ b/server/routes/maintainingReports/coordinator.ts
@@ -239,7 +239,7 @@ export default class CoordinatorRoutes {
     const { reportId } = req.params
     const report = await this.reviewService.getReport(parseInt(reportId, 10))
     const offenderDetail = await this.offenderService.getOffenderDetails(report.bookingId, res.locals.user.username)
-    const input = report.form.reasonsForUseOfForce.reasons
+    const input = report.form.reasonsForUseOfForce?.reasons || []
 
     const data = {
       UofReasons,
@@ -306,7 +306,7 @@ export default class CoordinatorRoutes {
     const primaryReason = req.flash('primaryReason')[0]
 
     const data = {
-      primaryReason: report.form.reasonsForUseOfForce.primaryReason,
+      primaryReason: report.form.reasonsForUseOfForce?.primaryReason || '',
       reasons: Object.values(UofReasons).filter(({ value }) => whyWasUOFAppliedReasons.includes(value)),
       offenderDetail,
       reportId,

--- a/server/services/editReports/reasonsForUseOfForce.test.ts
+++ b/server/services/editReports/reasonsForUseOfForce.test.ts
@@ -1,0 +1,101 @@
+import reasonsForUseOfForce from './reasonsForUseOfForce'
+
+describe('reasonsForUseOfForce', () => {
+  const baseReport = {
+    form: {
+      reasonsForUseOfForce: {
+        reasons: ['FIGHT_BETWEEN_PRISONERS'],
+      },
+    },
+  }
+
+  it('should return no changes when values match', () => {
+    const valuesFromRequestBody = {
+      reasons: ['FIGHT_BETWEEN_PRISONERS'],
+      primaryReason: undefined,
+    }
+
+    expect(reasonsForUseOfForce(baseReport, valuesFromRequestBody)).toEqual({
+      reasons: {
+        question: 'Why was use of force applied against this prisoner?',
+        oldValue: ['FIGHT_BETWEEN_PRISONERS'],
+        newValue: ['FIGHT_BETWEEN_PRISONERS'],
+        hasChanged: false,
+      },
+      primaryReason: {
+        question: 'What was the primary reason use of force was applied against this prisoner?',
+        oldValue: undefined,
+        newValue: undefined,
+        hasChanged: false,
+      },
+    })
+  })
+
+  it('should detect change in reasons', () => {
+    const valuesFromRequestBody = {
+      reasons: ['FIGHT_BETWEEN_PRISONERS', 'TO_PREVENT_ESCAPE_OR_ABSCONDING'],
+      primaryReason: undefined,
+    }
+
+    expect(reasonsForUseOfForce(baseReport, valuesFromRequestBody)).toEqual({
+      reasons: {
+        question: 'Why was use of force applied against this prisoner?',
+        oldValue: ['FIGHT_BETWEEN_PRISONERS'],
+        newValue: ['FIGHT_BETWEEN_PRISONERS', 'TO_PREVENT_ESCAPE_OR_ABSCONDING'],
+        hasChanged: true,
+      },
+      primaryReason: {
+        question: 'What was the primary reason use of force was applied against this prisoner?',
+        oldValue: undefined,
+        newValue: undefined,
+        hasChanged: false,
+      },
+    })
+  })
+
+  it('should detect change in primaryReason', () => {
+    const valuesFromRequestBody = {
+      reasons: ['FIGHT_BETWEEN_PRISONERS', 'TO_PREVENT_ESCAPE_OR_ABSCONDING'],
+      primaryReason: 'TO_PREVENT_ESCAPE_OR_ABSCONDING',
+    }
+
+    expect(reasonsForUseOfForce(baseReport, valuesFromRequestBody)).toEqual({
+      reasons: {
+        question: 'Why was use of force applied against this prisoner?',
+        oldValue: ['FIGHT_BETWEEN_PRISONERS'],
+        newValue: ['FIGHT_BETWEEN_PRISONERS', 'TO_PREVENT_ESCAPE_OR_ABSCONDING'],
+        hasChanged: true,
+      },
+      primaryReason: {
+        question: 'What was the primary reason use of force was applied against this prisoner?',
+        oldValue: undefined,
+        newValue: 'TO_PREVENT_ESCAPE_OR_ABSCONDING',
+        hasChanged: true,
+      },
+    })
+  })
+
+  it('should handle missing reasonsForUseOfForce in report', () => {
+    const reportWithoutReasons = { form: {} }
+
+    const valuesFromRequestBody = {
+      reasons: ['TO_PREVENT_ESCAPE_OR_ABSCONDING'],
+      primaryReason: undefined,
+    }
+
+    expect(reasonsForUseOfForce(reportWithoutReasons, valuesFromRequestBody)).toEqual({
+      reasons: {
+        question: 'Why was use of force applied against this prisoner?',
+        oldValue: undefined,
+        newValue: ['TO_PREVENT_ESCAPE_OR_ABSCONDING'],
+        hasChanged: true,
+      },
+      primaryReason: {
+        question: 'What was the primary reason use of force was applied against this prisoner?',
+        oldValue: undefined,
+        newValue: undefined,
+        hasChanged: false,
+      },
+    })
+  })
+})

--- a/server/services/editReports/reasonsForUseOfForce.ts
+++ b/server/services/editReports/reasonsForUseOfForce.ts
@@ -5,15 +5,15 @@ export default (report, valuesFromRequestBody) => {
   return {
     reasons: {
       question: QUESTION_SET.REASONS,
-      oldValue: report.form.reasonsForUseOfForce.reasons,
+      oldValue: report.form.reasonsForUseOfForce?.reasons,
       newValue: valuesFromRequestBody.reasons,
-      hasChanged: !R.equals(report.form.reasonsForUseOfForce.reasons, valuesFromRequestBody.reasons),
+      hasChanged: !R.equals(report.form.reasonsForUseOfForce?.reasons, valuesFromRequestBody.reasons),
     },
     primaryReason: {
       question: QUESTION_SET.PRIMARY_REASON,
-      oldValue: report.form.reasonsForUseOfForce.primaryReason,
+      oldValue: report.form.reasonsForUseOfForce?.primaryReason,
       newValue: valuesFromRequestBody.primaryReason,
-      hasChanged: !R.equals(report.form.reasonsForUseOfForce.primaryReason, valuesFromRequestBody.primaryReason),
+      hasChanged: !R.equals(report.form.reasonsForUseOfForce?.primaryReason, valuesFromRequestBody.primaryReason),
     },
   }
 }


### PR DESCRIPTION
Some old reports don't have reasonsForUseOfForce in their dataset. 
This code is to prevent an application crash for those reports by checking whether the data exists before trying to access the reasons value
see `report.form.reasonsForUseOfForce?.reasons || []` and `report.form.reasonsForUseOfForce?.primaryReason || ''`


