### PR TITLE
bump the veracode workflow jobs

### DIFF
--- a/.github/workflows/security_veracode_pipeline_scan.yml
+++ b/.github/workflows/security_veracode_pipeline_scan.yml
@@ -1,4 +1,4 @@
-name: Security veracode pipeline scan
+name: Security veracode pipeline scan # weekly
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/security_veracode_policy_scan.yml
+++ b/.github/workflows/security_veracode_policy_scan.yml
@@ -1,4 +1,4 @@
-name: Security veracode policy scan
+name: Security veracode policy scan # weekdays
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
The Veracode scans aren't running, which means the latest report in Dev Portal is out of date.
This will - hopefully - re-initiate them, and they'll run as normal next week (I'll keep an eye out)