### PR TITLE
Fix high-severity tmp path traversal (GHSA-ph9p-34f9-6g65)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14294,9 +14294,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"

--- a/package.json
+++ b/package.json
@@ -202,6 +202,7 @@
     },
     "tar": ">=7.5.15",
     "brace-expansion": "5.0.6",
+    "tmp": "0.2.7",
     "mocha": {
       "serialize-javascript": "7.0.5"
     }


### PR DESCRIPTION
## What

Pins `tmp` to the patched **0.2.7** via npm `overrides`.

## Why

npm audit / Snyk flagged a **high** severity path traversal in `tmp` — [GHSA-ph9p-34f9-6g65](https://github.com/advisories/GHSA-ph9p-34f9-6g65) (unsanitized prefix/postfix enables directory escape). Affected range is `< 0.2.6`; the dependency was resolving transitively at **0.2.5**, so it was still vulnerable. This forces resolution to the patched **0.2.7**, following the existing convention in the repo's `overrides` block.

## Verification

- `npm install --package-lock-only` resolves a single `node_modules/tmp` at **0.2.7**.
- `npm audit` no longer reports tmp.