### PR TITLE
MAPB-460 move session deletion to different stage of edit journey

### DIFF
--- a/integration-tests/integration/coordinator/edit-report/use-of-force-details.cy.js
+++ b/integration-tests/integration/coordinator/edit-report/use-of-force-details.cy.js
@@ -507,4 +507,71 @@ context("A use of force coordinator needs to edit a submitted report's Use of Fo
     cy.go('back')
     ViewIncidentPage.verifyOnPage()
   })
+
+  it('does not lose session data if navigates to /view-incident part way through an edit', () => {
+    const notCompletedIncidentsPage = NotCompletedIncidentsPage.goTo()
+    notCompletedIncidentsPage.viewIncidentLink().click()
+
+    const viewIncidentPage = ViewIncidentPage.verifyOnPage()
+    viewIncidentPage.editReportButton().click()
+
+    const editReportPage = EditReportPage.verifyOnPage()
+    editReportPage.changeUofDetailsLink().click()
+
+    const reasonsPage = ReasonsForUseOfForcePage.verifyOnPage()
+    reasonsPage.reasons().then(reasons => {
+      expect(reasons).to.deep.equal(['FIGHT_BETWEEN_PRISONERS'])
+    })
+    reasonsPage.checkReason('ASSAULT_ON_A_MEMBER_OF_STAFF')
+    reasonsPage.clickContinue()
+
+    const primaryReasonPage = PrimaryReasonForUseOfForcePage.verifyOnPage()
+    primaryReasonPage.checkReason('ASSAULT_ON_A_MEMBER_OF_STAFF')
+    primaryReasonPage.clickContinue()
+
+    const useOfForceDetailsPage = UseOfForceDetailsPage.verifyOnPage()
+
+    // rather than submitting changes, user navigates to /view-incident again
+    cy.location('pathname').then(pathname => {
+      const reportId = pathname.split('/')[1]
+      cy.visit(`/${reportId}/view-incident`)
+    })
+
+    // then returns to the /use-of-force-details page to submit changes
+    cy.location('pathname').then(pathname => {
+      const reportId = pathname.split('/')[1]
+      cy.visit(`/${reportId}/edit-report/use-of-force-details`)
+    })
+
+    useOfForceDetailsPage.continueButton().click()
+
+    const reasonForChangePage = ReasonForChangePage.verifyOnPage()
+    reasonForChangePage.backLink().should('exist')
+
+    reasonForChangePage
+      .tableRowAndColHeading(1, 'question')
+      .should('contain', 'Why was use of force applied against this prisoner?')
+    reasonForChangePage.tableRowAndColHeading(1, 'old-value').should('contain', 'Fight between prisoners')
+    reasonForChangePage
+      .tableRowAndColHeading(1, 'new-value')
+      .should('contain', 'Assault on a member of staff, Fight between prisoners')
+    reasonForChangePage.radioAnotherReason().click()
+    reasonForChangePage.anotherReasonText().type('Some more details')
+    reasonForChangePage.additionalInfoText().type('Some even more additional details')
+    reasonForChangePage.saveButton().click()
+
+    ViewIncidentPage.verifyOnPage()
+    viewIncidentPage.successBanner().should('exist')
+    viewIncidentPage.reasonsForUseOfForce().should('contain', 'Assault on a member of staff, Fight between prisoners')
+    viewIncidentPage.editHistoryLinkInSuccessBanner().click()
+    const editHistoryPage = EditHistoryPage.verifyOnPage()
+    editHistoryPage
+      .tableRowAndColHeading(1, 'what-changed')
+      .should('contain', 'Why was use of force applied against this prisoner?')
+    editHistoryPage.tableRowAndColHeading(1, 'old-value').should('contain', 'Fight between prisoners')
+    editHistoryPage
+      .tableRowAndColHeading(1, 'new-value')
+      .should('contain', 'Assault on a member of staff, Fight between prisoners')
+    editHistoryPage.tableRowAndColHeading(1, 'reason').should('contain', 'Another reason: Some more details')
+  })
 })

--- a/server/routes/maintainingReports/coordinator-unit.test.ts
+++ b/server/routes/maintainingReports/coordinator-unit.test.ts
@@ -309,6 +309,20 @@ describe('CoordinatorEditReportController', () => {
         },
       })
     })
+
+    it('should call deleteAnyPendingEditsForThisReport with the correct incidentId', async () => {
+      req.params = { reportId: '123' }
+      req.session.incidentReport = [
+        { reportId: 123, reasonForChange: 'old reason' },
+        { reportId: 456, reasonForChange: 'keep me' },
+      ]
+      const spy = jest.spyOn(controller, 'deleteAnyPendingEditsForThisReport')
+
+      await controller.viewEditReport(req, res)
+
+      expect(spy).toHaveBeenCalledWith(req, 123)
+      expect(req.session.incidentReport).toEqual([{ reportId: 456, reasonForChange: 'keep me' }])
+    })
   })
 
   describe('Report details', () => {

--- a/server/routes/maintainingReports/coordinator.ts
+++ b/server/routes/maintainingReports/coordinator.ts
@@ -45,13 +45,21 @@ export default class CoordinatorRoutes {
     private readonly reportEditService: ReportEditService
   ) {}
 
+  // when user starts a new journey, delete any edits from session that may exist for any previous edit journey that was not completed
+  deleteAnyPendingEditsForThisReport(req: Request, reportId: number): void {
+    if (!req.session.incidentReport || !Array.isArray(req.session.incidentReport)) return
+    req.session.incidentReport = req.session.incidentReport.filter(
+      (entry: { reportId: number }) => entry.reportId !== reportId
+    )
+  }
+
   viewEditReport: RequestHandler = async (req, res) => {
     const reportId = extractReportId(req)
     const reportEditOrDeletePermitted = await this.reportEditService.isTodaysDateWithinEditabilityPeriod(reportId)
     if (!reportEditOrDeletePermitted) {
       return res.redirect(`/${reportId}/view-incident?tab=report`)
     }
-
+    this.deleteAnyPendingEditsForThisReport(req, reportId)
     const { user } = res.locals
     const systemToken = await this.authService.getSystemClientToken(user.username)
     const report = await this.reviewService.getReport(reportId)

--- a/server/routes/viewingIncidents/viewIncidents.test.ts
+++ b/server/routes/viewingIncidents/viewIncidents.test.ts
@@ -7,7 +7,6 @@ import ReportService from '../../services/reportService'
 import ReportEditService from '../../services/reportEditService'
 import AuthService from '../../services/authService'
 import ReportDetailBuilder, { ReportDetail } from '../../services/reportDetailBuilder'
-import ViewIncidentsRoutes from './viewIncidents'
 import logger from '../../../log'
 
 jest.mock('../../services/reviewService')
@@ -744,89 +743,5 @@ describe('Edit history tab', () => {
           'someOtherUser attempted to access edit history for report 1 even though they are not the reporter or a reviewer/coordinator'
         )
       })
-  })
-})
-
-describe('deleteAnyPendingEditsForThisReport', () => {
-  let viewIncidentsRoutes: ViewIncidentsRoutes
-
-  beforeEach(() => {
-    viewIncidentsRoutes = new ViewIncidentsRoutes(
-      reportService,
-      reportEditService,
-      reportDetailBuilder,
-      reviewService,
-      authService
-    )
-  })
-
-  it('should remove the entry with the given reportId from session.incidentReport', () => {
-    const req = {
-      session: {
-        incidentReport: [
-          { reportId: 1, data: 'foo' },
-          { reportId: 2, data: 'bar' },
-        ],
-      },
-    } as any
-    viewIncidentsRoutes.deleteAnyPendingEditsForThisReport(req, 1)
-    expect(req.session.incidentReport).toEqual([{ reportId: 2, data: 'bar' }])
-  })
-
-  it('should do nothing if session.incidentReport is not an array', () => {
-    const req = { session: { incidentReport: {} } } as any
-    viewIncidentsRoutes.deleteAnyPendingEditsForThisReport(req, 1)
-    expect(req.session.incidentReport).toEqual({})
-  })
-
-  it('should do nothing if session.incidentReport is undefined', () => {
-    const req = { session: {} } as any
-    viewIncidentsRoutes.deleteAnyPendingEditsForThisReport(req, 1)
-    expect(req.session.incidentReport).toBeUndefined()
-  })
-})
-
-describe('ViewIncidentsRoutes', () => {
-  let viewIncidentsRoutes: any
-  let req: any
-  let res: any
-
-  beforeEach(() => {
-    viewIncidentsRoutes = new ViewIncidentsRoutes(
-      reportService,
-      reportEditService,
-      reportDetailBuilder,
-      reviewService,
-      authService
-    )
-    req = {
-      params: { incidentId: '123' },
-      session: {},
-      query: {},
-      user: {},
-      flash: jest.fn().mockReturnValue([{}]),
-      res: {},
-      ...{
-        locals: { user: { isCoordinator: true, username: 'user1' } },
-      },
-    }
-    res = {
-      render: jest.fn(),
-      redirect: jest.fn(),
-      locals: req.locals,
-    }
-  })
-
-  it('should call deleteAnyPendingEditsForThisReport with the correct incidentId', async () => {
-    const spy = jest.spyOn(viewIncidentsRoutes, 'deleteAnyPendingEditsForThisReport')
-    reviewService.getReport.mockResolvedValue({ username: 'user1', form: {} } as Report)
-    reportService.getReportEdits.mockResolvedValue([])
-    reportEditService.mapEditDataToViewOutput.mockResolvedValue([])
-    reportDetailBuilder.build.mockResolvedValue({ offenderDetail: {}, form: {} } as unknown as ReportDetail)
-    authService.getSystemClientToken.mockResolvedValue('token')
-    reviewService.getStatements.mockResolvedValue([])
-
-    await viewIncidentsRoutes.viewIncident(req, res)
-    expect(spy).toHaveBeenCalledWith(req, 123)
   })
 })

--- a/server/routes/viewingIncidents/viewIncidents.ts
+++ b/server/routes/viewingIncidents/viewIncidents.ts
@@ -18,15 +18,8 @@ export default class ViewIncidentsRoutes {
     private readonly authService: AuthService
   ) {}
 
-  // handle any session data for this report if user closes browser tab without completing the edit
-  deleteAnyPendingEditsForThisReport(req, reportId) {
-    if (!req.session.incidentReport || !Array.isArray(req.session.incidentReport)) return
-    req.session.incidentReport = req.session.incidentReport.filter(entry => entry.reportId !== reportId)
-  }
-
   viewIncident: RequestHandler = async (req, res) => {
     const incidentId = extractReportId(req)
-    this.deleteAnyPendingEditsForThisReport(req, incidentId)
     const { tab } = req.query
     const { isReviewer, isCoordinator, username } = res.locals.user
     const report = await this.reviewService.getReport(incidentId)


### PR DESCRIPTION
[MAPB-460](https://dsdmoj.atlassian.net/jira/software/c/projects/MAPB/boards/13171?selectedIssue=MAPB-460)

Fix: Prevent premature deletion of edit data in session by moving session clearing from /view-incident to /edit-report

We identified several cases where users’ edits to the “Use of force details” section were not being persisted correctly.

Previously, the application would intentionally clear any in-progress edit data when a user navigated to /view-incident. This was based on the assumption that /view-incident marked the start of a new journey, and therefore any stale or orphaned session data should be removed.

However, analysis of user behaviour shows that some users deliberately navigate to /view-incident (most likely by having multiple browser tabs open and refreshing) mid-edit before returning to complete and submit their changes. This led to unintended data loss.

Observed App Insights navigation pattern that led to incorrect data:
GET  /{reportId}/view-incident.  <-- session data cleared here at beginning of journey
GET  /{reportId}/edit-report
GET  /{reportId}/edit-report/why-was-uof-applied
POST /{reportId}/edit-report/why-was-uof-applied
GET  /{reportId}/edit-report/use-of-force-details
GET  /{reportId}/edit-report/view-incident   <-- session data was being cleared here for the second time
POST /{reportId}/edit-report/use-of-force-details   <-- session data for why-was-uof-applied missing
GET  /{reportId}/edit-report/reason-for-change
POST /{reportId}/edit-report/reason-for-change
GET  /{reportId}/edit-report/view-incident

If the second GET  /{reportId}/view-incident request had not been made, the journey would have completed successfully.

**Change made**

Session data clearing has been moved from /{reportId}/view-incident to /{reportId}/edit-report

This ensures that even if a user navigates to /{reportId}/view-incident  mid-edit, their session data is preserved and not prematurely deleted.


NB: there is no App Insights data to show users navigated to GET  /{reportId}/edit-report outside of the correct sequence

[MAPB-460]: https://dsdmoj.atlassian.net/browse/MAPB-460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ