### PR TITLE
MAPB-528 corrected link back to statements page

### DIFF
--- a/integration-tests/integration/coordinator/remove-statement.cy.js
+++ b/integration-tests/integration/coordinator/remove-statement.cy.js
@@ -6,6 +6,7 @@ const ConfirmStatementDeletePage = require('../../pages/reviewer/confirmStatemen
 const NotCompletedIncidentsPage = require('../../pages/reviewer/notCompletedIncidentsPage')
 const StaffMemberNotRemovedPage = require('../../pages/coordinator/staffMemberNotRemovedPage')
 const { ReportStatus } = require('../../../server/config/types')
+const ViewIncidentPage = require('../../pages/coordinator/viewIncidentPage')
 
 context('A use of force coordinator can accept or refuse removal statement requests', () => {
   beforeEach(() => {
@@ -95,7 +96,7 @@ context('A use of force coordinator can accept or refuse removal statement reque
       )
   })
 
-  xit(`A coordinator can refuse a statment removal request`, () => {
+  it(`A coordinator can refuse a statement removal request`, () => {
     cy.task('stubCoordinatorLogin')
     cy.login()
 
@@ -105,26 +106,35 @@ context('A use of force coordinator can accept or refuse removal statement reque
     notCompletedIncidentsPage.getTodoRows().should('have.length', 1)
 
     {
-      const { prisoner, reporter, viewStatementsButton } = notCompletedIncidentsPage.getTodoRow(0)
+      const { prisoner, reporter } = notCompletedIncidentsPage.getTodoRow(0)
       prisoner().contains('Smith, Norman')
       reporter().contains('James Stuart')
-      viewStatementsButton().click()
     }
 
-    const viewStatementsPage = ViewStatementsPage.verifyOnPage()
-    viewStatementsPage.statements().then(result =>
+    notCompletedIncidentsPage.viewIncidentLink().click()
+
+    const viewIncidentPage = ViewIncidentPage.verifyOnPage()
+
+    viewIncidentPage.statementsTabLink().click()
+
+    viewIncidentPage.statements().then(result =>
       expect(result).to.deep.equal([
-        { username: 'MRS_JONES name', badge: '', link: '', isOverdue: false, isUnverified: false },
         {
-          username: 'TEST_USER name',
-          badge: 'REMOVAL REQUEST',
-          link: 'View removal request',
-          isOverdue: false,
-          isUnverified: false,
+          username: 'MRS_JONES name (MRS_JONES)',
+          email: 'MRS_JONES@gov.uk',
+          status: '',
+          action: '',
+        },
+        {
+          username: 'TEST_USER name (TEST_USER)',
+          email: 'TEST_USER@gov.uk, REMOVAL REQUEST',
+          status: '',
+          action: 'View removal request',
         },
       ])
     )
-    viewStatementsPage.statementLink(1).click()
+
+    viewIncidentPage.removalRequestLink().click()
 
     const viewRemovalRequestPage = ViewRemovalRequestPage.verifyOnPage()
     viewRemovalRequestPage.name().contains('TEST_USER name')
@@ -139,117 +149,36 @@ context('A use of force coordinator can accept or refuse removal statement reque
     staffMemberNotRemovedPage.name().contains('TEST_USER name')
     staffMemberNotRemovedPage.return().click()
 
-    viewStatementsPage.statements().then(result =>
+    viewIncidentPage.statements().then(result =>
       expect(result).to.deep.equal([
-        { username: 'MRS_JONES name', badge: '', link: '', isOverdue: false, isUnverified: false },
         {
-          username: 'TEST_USER name',
-          badge: '',
-          link: '',
-          isOverdue: false,
-          isUnverified: false,
+          username: 'MRS_JONES name (MRS_JONES)',
+          email: 'MRS_JONES@gov.uk',
+          status: '',
+          action: '',
+        },
+        {
+          username: 'TEST_USER name (TEST_USER)',
+          email: 'TEST_USER@gov.uk',
+          status: '',
+          action: '',
         },
       ])
     )
+    viewIncidentPage.returnToUseOfForceIncidentsLink().should('have.attr', 'href', '/not-completed-incidents')
   })
 
-  xit(`A coordinator can change their mind about accepting a statment removal request`, () => {
+  it(`A coordinator is shown a validation message when they neither accept or refuse a statment removal request`, () => {
     cy.task('stubCoordinatorLogin')
     cy.login()
-
     seedReport()
-
     const notCompletedIncidentsPage = NotCompletedIncidentsPage.goTo()
-    notCompletedIncidentsPage.getTodoRows().should('have.length', 1)
-
-    {
-      const { prisoner, reporter, viewStatementsButton } = notCompletedIncidentsPage.getTodoRow(0)
-      prisoner().contains('Smith, Norman')
-      reporter().contains('James Stuart')
-      viewStatementsButton().click()
-    }
-
-    const viewStatementsPage = ViewStatementsPage.verifyOnPage()
-    viewStatementsPage.statements().then(result =>
-      expect(result).to.deep.equal([
-        { username: 'MRS_JONES name', badge: '', link: '', isOverdue: false, isUnverified: false },
-        {
-          username: 'TEST_USER name',
-          badge: 'REMOVAL REQUEST',
-          link: 'View removal request',
-          isOverdue: false,
-          isUnverified: false,
-        },
-      ])
-    )
-    viewStatementsPage.statementLink(1).click()
-
+    notCompletedIncidentsPage.viewIncidentLink().click()
+    const viewIncidentPage = ViewIncidentPage.verifyOnPage()
+    viewIncidentPage.statementsTabLink().click()
+    viewIncidentPage.removalRequestLink().click()
     const viewRemovalRequestPage = ViewRemovalRequestPage.verifyOnPage()
-    viewRemovalRequestPage.name().contains('TEST_USER name')
-    viewRemovalRequestPage.userId().contains('TEST_USER')
-    viewRemovalRequestPage.location().contains('Moorland')
-    viewRemovalRequestPage.emailAddress().contains('TEST_USER@gov.uk')
-    viewRemovalRequestPage.removalReason().contains('not working')
-    viewRemovalRequestPage.confirm()
     viewRemovalRequestPage.continue().click()
-
-    const confirmStatementDeletePage = ConfirmStatementDeletePage.verifyOnPage('TEST_USER name')
-    confirmStatementDeletePage.refuse()
-    confirmStatementDeletePage.continue().click()
-
-    viewStatementsPage.statements().then(result =>
-      expect(result).to.deep.equal([
-        { username: 'MRS_JONES name', badge: '', link: '', isOverdue: false, isUnverified: false },
-        {
-          username: 'TEST_USER name',
-          badge: 'REMOVAL REQUEST',
-          link: 'View removal request',
-          isOverdue: false,
-          isUnverified: false,
-        },
-      ])
-    )
-  })
-
-  xit(`A coordinator is shown a validation message when they neither accept or refuse a statment removal request`, () => {
-    cy.task('stubCoordinatorLogin')
-    cy.login()
-
-    seedReport()
-
-    const notCompletedIncidentsPage = NotCompletedIncidentsPage.goTo()
-    notCompletedIncidentsPage.getTodoRows().should('have.length', 1)
-
-    {
-      const { prisoner, reporter, viewStatementsButton } = notCompletedIncidentsPage.getTodoRow(0)
-      prisoner().contains('Smith, Norman')
-      reporter().contains('James Stuart')
-      viewStatementsButton().click()
-    }
-
-    const viewStatementsPage = ViewStatementsPage.verifyOnPage()
-    viewStatementsPage.statements().then(result =>
-      expect(result).to.deep.equal([
-        { username: 'MRS_JONES name', badge: '', link: '', isOverdue: false, isUnverified: false },
-        {
-          username: 'TEST_USER name',
-          badge: 'REMOVAL REQUEST',
-          link: 'View removal request',
-          isOverdue: false,
-          isUnverified: false,
-        },
-      ])
-    )
-    viewStatementsPage.statementLink(1).click()
-
-    const viewRemovalRequestPage = ViewRemovalRequestPage.verifyOnPage()
-    viewRemovalRequestPage.name().contains('TEST_USER name')
-    viewRemovalRequestPage.userId().contains('TEST_USER')
-    viewRemovalRequestPage.location().contains('Moorland')
-    viewRemovalRequestPage.emailAddress().contains('TEST_USER@gov.uk')
-    viewRemovalRequestPage.removalReason().contains('not working')
-    viewRemovalRequestPage.continue().click()
-
     viewRemovalRequestPage.errorSummaryTitle().contains('There is a problem')
     viewRemovalRequestPage.errorSummaryBody().contains('Select yes if you want to remove this person from the incident')
     viewRemovalRequestPage.inlineError().contains('Select yes if you want to remove this person from the incident')

--- a/integration-tests/pages/coordinator/viewIncidentPage.js
+++ b/integration-tests/pages/coordinator/viewIncidentPage.js
@@ -9,8 +9,24 @@ const viewIncidentPage = () =>
     reasonsForUseOfForce: () => cy.get('[data-qa=reasonsForUseOfForce]'),
     statementsTabLink: () => cy.get('[data-qa=statements-tab'),
     statementsTableRows: () => cy.get('[data-qa=statements] tbody tr'),
+    statements: () =>
+      cy
+        .get('[data-qa="statements"]')
+        .find('.govuk-table__body tr')
+        .spread((...rest) =>
+          rest.map(element => {
+            const tds = Cypress.$(element).find('td.govuk-table__cell')
+            return {
+              username: Cypress.$(tds[0]).text(),
+              email: Cypress.$(tds[1]).text().trim().replace(/\s\s+/g, ', '),
+              status: Cypress.$(tds[2]).text().trim().replace(/\s\s+/g, ', '),
+              action: Cypress.$(tds[3]).text().trim().replace(/\s\s+/g, ', '),
+            }
+          })
+        ),
     staffInvolvedTableRows: () => cy.get('[data-qa=staff-involved]'),
     returnToUseOfForceIncidentsLink: () => cy.get('[data-qa="use-of-force-incidents-link"]'),
+    removalRequestLink: () => cy.get('[data-qa="view-removal-request"]'),
   })
 
 module.exports = {

--- a/server/views/pages/coordinator/staff-member-not-removed.html
+++ b/server/views/pages/coordinator/staff-member-not-removed.html
@@ -32,7 +32,7 @@
           </div>
       </dl>
 
-      <p><a data-qa="return-to-incident" href="/{{ data.reportId }}/view-statements">Return to use of force incident</a></p>
+      <p><a data-qa="return-to-incident" href="/{{ data.reportId }}/view-incident?tab=statements">Return to use of force incident</a></p>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
[MAPB_528](https://dsdmoj.atlassian.net/jira/software/c/projects/MAPB/boards/13171?selectedIssue=MAPB-528)

Staff included in a UOF report as an ‘involved person’ will receive an email to complete their statement. The email contains 2 links one of which lets the staff member request they be removed from the report altogether.

A coordinator will identify such a request via a ‘Removal Request’ tag. 

The coordinator navigates to `coordinator/report/{reportId}/statement/{statementId}/view-removal-request` and they will either accept or deny the request. 

If they deny the request, the uof app redirects to `coordinator/report/{reportId}/statement/{statementId}/staff-member-not-removed `

There is a link on this  page called ‘Return to use of force incident’ which points to a page we don’t use anymore (`/reportId/view-statements`) 

The equivalent new page is `/{reportId}/view-incident?tab=statements`

This ticket is to correct the href of the 'Return to use of force incident’ link to replace `/reportId/view-statements` with `/{reportId}/view-incident?tab=statements` and to update any tests
