### PR TITLE
MAP-2798 fix backlinks and temp edit storage

### DIFF
--- a/integration-tests/pages/coordinator/primaryReasonForUseOfForcePage.js
+++ b/integration-tests/pages/coordinator/primaryReasonForUseOfForcePage.js
@@ -9,6 +9,7 @@ const editPrimaryReasonPage = () =>
       checkReason: value => cy.get('#uof-primary-reasons [type="radio"]').check(value),
       clickContinue: () => cy.get('[data-qa="continue-coordinator-edit"]').click(),
       clickCancel: () => cy.get('[data-qa="cancel"]').click(),
+      clickBack: () => cy.get('[data-qa="back-link"]').click(),
       errorSummaryTitle: () => cy.get('.govuk-error-summary__title'),
       errorSummaryText: () => cy.get('.govuk-error-summary__list'),
     }

--- a/integration-tests/pages/coordinator/useOfForceDetailsPage.js
+++ b/integration-tests/pages/coordinator/useOfForceDetailsPage.js
@@ -4,7 +4,9 @@ const useOfForceDetailsPage = () =>
   page('Use of force details', {
     continueButton: () => cy.get('[data-qa="continue-coordinator-edit"]'),
     cancelLink: () => cy.get('[data-qa="cancel-coordinator-edit"]'),
+    clickBack: () => cy.get('[data-qa="back-link"]').click(),
     radio: (name, value) => cy.get(`input[name=${name}]`).check(value),
+    isCheckedRadio: (name, value) => cy.get(`input[name=${name}][value=${value}]`).should('be.checked'),
     checkBox: id => cy.get(`#${id}`),
   })
 

--- a/server/routes/maintainingReports/coordinator.test.ts
+++ b/server/routes/maintainingReports/coordinator.test.ts
@@ -534,6 +534,7 @@ describe('coordinator', () => {
     })
 
     it('should render error messages when no data submitted', async () => {
+      flash.mockReturnValueOnce([])
       flash.mockReturnValueOnce([
         {
           text: 'Select the reasons why use of force was applied',
@@ -1203,6 +1204,8 @@ describe('coordinator', () => {
   describe('viewReasonForChange', () => {
     it('should render page', async () => {
       flash.mockReturnValueOnce([])
+      flash.mockReturnValueOnce([])
+      flash.mockReturnValueOnce([])
       flash.mockReturnValueOnce([
         {
           text: 'the incident details',
@@ -1210,7 +1213,6 @@ describe('coordinator', () => {
         },
       ])
       flash.mockReturnValueOnce([{}])
-      flash.mockReturnValueOnce([])
       reportEditService.constructChangesToView.mockResolvedValue([])
       await request(app)
         .get('/1/edit-report/reason-for-change')
@@ -1283,6 +1285,8 @@ describe('coordinator', () => {
         })
     })
     it('should render correct error when no radio button is selected', async () => {
+      flash.mockReturnValueOnce([])
+      flash.mockReturnValueOnce([])
       flash.mockReturnValueOnce([
         {
           href: '#reason',
@@ -1310,6 +1314,8 @@ describe('coordinator', () => {
     })
 
     it('should render correct error when Another reason radio selected but no reason ext entered', async () => {
+      flash.mockReturnValueOnce([])
+      flash.mockReturnValueOnce([])
       flash.mockReturnValueOnce([
         {
           href: '#anotherReasonForEdit',
@@ -1339,6 +1345,8 @@ describe('coordinator', () => {
 
   describe('submitReasonForChange', () => {
     it('should render reason-for-change page', async () => {
+      flash.mockReturnValueOnce([])
+      flash.mockReturnValueOnce([])
       flash.mockReturnValueOnce([])
       flash.mockReturnValueOnce([
         {
@@ -1373,6 +1381,8 @@ describe('coordinator', () => {
     })
 
     it('should display the changes, replacing booleans with Yes or No', async () => {
+      flash.mockReturnValueOnce([])
+      flash.mockReturnValueOnce([])
       flash.mockReturnValueOnce([])
       flash.mockReturnValueOnce([
         {
@@ -1420,6 +1430,8 @@ describe('coordinator', () => {
     })
 
     it('should display correct error when no radio button is selected', async () => {
+      flash.mockReturnValueOnce([])
+      flash.mockReturnValueOnce([])
       flash.mockReturnValueOnce([
         {
           href: '#reason',
@@ -1448,6 +1460,8 @@ describe('coordinator', () => {
     })
 
     it("should display correct error when 'Another reason' radio selected but no text entered", async () => {
+      flash.mockReturnValueOnce(['1'])
+      flash.mockReturnValueOnce(['1'])
       flash.mockReturnValueOnce([
         {
           href: '#anotherReasonForEdit',

--- a/server/views/pages/coordinator/use-of-force-details.njk
+++ b/server/views/pages/coordinator/use-of-force-details.njk
@@ -1,5 +1,5 @@
 {% set showBacklink = true %}
-{% set backlinkHref = '/' + data.reportId + '/edit-report/why-was-uof-applied' %}
+{% set backlinkHref = data.backLinkHref %}
 {% block content %}
     {% include "../../formPages/incident/useOfForceDetails.html" %}
 {% endblock %}


### PR DESCRIPTION
This code corrects the back links so that user can navigate back from /reason-for-change to ` /why-was-uof-applied `, `/what-was-the-primary-reason-of-uof `and finally `/use-of-force-details`. 
On navigating back, the user should still see the changes they made in preceeding pages. 
On refreshing any page, the data presented will be that already saved in the report, not the edits. This allows them to ;reset' any page without needing to cancel out of the process. 